### PR TITLE
Revised JUnit metrics

### DIFF
--- a/htmresearch/support/junit_testing.py
+++ b/htmresearch/support/junit_testing.py
@@ -27,6 +27,7 @@ helpStr = """
 import itertools
 import numpy
 from prettytable import PrettyTable
+from scipy.stats import skew
 
 from htmresearch.frameworks.nlp.classification_model import ClassificationModel
 from htmresearch.frameworks.nlp.model_factory import (
@@ -91,40 +92,32 @@ def setupExperiment(args):
   return newModel, dataSet
 
 
-def testModel(model, testData, categorySize, verbosity=0,
-  separationMetric=False):
+def testModel(model, testData, categorySize, verbosity=0):
   """
   Test the given model on testData, print out and return results metrics. The
   categorySize specifies the number of documents per category.
 
   For each data sample in testData the model infers the similarity to each other
   sample; distances are number of bits apart. We then calculate two types of
-  results metrics: (i) "degrees of separation" and (ii) "overall ranks". We only
-  compute (i) if specified by the separationMetric param.
+  results metrics: (i) true positives (TPs) and (ii) "ranks" statistics.
 
-    i. Doc #403 is separated from doc #s 402 and 404 by one degree, from doc #s
-    401 and 405 by two degrees, and so on. The fewer degrees of separation, the
-    more similarity we expect.
-    For the test document we want the distances for each "degree of
-    separation" within the document's category -- e.g. doc #403,
-         degree 0: distance to #403
-         degree 1: mean of distances to #402 and #404
-         degree 2: mean of distances to #401 and #405
-         degree 3: distance to #400
-         degree 4: none
-         degree 5: none
+    i. From the sorted inference results, we get the top-ranked documents 1 to
+    the categorySize. A true positive is defined as a top-ranked document that
+    is in the same category as the test document. The max possible is thus the
+    category size.
 
     ii. From the sorted inference results, we get the ranks of the
     samples that share the same category as the inference sample. Ideally these
     ranks would be low, and the test document itself would be at rank 0. The
-    final score is the sum of these ranks across all test documents.
+    stats to describe these ranks are mean and skewness -- about 0 for normally
+    distributed data, and a skewness value > 0 means that there is more weight
+    in the left tail of the distribution. For example,
+      [10, 11, 12, 13, 14, 15] --> mean=12.5, skew=0.0
+      [0, 1, 2, 3, 4, 72] --> mean=13.7, skew=1.8
 
   @param categorySize (int) Number of documents per category; these unit tests
       use datasets with an exact number of docs in each category.
-  @param separationMetric (bool) Compute the "degrees of separation" metric.
 
-  @return degreesOfSeperation (dict) Distance (bits away) for each degree of
-      separation from the test document.
   @return allRanks (numpy array) Positions within the inference results list
       of the documents in the test document's category.
   """
@@ -134,79 +127,58 @@ def testModel(model, testData, categorySize, verbosity=0,
   print "positions 0-{}.".format(categorySize-1)
   if verbosity > 0:
     print
-    printTemplate = PrettyTable(["ID", "Document", "Result"])
+    printTemplate = PrettyTable(["ID", "Document", "TP", "Ranks (Mean, Skew)"])
     printTemplate.align = "l"
     printTemplate.header_style = "upper"
 
   allRanks = []
-  allSeparations = []
-  totalPassed = 0
-  perfectScore = sum(xrange(categorySize))
+  totalTPs = 0
+  totalMeans = 0
+  totalSkews = 0
   for (document, labels, docId) in testData:
     _, sortedIds, sortedDistances = model.inferDocument(
       document, returnDetailedResults=True, sortResults=True)
 
-    # Compute the "ranks" for this document
+    # Compute TPs for this document
     expectedCategory = docId / 100
+    truePositives = 0
+    for i in xrange(categorySize):
+      if sortedIds[i]/100 == expectedCategory:
+        truePositives += 1
+    totalTPs += truePositives
+
+    # Compute the rank metrics for this document
     ranks = numpy.array(
       [i for i, index in enumerate(sortedIds) if index/100 == expectedCategory])
     allRanks.append(ranks)
-    score = ranks.sum()
-
-    if score == perfectScore:
-      result = "Pass"
-      totalPassed += 1
-    else:
-      result = "Fail"
+    ranksMean = round(ranks.mean(), 2)
+    ranksSkew = round(skew(ranks), 2)
+    totalMeans += ranksMean
+    totalSkews += ranksSkew
 
     if verbosity > 0:
-      printTemplate.add_row([docId, document, result])
-
-    if separationMetric:
-      allSeparations.append(_computeSeparationMetric(sortedIds,
-                                                     sortedDistances,
-                                                     expectedCategory))
+      printTemplate.add_row(
+        [docId, document, truePositives, (ranksMean, ranksSkew)])
 
   if verbosity > 0:
     print printTemplate
+  lengthOfTest = float(len(testData))
   print
-  print "{}% of test documents passed ({}/{}).".format(
-    float(100*totalPassed/len(testData)), totalPassed, len(testData))
+  print "Averages across all test documents:"
+  print "TPs =", totalTPs/lengthOfTest
+  print "Rank metrics (mean, skew) = ({}, {})".format(
+    totalMeans/lengthOfTest, totalSkews/lengthOfTest)
 
-  return allSeparations, allRanks
-
-
-def _computeSeparationMetric(sortedIds, sortedDistances, expectedCategory):
-  """
-  Compute the "degrees of separation" for this document; metric is described
-  in the testModel() method.
-  """
-  distancesWithinCategory = {k: v for k, v in zip(sortedIds, sortedDistances)
-                             if k/100 == expectedCategory}
-  degreesOfSeperation = {}
-  for degree in xrange(categorySize):
-    # Get the mean separation for each relevant degree
-    separation = 0
-    count = 0
-    if distancesWithinCategory.has_key(docId+degree):
-      separation += distancesWithinCategory[docId+degree]
-      count += 1
-    if distancesWithinCategory.has_key(docId-degree):
-      separation += distancesWithinCategory[docId-degree]
-      count += 1
-    degreesOfSeperation[degree] = separation / float(count) if count else None
-
-  return degreesOfSeperation
-
+  return allRanks
 
 
 def printRankResults(testName, ranks):
   """ Print the ranking metric results."""
-  totalScore = sum(list(itertools.chain.from_iterable(ranks)))
+  ranksSum = sum(list(itertools.chain.from_iterable(ranks)))
   printTemplate = "{0:<32}|{1:<10}"
   print
   print
-  print "Final test scores for {} (lower is better):".format(testName)
-  print printTemplate.format("Total score", totalScore)
-  print printTemplate.format("Avg. score per test sample",
-                             float(totalScore) / len(ranks))
+  print "Final rank sums for {} (lower is better):".format(testName)
+  print printTemplate.format("Total", ranksSum)
+  print printTemplate.format("Avg. per test sample",
+                             float(ranksSum) / len(ranks))

--- a/projects/nlp/junit_test1.py
+++ b/projects/nlp/junit_test1.py
@@ -41,10 +41,10 @@ def runExperiment(args):
   """ Build a model and test it."""
   model, dataSet = setupExperiment(args)
 
-  _, ranks = testModel(model,
-                       dataSet,
-                       categorySize=6,
-                       verbosity=args.verbosity)
+  ranks = testModel(model,
+                    dataSet,
+                    categorySize=6,
+                    verbosity=args.verbosity)
   printRankResults("JUnit1", ranks)
 
   return model

--- a/projects/nlp/junit_test2.py
+++ b/projects/nlp/junit_test2.py
@@ -43,16 +43,16 @@ def runExperiment(args):
   """ Build a model and test it."""
   model, dataSet = setupExperiment(args)
 
-  _, ranks = testModel(model,
-                       [d for d in dataSet if d[2]%100==0],
-                       categorySize=5,
-                       verbosity=args.verbosity)
+  ranks = testModel(model,
+                    [d for d in dataSet if d[2]%100==0],
+                    categorySize=5,
+                    verbosity=args.verbosity)
   printRankResults("JUnit2a", ranks)
 
-  _, ranks = testModel(model,
-                       [d for d in dataSet if d[2]%100==4],
-                       categorySize=5,
-                       verbosity=args.verbosity)
+  ranks = testModel(model,
+                    [d for d in dataSet if d[2]%100==4],
+                    categorySize=5,
+                    verbosity=args.verbosity)
   printRankResults("JUnit2b", ranks)
 
   return model

--- a/projects/nlp/junit_test3.py
+++ b/projects/nlp/junit_test3.py
@@ -43,10 +43,10 @@ def runExperiment(args):
   """ Build a model and test it."""
   model, dataSet = setupExperiment(args)
 
-  _, ranks = testModel(model,
-                       dataSet,
-                       categorySize=5,
-                       verbosity=args.verbosity)
+  ranks = testModel(model,
+                    dataSet,
+                    categorySize=5,
+                    verbosity=args.verbosity)
   printRankResults("JUnit3", ranks)
 
   return model

--- a/projects/nlp/junit_test4.py
+++ b/projects/nlp/junit_test4.py
@@ -46,10 +46,10 @@ def runExperiment(args):
 
   model, dataSet = setupExperiment(args)
 
-  _, ranks = testModel(model,
-                       [d for d in dataSet if d[2]%100==0],
-                       categorySize=5,
-                       verbosity=args.verbosity)
+  ranks = testModel(model,
+                    [d for d in dataSet if d[2]%100==0],
+                    categorySize=5,
+                    verbosity=args.verbosity)
   printRankResults("JUnit4", ranks)
 
   return model

--- a/projects/nlp/junit_test5.py
+++ b/projects/nlp/junit_test5.py
@@ -41,10 +41,10 @@ def runExperiment(args):
   """ Build a model and test it."""
   model, dataSet = setupExperiment(args)
 
-  _, ranks = testModel(model,
-                       [d for d in dataSet if d[2]%100==0],
-                       categorySize=5,
-                       verbosity=args.verbosity)
+  ranks = testModel(model,
+                    [d for d in dataSet if d[2]%100==0],
+                    categorySize=5,
+                    verbosity=args.verbosity)
   printRankResults("JUnit4", ranks)
 
   return model


### PR DESCRIPTION
@subutai this implements the new metrics:
- True positives (total number of desired documents within the top x closest documents)
- Ranks statistics
  - Mean
  - Skewness; this tells us how unbalanced the distribution of ranks is. E.g., for ranks [10, 11, 12, 13, 14, 15], the mean=12.5 and skewness=0.0. For [0, 1, 2, 3, 4, 65] the mean=12.5 and skewness=1.8

For example, running CioDocumentFingerprint on unit test 4 gives the following results:
```
Averages across the 10 test documents:
TPs = 2.0
Rank metrics (mean, skew) = (9.96, 0.271)

Final rank sums (lower is better):
Total                           |498       
Avg. per test sample            |49.8
```