### PR TITLE
Remove pandas dependencies in aggregation experiment

### DIFF
--- a/projects/wavelet_dataAggregation/runDataAggregationExperiment.py
+++ b/projects/wavelet_dataAggregation/runDataAggregationExperiment.py
@@ -1,10 +1,15 @@
-from os import listdir, makedirs, system, getcwd
 from os.path import isfile, join, exists
 import pandas as pd
 import numpy as np
 from scipy import signal
 import numpy.matlib
 import time
+import csv
+
+import os
+import time
+os.environ['TZ'] = 'GMT'
+time.tzset()
 
 display = True
 if display:
@@ -48,23 +53,20 @@ def plotWaveletPower(sig, cwtmatr, time_scale, x_range=None, title=''):
   plt.show()
 
 
-def calculate_cwt(dat, figDir='./', fileName='./', display=True):
+def calculate_cwt(sampling_interval, sig, figDir='./', fileName='./', display=True):
   """
   Calculate continuous wavelet transformation (CWT)
   Return variance of the cwt coefficients overtime and its cumulative
   distribution
 
-  :param dat: pandas dataframe with two columns, 'timestamp' and 'value'
+  :param sampling_interval: sampling interval of the time series
+  :param sig: value of the time series
   :param figDir: directory of cwt plots
   :param fileName: name of the dataset, used for determining figDir
   :param display: whether to create the cwt plot
   """
-  sig = dat['value'].values
-  timestamp = pd.to_datetime(dat['timestamp'])
-  sampling_interval = timestamp[len(sig)-1] - timestamp[0]
-  dt = sampling_interval.total_seconds()/(len(sig)-1)
 
-  t = np.array(range(len(sig)))*dt
+  t = np.array(range(len(sig)))*sampling_interval
   widths = np.logspace(0, np.log10(len(sig)/20), 50)
 
   T = int(widths[-1])
@@ -75,8 +77,8 @@ def calculate_cwt(dat, figDir='./', fileName='./', display=True):
   sig = sig[4*T:-4*T]
   t = t[4*T:-4*T]
 
-  freq = 1/widths.astype('float') / dt / 4
-  time_scale = widths * dt * 4
+  freq = 1/widths.astype('float') / sampling_interval / 4
+  time_scale = widths * sampling_interval * 4
 
   # variance of wavelet power
   cwt_var = np.var(np.abs(cwtmatr), axis=1)
@@ -86,7 +88,7 @@ def calculate_cwt(dat, figDir='./', fileName='./', display=True):
   (useTimeOfDay, useDayOfWeek, local_min, local_max, strong_local_max) = get_local_maxima(cwt_var, time_scale)
 
   if not exists(figDir):
-      makedirs(figDir)
+      os.makedirs(figDir)
 
   if display:
     # plot wavelet coefficients along with the raw signal
@@ -184,13 +186,11 @@ def get_local_maxima(cwt_var, time_scale):
   return useTimeOfDay, useDayOfWeek, local_min, local_max, strong_local_max
 
 
-def get_suggested_timescale_and_encoder(dat, thresh=0.2):
+def get_suggested_timescale_and_encoder(timestamp, sig, thresh=0.2):
 
-  sig = dat['value'].values
-  timestamp = pd.to_datetime(dat.timestamp)
-  sampling_interval = timestamp[len(sig)-1] - timestamp[0]
-  dt = sampling_interval.total_seconds()/(len(sig)-1)
-  (cum_cwt_var, cwt_var, time_scale) = calculate_cwt(dat, display=False)
+  dt = (timestamp[len(sig)-1] - timestamp[0])/(len(sig)-1)
+  dt_sec = dt.astype('float32')
+  (cum_cwt_var, cwt_var, time_scale) = calculate_cwt(dt_sec, sig, display=False)
 
   (useTimeOfDay, useDayOfWeek, local_min, local_max, strong_local_max) = get_local_maxima(cwt_var, time_scale)
 
@@ -204,67 +204,146 @@ def get_suggested_timescale_and_encoder(dat, thresh=0.2):
   return (new_sampling_interval, useTimeOfDay, useDayOfWeek)
 
 
-def aggregate_nab_data(thresh_list, dataPath='data/',
-                       aggregatedDataPath='data_aggregate', waveletDir='wavelet/'):
+def readCSVfiles(fileName):
   """
-  Aggregate NAB data using the wavelet transformation based algorithm
+  Read csv data file, the data file must have two columns
+  with header "timestamp", and "value"
+  """
+  fileReader = csv.reader(open(fileName, 'r'))
+  fileReader.next() # skip header line
+  timestamps = []
+  values = []
+
+  for row in fileReader:
+    timestamps.append(row[0])
+    values.append(row[1])
+
+  timestamps = np.array(timestamps, dtype='datetime64')
+  values = np.array(values, dtype='float32')
+
+  return (timestamps, values)
+
+
+def writeCSVfiles(fileName, timestamp, value):
+  """
+  write data to csv file,
+  the data file will have two columns with header "timestamp", and "value"
+  """
+  fileWriter = csv.writer(open(fileName, 'w'))
+  fileWriter.writerow(['timestamp', 'value'])
+  for i in xrange(len(timestamp)):
+    fileWriter.writerow([timestamp[i].astype('O').strftime("%Y-%m-%d %H:%M:%S"),
+                         value[i]])
+
+
+def resample_data(timestamp, sig, new_sampling_interval, display=False):
+  """
+  Resample time series data at new sampling interval using linear interpolation
+  Note: the resampling function is using interpolation, it may not be appropriate for aggregation purpose
+  :param timestamp: timestamp in numpy datetime64 type
+  :param sig: value of the time series
+  :param new_sampling_interval: new sampling interrval
+  """
+  nSampleNew = np.floor((timestamp[-1] - timestamp[0])/new_sampling_interval).astype('int') + 1
+
+  timestamp_new = np.empty(nSampleNew, dtype='datetime64[s]')
+  for sampleI in xrange(nSampleNew):
+    timestamp_new[sampleI] = timestamp[0] + sampleI * new_sampling_interval
+
+  sig_new = np.interp((timestamp_new-timestamp[0]).astype('float32'),
+                      (timestamp-timestamp[0]).astype('float32'), sig)
+
+  if display:
+    plt.figure(3)
+    plt.plot(timestamp, sig)
+    plt.plot(timestamp_new, sig_new)
+    plt.legend(['before resampling', 'after resampling'])
+
+  return (timestamp_new, sig_new)
+
+
+def aggregate_data(thresh_list, dataFile, aggregatedDataPath, waveletDir='./wavelet/', display=False, verbose=0):
+  """
+  Aggregate individual dataset, the aggregated data will be saved at aggregatedDataFile
+  :param thresh: aggregation threshold
+  :param dataFile: path of the original datafile
+  :param aggregatedDataFile: path of the aggregated datafile
+  :param waveletDir: path of wavelet transformations (for visual inspection)
+  """
+  data_file_dir = dataFile.split('/')
+
+  (timestamp, sig) = readCSVfiles(dataFile)
+
+  # dt = (timestamp[len(sig)-1] - timestamp[0])/(len(sig)-1)
+  dt = np.median(np.diff(timestamp))
+  dt_sec = dt.astype('float32')
+  # resample the data with homogeneous sampling intervals
+  (timestamp, sig) = resample_data(timestamp, sig, dt, display=True)
+
+  (cum_cwt_var, cwt_var, time_scale) = calculate_cwt(dt_sec, sig,
+                                                     display=display,
+                                                     figDir=join(waveletDir, data_file_dir[-2]),
+                                                     fileName=data_file_dir[-1])
+
+  for thresh in thresh_list:
+    new_data_dir = join(aggregatedDataPath, 'thresh='+str(thresh), data_file_dir[-2])
+    if not exists(new_data_dir):
+        os.makedirs(new_data_dir)
+
+    new_data_file = join(new_data_dir, data_file_dir[-1])
+
+    # determine aggregation time scale
+    cutoff_time_scale = time_scale[np.where(cum_cwt_var >= thresh)[0][0]]
+    aggregation_time_scale = cutoff_time_scale/10.0
+    if aggregation_time_scale < dt_sec*4:
+      aggregation_time_scale = dt_sec*4
+
+    new_sampling_interval = np.timedelta64(int(aggregation_time_scale/4 * 1000), 'ms')
+    nSampleNew = np.floor((timestamp[-1] - timestamp[0])/new_sampling_interval).astype('int') + 1
+
+    timestamp_new = np.empty(nSampleNew, dtype='datetime64[s]')
+    value_new = np.empty(nSampleNew, dtype='float32')
+
+    left_sampleI = 0
+    new_sampleI = 0
+
+    for sampleI in xrange(len(sig)):
+      if timestamp[sampleI] >= timestamp[0] + new_sampleI * new_sampling_interval:
+        timestamp_new[new_sampleI] = timestamp[0] + new_sampleI * new_sampling_interval
+        value_new[new_sampleI] = (np.mean(sig[left_sampleI:sampleI+1]))
+        left_sampleI = sampleI+1
+        new_sampleI += 1
+
+    writeCSVfiles(new_data_file, timestamp_new, value_new)
+
+    if verbose > 0:
+      print " original length: ", len(sig), "\t file: ", dataFile
+      print "\t\tthreshold: ", thresh, "\t new length: ", len(value_new)
+
+
+def aggregate_nab_data(thresh_list, dataPath='data/',
+                       aggregatedDataPath='data_aggregate/',
+                       waveletDir='wavelet/',
+                       verbose=0):
+  """
+  Aggregate all NAB data using the wavelet transformation based algorithm
 
   :param thresh_list: threshold of the aggregation, a number in [0, 1)
   :param dataPath: path of the original NAB data
   :param aggregatedDataPath: path of the aggregated NAB data
   :param waveletDir: path of wavelet transformations (for visual inspection)
   """
+
   if not exists(aggregatedDataPath):
-      makedirs(aggregatedDataPath)
+      os.makedirs(aggregatedDataPath)
 
-  dataDirs = [join(dataPath, f) for f in listdir(dataPath) if not isfile(join(dataPath, f))]
+  dataDirs = [join(dataPath, f) for f in os.listdir(dataPath) if not isfile(join(dataPath, f))]
 
-  data_length = []
   for dir in dataDirs:
-    datafiles = [join(dir, f) for f in listdir(dir) if isfile(join(dir, f))]
+    datafiles = [join(dir, f) for f in os.listdir(dir) if isfile(join(dir, f))]
 
     for i in range(len(datafiles)):
-      dat = pd.read_csv(datafiles[i], header=0, names=['timestamp', 'value'])
-      data_file_dir = datafiles[i].split('/')
-      data_length.append(len(dat))
-
-      print " length: ", len(dat), " file: ", datafiles[i]
-
-      sig = dat['value'].values
-      timestamp = pd.to_datetime(dat.timestamp)
-      sampling_interval = timestamp[len(sig)-1] - timestamp[0]
-      dt = sampling_interval.total_seconds()/(len(sig)-1)
-
-      (cum_cwt_var, cwt_var, time_scale) = calculate_cwt(dat,
-                                                  figDir=join(waveletDir, data_file_dir[-2]),
-                                                  fileName=data_file_dir[-1])
-
-      ts = pd.Series(np.array(dat.value).astype('float32'), index=pd.to_datetime(dat.timestamp))
-      # apply different threshold to the cumulative power variance
-      for thresh in thresh_list:
-        cutoff_time_scale = time_scale[np.where(cum_cwt_var >= thresh)[0][0]]
-        aggregation_time_scale = cutoff_time_scale/10.0
-        if aggregation_time_scale < dt*4:
-          aggregation_time_scale = dt*4
-
-        new_sampling_interval = str(int(aggregation_time_scale/4))+'S'
-        ts_aggregate = ts.resample(new_sampling_interval, how='mean')
-        ts_aggregate = ts_aggregate.interpolate(method='linear')
-
-        timestamp = ts_aggregate.index
-        value = np.array(ts_aggregate.values)
-        dat_aggregated = pd.DataFrame(np.transpose(np.array([timestamp, value])), columns=['timestamp', 'value'])
-
-        print "thresh: ", thresh, " original dt ", dt, " new dt: ", new_sampling_interval, \
-              "original length: ", len(ts), " new length: ", len(ts_aggregate)
-
-        new_data_dir = join(aggregatedDataPath, 'thresh='+str(thresh), data_file_dir[-2])
-        if not exists(new_data_dir):
-            makedirs(new_data_dir)
-
-        new_data_file = join(new_data_dir, data_file_dir[-1])
-
-        dat_aggregated.to_csv(new_data_file, index=False)
+      aggregate_data(thresh_list, datafiles[i], aggregatedDataPath, waveletDir, verbose=verbose)
 
         
 def get_pre_aggregated_anomaly_score(data_path, result_folder, result_folder_pre_aggregate):
@@ -274,10 +353,10 @@ def get_pre_aggregated_anomaly_score(data_path, result_folder, result_folder_pre
   score will be saved to result_folder_pre_aggregate
   """
 
-  dataDirs = [join(result_folder, f) for f in listdir(result_folder) if not isfile(join(result_folder, f))]
+  dataDirs = [join(result_folder, f) for f in os.listdir(result_folder) if not isfile(join(result_folder, f))]
 
   for dir in dataDirs:
-    resultfiles = [join(dir, f) for f in listdir(dir) if isfile(join(dir, f))]
+    resultfiles = [join(dir, f) for f in os.listdir(dir) if isfile(join(dir, f))]
 
     for i in range(len(resultfiles)):
       result_file_dir = resultfiles[i].split('/')
@@ -287,7 +366,7 @@ def get_pre_aggregated_anomaly_score(data_path, result_folder, result_folder_pre
       result = pd.read_csv(resultfiles[i], header=0,
                            names=['timestamp', 'value', 'anomaly_score', 'raw_score', 'label'])
 
-      time_stamp_pre_aggregation =pd.to_datetime(dat.timestamp)
+      time_stamp_pre_aggregation = pd.to_datetime(dat.timestamp)
       time_stamp_after_aggregation = pd.to_datetime(result.timestamp)
 
       binary_anomaly_score_pre_aggregation = np.zeros(shape=(len(dat),))
@@ -313,12 +392,12 @@ def get_pre_aggregated_anomaly_score(data_path, result_folder, result_folder_pre
 
       result_file_dir_pre_aggregate = join(result_folder_pre_aggregate, result_file_dir[-2])
       if not exists(result_file_dir_pre_aggregate):
-          makedirs(result_file_dir_pre_aggregate)
+          os.makedirs(result_file_dir_pre_aggregate)
       result_file_pre_aggregate = join(result_file_dir_pre_aggregate, result_file_dir[-1])
       result_pre_aggregate.to_csv(result_file_pre_aggregate, index=False)
       print " write pre-aggregated file to ", result_file_pre_aggregate
 
-      # compare anomaly scores before and after aggregations
+      # compare anomaly scores before and after aggregations for individual files
       # plt.figure(2)
       # plt.plot(time_stamp_after_aggregation, binary_anomaly_score_after_aggregation)
       # plt.plot(time_stamp_pre_aggregation, binary_anomaly_score_pre_aggregation)
@@ -329,35 +408,27 @@ def runTimeVsDataLength(dataPath):
   Plot Data Aggregation Algorithm Runtime vs length of the data
   """
 
-  dataDirs = [join(dataPath, f) for f in listdir(dataPath) if not isfile(join(dataPath, f))]
+  dataDirs = [join(dataPath, f) for f in os.listdir(dataPath) if not isfile(join(dataPath, f))]
 
   thresh = 0.2
 
   dataLength = []
   runTime = []
   for dir in dataDirs:
-    datafiles = [join(dir, f) for f in listdir(dir) if isfile(join(dir, f))]
+    datafiles = [join(dir, f) for f in os.listdir(dir) if isfile(join(dir, f))]
 
     for i in range(len(datafiles)):
-      dat = pd.read_csv(datafiles[i], header=0, names=['timestamp', 'value'])
-      data_file_dir = datafiles[i].split('/')
-      dataLength.append(len(dat))
+      (timestamp, sig) = readCSVfiles(datafiles[i])
 
-      sig = dat['value'].values
-      timestamp = pd.to_datetime(dat.timestamp)
-      sampling_interval = timestamp[len(sig)-1] - timestamp[0]
-      dt = sampling_interval.total_seconds()/(len(sig)-1)
-      ts = pd.Series(np.array(dat.value).astype('float32'), index=pd.to_datetime(dat.timestamp))
+      dataLength.append(len(sig))
 
       start_time = time.time()
-      (cum_cwt_var, time_scale) = calculate_cwt(dat, display=False)
-      # apply different threshold to the cumulative power variance
 
-      cutoff_time_scale = time_scale[np.where(cum_cwt_var >= thresh)[0][0]]
+      aggregate_data([thresh], datafiles[i], aggregatedDataPath='data_aggregate/', display=False)
 
       end_time = time.time()
 
-      print " length: ", len(dat), " file: ", datafiles[i], " Time: ", end_time - start_time
+      print " length: ", len(dat), " file: ", datafiles[i], " Time: ", (end_time - start_time)
 
       runTime.append(end_time - start_time)
 
@@ -373,23 +444,29 @@ def runTimeVsDataLength(dataPath):
 if __name__ == "__main__":
 
   NABPath = '/Users/ycui/nta/NAB/'
-  currentPath = getcwd()
+  currentPath = os.getcwd()
 
   thresh_list = [0, 0.02, 0.04, 0.06, 0.08, 0.1, 0.12, 0.14, 0.16, 0.18, 0.2,
                  0.22, 0.24, 0.26, 0.28, 0.3, 0.32, 0.34, 0.36, 0.38, 0.40]
 
   # step 1: aggregate NAB data with different threshold
   print " aggregating NAB data ..."
-  aggregate_nab_data(thresh_list, dataPath=NABPath+'data/')
+  aggregate_nab_data(thresh_list, dataPath=NABPath+'data/', verbose=2)
 
   # step 2: run HTM on aggregated NAB data
   for thresh in thresh_list:
+    resultsAggregatePath = currentPath + "/results_aggregate/thresh=" + str(thresh) + "/numenta"
+    if not os.path.exists(resultsAggregatePath):
+      os.os.makedirs(resultsAggregatePath)
     print " run HTM on aggregated data with threshold " + str(thresh)
-    system("python " + NABPath + "run.py -d numenta --detect --dataDir data_aggregate/thresh=" + str(thresh) +
+    os.system("python " + NABPath + "run.py -d numenta --detect --dataDir " + currentPath + "/data_aggregate/thresh=" + str(thresh) + \
               "/ --resultsDir "+ currentPath + "/results_aggregate/thresh=" + str(thresh) + " --skipConfirmation")
 
   # step 3: get pre-aggregated anomaly score
   for thresh in thresh_list:
+    preresultAggregatePath = currentPath + "/results_pre_aggregate/thresh=" + str(thresh) + "/numenta"
+    if not os.path.exists(preresultAggregatePath):
+      os.os.makedirs(preresultAggregatePath)
     get_pre_aggregated_anomaly_score(data_path=NABPath+'data/',
                                      result_folder='results_aggregate/thresh=' + str(thresh) + '/numenta',
                                      result_folder_pre_aggregate='results_pre_aggregate/thresh=' + str(thresh) + '/numenta')
@@ -397,7 +474,7 @@ if __name__ == "__main__":
   # step 4: run NAB scoring
   for thresh in thresh_list:
     print " run scoring on aggregated data with threshold " + str(thresh)
-    system("python " + NABPath + "run.py -d numenta --score --skipConfirmation " +
+    os.system("python " + NABPath + "run.py -d numenta --score --skipConfirmation " +
            "--thresholdsFile " + NABPath + "config/thresholds.json " +
            "--resultsDir " + currentPath + "/results_pre_aggregate/thresh="+str(thresh)+"/")
 

--- a/projects/wavelet_dataAggregation/runDatetimeEncoderExperiment.py
+++ b/projects/wavelet_dataAggregation/runDatetimeEncoderExperiment.py
@@ -11,9 +11,10 @@ plt.ion()
 You need to run NAB with four different sets of model parameters before using this script
 
 
-# go to the NAB directory, create a new result directory named results_encoder/
+go to the NAB directory, create a new result directory named results_encoder/
 
-# the model parameters are located in ./nab_modelparams
+replace the nab/detectors/numenta/modelParams/model_params.json with
+the model parameters are located in ./nab_modelparams
 
 # first use model_params_value_only
 python run.py -d numenta --detect --dataDir data_processed/ --resultsDir results_encoder/value_only --score
@@ -23,7 +24,6 @@ python run.py -d numenta --detect --dataDir data_processed/ --resultsDir results
 
 # third use model_params_day_of_week
 python run.py -d numenta --detect --dataDir data_processed/ --resultsDir results_encoder/day_of_week/ --score
-
 
 """
 


### PR DESCRIPTION
@marionleborgne 

* remove pandas dependency in core functions for data aggregation. pandas is still used in places specific for this experiment, but it shouldn't affect unicorn

* use numpy datetime64 for datetime, instead of pandas timestamps

* add two functions to replace data aggregation in pandas, 
       resample_data, to resample data at a homogeneous sampling rate and 
       aggregate_data, to aggregate data at larger sampling intervals

* make sure required directory exists, if not, create them