### PR TITLE
update union pooler excitation rule

### DIFF
--- a/union_pooling/union_pooling/activation/excite_functions/excite_functions_all.py
+++ b/union_pooling/union_pooling/activation/excite_functions/excite_functions_all.py
@@ -62,7 +62,7 @@ class LogisticExciteFunction(ExciteFunctionBase):
     @param inputs            (numpy array) inputs for each cell
     """
 
-    currentActivation += self._minValue + (self._maxValue - self._minValue) / \
+    currentActivation = self._minValue + (self._maxValue - self._minValue) / \
                                           (1 + numpy.exp(-self._steepness * (inputs - self._xMidpoint)))
 
     return currentActivation
@@ -101,7 +101,7 @@ class FixedExciteFunction(ExciteFunctionBase):
     @param inputs            (numpy array) inputs for each cell
     """
 
-    currentActivation += self._targetExcLevel
+    currentActivation = self._targetExcLevel
 
     return currentActivation
 


### PR DESCRIPTION
Update activation function for union pooler. The persistence values get reset, rather than accumulated upon each update.