### PR TITLE
reverted to original q learning update rule

### DIFF
--- a/sensorimotor/sensorimotor/q_learner.py
+++ b/sensorimotor/sensorimotor/q_learner.py
@@ -31,7 +31,7 @@ from sensorimotor.reinforcement_learner import ReinforcementLearner
 class QLearner(ReinforcementLearner):
 
   def __init__(self, actions,
-               alpha=0.2, gamma=0.8, elambda=0.3,
+               alpha=0.9, gamma=0.8, elambda=0.3,
                n=2048):
     super(QLearner, self).__init__(actions,
                                    alpha=alpha, gamma=gamma, elambda=elambda)
@@ -74,14 +74,6 @@ class QLearner(ReinforcementLearner):
     targetValue = reward + (self.gamma * self.value(nextState))
     qValue = self.qValue(state, action)
     correction = (targetValue - qValue) / sum(state)
-    targetWeight = targetValue / sum(state)
 
-    diffs = [abs(targetWeight - self.weights[action][i])
-             for i in state.nonzero()[0]]
-    maxDiff = max(diffs)
-
-    if maxDiff != 0:
-      for i in state.nonzero()[0]:
-        diff = abs(targetWeight - self.weights[action][i])
-        scale = diff / maxDiff
-        self.weights[action][i] += self.alpha * correction * scale
+    for i in state.nonzero()[0]:
+      self.weights[action][i] += self.alpha * correction

--- a/sensorimotor/sensorimotor/q_learner.py
+++ b/sensorimotor/sensorimotor/q_learner.py
@@ -31,7 +31,7 @@ from sensorimotor.reinforcement_learner import ReinforcementLearner
 class QLearner(ReinforcementLearner):
 
   def __init__(self, actions,
-               alpha=0.9, gamma=0.8, elambda=0.3,
+               alpha=0.2, gamma=0.8, elambda=0.3,
                n=2048):
     super(QLearner, self).__init__(actions,
                                    alpha=alpha, gamma=gamma, elambda=elambda)


### PR DESCRIPTION
This performs about the same as the current update rule for the T maze (which is not very well), but the update rule is cleaner. We may revisit and try to understand better why the algorithm mistakenly learns a high Q value for turning right into a negative reward.

@chetan51 