### PR TITLE
json is not a drop-in replacement for simplejson

### DIFF
--- a/htmresearch/frameworks/classification/classification_network.py
+++ b/htmresearch/frameworks/classification/classification_network.py
@@ -24,10 +24,7 @@ The methods here are a factory to create a classification network
 of any of sensor, SP, TM, TP, and classifier regions.
 """
 import copy
-try:
-  import simplejson as json
-except ImportError:
-  import json
+import simplejson as json
 import logging
 import numpy
 import sys

--- a/htmresearch/frameworks/nlp/classification_model.py
+++ b/htmresearch/frameworks/nlp/classification_model.py
@@ -30,10 +30,7 @@ from collections import defaultdict, OrderedDict
 
 from htmresearch.support.text_preprocess import TextPreprocess
 
-try:
-  import simplejson as json
-except ImportError:
-  import json
+import simplejson as json
 
 
 

--- a/htmresearch/frameworks/nlp/classify_keywords.py
+++ b/htmresearch/frameworks/nlp/classify_keywords.py
@@ -26,10 +26,7 @@ import os
 from htmresearch.frameworks.nlp.classification_model import ClassificationModel
 from nupic.algorithms.KNNClassifier import KNNClassifier
 
-try:
-  import simplejson as json
-except ImportError:
-  import json
+import simplejson as json
 
 
 

--- a/htmresearch/frameworks/nlp/classify_windows.py
+++ b/htmresearch/frameworks/nlp/classify_windows.py
@@ -31,11 +31,7 @@ from htmresearch.frameworks.nlp.classification_model import ClassificationModel
 from htmresearch.support.text_preprocess import TextPreprocess
 from nupic.algorithms.KNNClassifier import KNNClassifier
 
-try:
-  import simplejson as json
-except ImportError:
-  import json
-
+import simplejson as json
 
 
 class ClassificationModelWindows(ClassificationModel):

--- a/htmresearch/frameworks/nlp/htm_runner.py
+++ b/htmresearch/frameworks/nlp/htm_runner.py
@@ -30,10 +30,7 @@ from htmresearch.frameworks.nlp.classify_htm import ClassificationModelHTM
 from htmresearch.support.data_split import KFolds
 from htmresearch.support.network_text_data_generator import NetworkDataGenerator
 
-try:
-  import simplejson as json
-except ImportError:
-  import json
+import simplejson as json
 
 
 

--- a/htmresearch/support/network_text_data_generator.py
+++ b/htmresearch/support/network_text_data_generator.py
@@ -36,10 +36,7 @@ from collections import defaultdict, OrderedDict
 from htmresearch.support.csv_helper import readCSV
 from htmresearch.support.text_preprocess import TextPreprocess
 
-try:
-  import simplejson as json
-except ImportError:
-  import json
+import simplejson as json
 
 
 

--- a/projects/classification/sensor/artificial_data/run_experiments.py
+++ b/projects/classification/sensor/artificial_data/run_experiments.py
@@ -20,10 +20,7 @@
 # http://numenta.org/licenses/
 # ----------------------------------------------------------------------
 
-try:
-  import simplejson as json
-except ImportError:
-  import json
+import simplejson as json
 
 from nupic.data.file_record_stream import FileRecordStream
 

--- a/projects/nlp/imbu_runner.py
+++ b/projects/nlp/imbu_runner.py
@@ -38,10 +38,7 @@ from htmresearch.frameworks.nlp.classify_windows import (
   ClassificationModelWindows)
 from htmresearch.support.csv_helper import readCSV
 
-try:
-  import simplejson as json
-except ImportError:
-  import json
+import simplejson as json
 
 
 _MODEL_MAPPING = {

--- a/projects/nlp/run_buckets_experiment.py
+++ b/projects/nlp/run_buckets_experiment.py
@@ -31,10 +31,7 @@ import time
 from htmresearch.frameworks.nlp.bucket_runner import BucketRunner
 from htmresearch.frameworks.nlp.bucket_htm_runner import BucketHTMRunner
 
-try:
-  import simplejson as json
-except ImportError:
-  import json
+import simplejson as json
 
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 # Program requirements
 pandas
 plotly
+simplejson
 nupic

--- a/tests/classification/test_sensor_data_classification.py
+++ b/tests/classification/test_sensor_data_classification.py
@@ -22,10 +22,7 @@
 import shutil
 import unittest
 
-try:
-  import simplejson as json
-except ImportError:
-  import json
+import simplejson as json
 
 from nupic.data.file_record_stream import FileRecordStream
 

--- a/tests/nlp/integration/cio_encodings_test.py
+++ b/tests/nlp/integration/cio_encodings_test.py
@@ -27,10 +27,7 @@ from htmresearch.encoders import EncoderTypes
 from htmresearch.encoders.cio_encoder import CioEncoder
 from htmresearch.support.text_preprocess import TextPreprocess
 
-try:
-  import simplejson as json
-except ImportError:
-  import json
+import simplejson as json
 
 
 DATA_DIR = os.path.join(os.path.dirname(os.path.abspath(__file__)), "test_data")

--- a/tests/nlp/integration/sample_matching_test.py
+++ b/tests/nlp/integration/sample_matching_test.py
@@ -29,10 +29,7 @@ from htmresearch.encoders import EncoderTypes
 from htmresearch.frameworks.nlp.htm_runner import HTMRunner
 from htmresearch.support.csv_helper import readCSV
 
-try:
-  import simplejson as json
-except ImportError:
-  import json
+import simplejson as json
 
 
 DATA_DIR = os.path.join(os.path.dirname(os.path.abspath(__file__)), "test_data")

--- a/tests/nlp/unit/utils/network_text_data_generator_test.py
+++ b/tests/nlp/unit/utils/network_text_data_generator_test.py
@@ -30,10 +30,7 @@ import unittest
 from htmresearch.support.network_text_data_generator import NetworkDataGenerator
 from nupic.data.file_record_stream import FileRecordStream
 
-try:
-  import simplejson as json
-except:
-  import json
+import simplejson as json
 
 
 


### PR DESCRIPTION
Fixes #380 

I've changed all the fallback imports and added simplejson to requirements.txt. I'm not sure how to test this since much of the affected code is not covered by unit tests. However, compared to master, the same number of tests under tests/nlp/unit fail with this change (11 fail, 26 pass). Also, if code was previously working with simplejson importable, there should not be any reason why it would stop working by removing the json fallback.

@BoltzmannBrain @subutai 