### PR TITLE
Adding poolingActivationBurst parameter to Union Pooler

### DIFF
--- a/union_pooling/union_pooling/experiments/union_sdr_overlap/params/debug/0_trainingPasses.yaml
+++ b/union_pooling/union_pooling/experiments/union_sdr_overlap/params/debug/0_trainingPasses.yaml
@@ -43,5 +43,6 @@ unionPoolerParams:
   # Union Pooler Params
   activeOverlapWeight: 1.0
   predictedActiveOverlapWeight: 10.0
+  poolingActivationBurst: 10
   maxUnionActivity: 0.20
   decayFunctionSlope: 1.0

--- a/union_pooling/union_pooling/union_pooler.py
+++ b/union_pooling/union_pooling/union_pooler.py
@@ -18,6 +18,7 @@
 #
 # http://numenta.org/licenses/
 # ----------------------------------------------------------------------
+import random
 
 import numpy
 
@@ -26,6 +27,7 @@ from nupic.research.spatial_pooler import SpatialPooler
 
 
 REAL_DTYPE = numpy.float32
+_TIE_BREAKER_FACTOR = 0.0001
 
 
 
@@ -181,6 +183,9 @@ class UnionPooler(SpatialPooler):
     if self._poolingActivationBurst is not None:
       # Increase is based on fixed parameter
       self._poolingActivation[activeCells] += self._poolingActivationBurst
+      tieBreaker = [random.random() * _TIE_BREAKER_FACTOR
+                    for _ in xrange(len(activeCells))]
+      self._poolingActivation[activeCells] += tieBreaker
     else:
       # Increase is based on active & predicted-active overlap
       self._addToPoolingActivation(activeCells, overlapsActive)

--- a/union_pooling/union_pooling/union_pooler.py
+++ b/union_pooling/union_pooling/union_pooler.py
@@ -182,10 +182,10 @@ class UnionPooler(SpatialPooler):
     # Add to the poolingActivation of current active Union Pooler cells
     if self._poolingActivationBurst is not None:
       # Increase is based on fixed parameter
-      self._poolingActivation[activeCells] += self._poolingActivationBurst
       tieBreaker = [random.random() * _TIE_BREAKER_FACTOR
                     for _ in xrange(len(activeCells))]
-      self._poolingActivation[activeCells] += tieBreaker
+      self._poolingActivation[activeCells] = (self._poolingActivationBurst +
+                                             tieBreaker)
     else:
       # Increase is based on active & predicted-active overlap
       self._addToPoolingActivation(activeCells, overlapsActive)


### PR DESCRIPTION
If set, this parameter specifies the amount of pooling activation given to all winning cells in the Union Pooler. (The pooling activation determines the length of time an active cells pools). If the parameter is not set the cell's overlap score is used to set the pooling activation.