### PR TITLE
Fixes Initialization Problem of Temporal Pooler Region

### DIFF
--- a/htmresearch/regions/TemporalPoolerRegion.py
+++ b/htmresearch/regions/TemporalPoolerRegion.py
@@ -35,9 +35,9 @@ class MonitoredUnionTemporalPooler(UnionTemporalPoolerMonitorMixin,
 
 
 def _getPoolerClass(name):
-    if name=="union":
+    if name == "union":
       return UnionTemporalPooler
-    elif name=="unionMonitored":
+    elif name == "unionMonitored":
       return MonitoredUnionTemporalPooler
     else:
       raise RuntimeError("Invalid pooling implementation %s. Valid ones are:" +
@@ -117,7 +117,7 @@ def _buildArgs(poolerClass, self=None, kwargs={}):
   return argTuples
 
 
-def _getAdditionalSpecs(poolerClass=_getDefaultPoolerClass()):
+def _getAdditionalSpecs(poolerClass=_getDefaultPoolerClass(), poolerType="union"):
   """Build the additional specs in three groups (for the inspector)
 
   Use the type of the default argument to set the Spec type, defaulting
@@ -162,7 +162,7 @@ def _getAdditionalSpecs(poolerClass=_getDefaultPoolerClass()):
   # Get arguments from spatial pooler constructors, figure out types of
   # variables and populate poolerSpec.
   # This allows setting SP parameters
-  pArgTuples = _buildArgs(_getParentSpatialPoolerClass())
+  pArgTuples = _buildArgs(_getParentSpatialPoolerClass(poolerType))
   for argTuple in pArgTuples:
     d = dict(
       description=argTuple[1],
@@ -258,7 +258,7 @@ class TemporalPoolerRegion(PyRegion):
     # These calls whittle down kwargs and create instance variables of TemporalPoolerRegion
     self._poolerClass = _getPoolerClass(poolerType)
     pArgTuples = _buildArgs(self._poolerClass, self, kwargs)
-    pArgTuplesSP = _buildArgs(_getParentSpatialPoolerClass(), self, kwargs)
+    pArgTuplesSP = _buildArgs(_getParentSpatialPoolerClass(poolerType), self, kwargs)
     # Make a list of automatic pooler arg names for later use
     self._poolerArgNames = [t[0] for t in pArgTuples] + [t[0] for t in pArgTuplesSP]
 
@@ -353,6 +353,15 @@ class TemporalPoolerRegion(PyRegion):
                          or not the input vector received in this compute cycle
                          represents the start of a new temporal sequence.""",
           dataType='Real32',
+          count=1,
+          required=False,
+          regionLevel=True,
+          isDefaultInput=False,
+          requireSplitterMap=False),
+
+        sequenceIdIn=dict(
+          description="Sequence ID",
+          dataType='UInt64',
           count=1,
           required=False,
           regionLevel=True,

--- a/projects/nlp/run_simple_classification_experiment.py
+++ b/projects/nlp/run_simple_classification_experiment.py
@@ -380,7 +380,7 @@ if __name__ == "__main__":
   plt.figure(1)
   plt.show()
   numTokens = NetworkDataGenerator.getNumberOfTokens(args.dataPath)
-  for numSample in xrange(200):#xrange(len(numTokens)):
+  for numSample in xrange(len(numTokens)):
     # union SDR for this sequence
     tmCellActivation = np.zeros((tmRegion._tfdr.cellsPerColumn * tmRegion._tfdr.columnDimensions[0],))
     tmInputActivation = np.zeros((tmRegion._tfdr.columnDimensions[0],))
@@ -420,7 +420,6 @@ if __name__ == "__main__":
         resetSignal = sensorOutput['resetOut']
         tpRegionInput = {"activeCells": tmRegionOutput["bottomUpOut"],
                          "predictedActiveCells": tmRegionOutput["predictedActiveCells"],
-                         "sequenceIdIn": sensorOutput["sequenceIdOut"],
                          "resetIn": resetSignal}
         tpRegionOutputs = {"mostActiveCells": np.zeros((tpRegion._columnCount,))}
         tpRegion.compute(tpRegionInput, tpRegionOutputs)


### PR DESCRIPTION
@BoltzmannBrain 

I fixes the problem of the temporal pooler region. You should be able to initialize it now. 

There were two problems. The first problem is because I forgot to pass in the poolerType when calling _getParentSpatialPoolerClass. Sorry about the bug.

To get it running, I also reverted an earlier commit that removed sequenceIDIn from the BaseSpec of TemporalPoolerRegion. 
https://github.com/numenta/nupic.research/commit/c13e74d34a1ce048711217a29c9fb920402b2f25#diff-29ead8af5de93cf140f7faf013f3002bL362

Why do we eliminate the sequenceIDIn information from TemporalPooler? If we really need to do that, we also need to change this
https://github.com/numenta/nupic.research/blob/master/htmresearch/frameworks/classification/classification_network.py#L326