### PR TITLE
Test Multiple prediction capacity with Random Scalar Encoders

### DIFF
--- a/projects/sequence_prediction/discrete_sequences/lstm/lstm_scalar_encoding_capacity.py
+++ b/projects/sequence_prediction/discrete_sequences/lstm/lstm_scalar_encoding_capacity.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python
+# ----------------------------------------------------------------------
+# Numenta Platform for Intelligent Computing (NuPIC)
+# Copyright (C) 2015, Numenta, Inc.  Unless you have an agreement
+# with Numenta, Inc., for a separate license for this software code, the
+# following terms and conditions apply:
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# See the GNU Affero Public License for more details.
+#
+# You should have received a copy of the GNU Affero Public License
+# along with this program.  If not, see http://www.gnu.org/licenses.
+#
+# http://numenta.org/licenses/
+# ----------------------------------------------------------------------
+
+
+import numpy as np
+from suite import DistributedEncoder
+
+num_encodings = 10
+num_multiple_prediction = 2
+nDim = 10
+
+enc = DistributedEncoder(nDim,
+                         minValue=-0.5,
+                         maxValue=0.5,
+                         classifyWithRandom=False)
+
+for i in range(num_encodings):
+  enc.encode(i)
+
+symbolList = enc.encodings.keys()
+
+outcome = []
+for _ in range(500):
+  # select two symbols, and decode using the average of the two encodings
+  symbol1 = np.random.choice(symbolList)
+  symbol2 = np.random.choice(symbolList)
+  encoding1 = enc.encode(symbol1)
+  encoding2 = enc.encode(symbol2)
+  closest_symbols = enc.classify((encoding1+encoding2)/2, num=2)
+  correct = symbol1 in closest_symbols and symbol2 in closest_symbols
+  outcome.append(correct)
+  print _, symbol1, symbol2, closest_symbols, correct
+
+print " Decode Success Rate: ", np.mean(outcome)
+
+


### PR DESCRIPTION
@chetan51 @subutai 

I did a simple experiment to test the capacity of holding multiple predictions with the random scalar encoder. I randomly select two symbols, take the average of the encodings, and find the closet two symbols according to the encodings average. This capacity does increase as a function of the dimension of the encodings, but varies within some range even for relatively small dimensions. If I run the script multiple times with nDim=10, I found that some times I get 99.2% decoding accuracy, some times I only get 75% accuracy. If I increase the dimension to nDim=100, I always get perfect decoding accuracy for the small number of elements scenario.

We can try to derive the capacity of holding multiple prediction for scalar random distributed encoder, my guess is that it will be much worse than SDR, but could be large enough to handle a small number of distinct elements.