### PR TITLE
Tuned encoder params for better overlaps

### DIFF
--- a/vehicle-control/agent/run_sm.py
+++ b/vehicle-control/agent/run_sm.py
@@ -39,7 +39,7 @@ class MonitoredGeneralTemporalMemory(TemporalMemoryMonitorMixin,
 
 
 SCALE = 5
-RADIUS = 7
+RADIUS = 10
 
 
 

--- a/vehicle-control/simulation/Assets/Resources/API.prefab
+++ b/vehicle-control/simulation/Assets/Resources/API.prefab
@@ -40,7 +40,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   blockOnResponse: 1
-  updateRate: 2
+  updateRate: 1.5
   runSpeed: 1
   serverURL: http://localhost:8080
 --- !u!1001 &100100000

--- a/vehicle-control/simulation/Assets/Scenes/MazeI.unity
+++ b/vehicle-control/simulation/Assets/Scenes/MazeI.unity
@@ -1050,10 +1050,6 @@ Prefab:
       propertyPath: m_RootOrder
       value: 3
       objectReference: {fileID: 0}
-    - target: {fileID: 11492992, guid: a848ff0c31ac74a799bccce306092316, type: 2}
-      propertyPath: updateRate
-      value: 2
-      objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_ParentPrefab: {fileID: 100100000, guid: a848ff0c31ac74a799bccce306092316, type: 2}
   m_IsPrefabParent: 0


### PR DESCRIPTION
Overlaps before:

![before-tuning-radius-7](https://cloud.githubusercontent.com/assets/310282/8583684/70315d48-2584-11e5-9dcb-79f2ccb4616d.png)

Overlaps after:

![after-tuning-radius-10-timestep-1 5](https://cloud.githubusercontent.com/assets/310282/8583688/75b1edb4-2584-11e5-8734-b50ad54dd009.png)

(x and y axes are timesteps)