### PR TITLE
Histograms for NLP JUnit tests

### DIFF
--- a/projects/nlp/junit_test2.py
+++ b/projects/nlp/junit_test2.py
@@ -33,29 +33,73 @@ helpStr = """
 """
 
 import argparse
+import os
 
 from htmresearch.support.junit_testing import (
-  printRankResults, setupExperiment, testModel)
+  htmConfigs, nlpModelTypes, plotResults, printRankResults, setupExperiment,
+  testModel,
+)
 
 
+# Dataset info
+CATEGORY_SIZE = 5
+NUMBER_OF_DOCS = 80
 
-def runExperiment(args):
-  """ Build a model and test it."""
+
+def runExperiment(args, testIndex=0):
+  """ Build a model and test it.
+  @param testIndex (int) Specifies the doc of each group we use for inference.
+  """
   model, dataSet = setupExperiment(args)
 
-  ranks = testModel(model,
-                    [d for d in dataSet if d[2]%100==0],
-                    categorySize=5,
+  allRanks, avgRanks, avgStats = testModel(model,
+                    [d for d in dataSet if d[2]%100==testIndex],
+                    categorySize=CATEGORY_SIZE,
                     verbosity=args.verbosity)
-  printRankResults("JUnit2a", ranks)
+  printRankResults("JUnit2", avgRanks, avgStats)
 
-  ranks = testModel(model,
-                    [d for d in dataSet if d[2]%100==4],
-                    categorySize=5,
-                    verbosity=args.verbosity)
-  printRankResults("JUnit2b", ranks)
+  return allRanks, avgRanks, avgStats
 
-  return model
+
+def run(args):
+  """ Method to handle scenarios for running a single model or all of them."""
+  if args.modelName == "all":
+    modelNames = nlpModelTypes
+    runningAllModels = True
+  else:
+    modelNames = [args.modelName]
+    runningAllModels = False
+
+  # Run both variations (a and b) of junit test 2
+  test2Types = (("a", 0), ("b", 4))
+  for testVariation, testIndex in test2Types:
+    allRanks = {}
+    ranks = {}
+    stats = {}
+    for name in modelNames:
+      # Setup args
+      args.modelName = name
+      args.modelDir = os.path.join(args.experimentDir, name)
+      if runningAllModels and name == "htm":
+        # Need to specify network config for htm models
+        try:
+          htmModelInfo = htmConfigs.pop()
+          htmConfigs.add(htmModelInfo)  # TODO: replace this hack
+        except KeyError:
+          print "Not enough HTM configs, so skipping the HTM model."
+          continue
+        name = htmModelInfo[0]
+        args.networkConfigPath = htmModelInfo[1]
+
+      # Run the junit test, update metrics dicts
+      ar, r, s = runExperiment(args, testIndex)
+      allRanks.update({name:ar})
+      ranks.update({name:r})
+      stats.update({name:s})
+
+    plotResults(
+      allRanks, ranks, maxRank=NUMBER_OF_DOCS,
+      testName="JUnit Test 2{}".format(testVariation))
 
 
 
@@ -74,9 +118,9 @@ if __name__ == "__main__":
                       default="htm",
                       type=str,
                       help="Name of model class. Options: [keywords,htm]")
-  parser.add_argument("--modelDir",
-                      default="MODELNAME.checkpoint",
-                      help="Model will be saved in this directory.")
+  parser.add_argument("--experimentDir",
+                      default="junit2_checkpoints",
+                      help="Model(s) will be saved in this directory.")
   parser.add_argument("--retina",
                       default="en_associative_64_univ",
                       type=str,
@@ -90,16 +134,10 @@ if __name__ == "__main__":
                       default=1,
                       type=int,
                       help="verbosity 0 will print out experiment steps, "
-                           "verbosity 1 will include results, and verbosity > "
-                           "1 will print out preprocessed tokens and kNN "
-                           "inference metrics.")
+                           "verbosity 1 will include train and test data.")
   args = parser.parse_args()
-
-  # By default set checkpoint directory name based on model name
-  if args.modelDir == "MODELNAME.checkpoint":
-    args.modelDir = args.modelName + ".checkpoint"
 
   # Default dataset for this unit test
   args.dataPath = "data/junit/unit_test_2.csv"
 
-  model = runExperiment(args)
+  run(args)

--- a/projects/nlp/junit_test3.py
+++ b/projects/nlp/junit_test3.py
@@ -33,9 +33,17 @@ helpStr = """
 """
 
 import argparse
+import os
 
 from htmresearch.support.junit_testing import (
-  printRankResults, setupExperiment, testModel)
+  htmConfigs, nlpModelTypes, plotResults, printRankResults, setupExperiment,
+  testModel,
+)
+
+
+# Dataset info
+CATEGORY_SIZE = 5
+NUMBER_OF_DOCS = 50
 
 
 
@@ -43,13 +51,48 @@ def runExperiment(args):
   """ Build a model and test it."""
   model, dataSet = setupExperiment(args)
 
-  ranks = testModel(model,
+  allRanks, avgRanks, avgStats = testModel(model,
                     dataSet,
-                    categorySize=5,
+                    categorySize=CATEGORY_SIZE,
                     verbosity=args.verbosity)
-  printRankResults("JUnit3", ranks)
+  printRankResults("JUnit3", avgRanks, avgStats)
 
-  return model
+  return allRanks, avgRanks, avgStats
+
+
+def run(args):
+  """ Method to handle scenarios for running a single model or all of them."""
+  if args.modelName == "all":
+    modelNames = nlpModelTypes
+    runningAllModels = True
+  else:
+    modelNames = [args.modelName]
+    runningAllModels = False
+
+  allRanks = {}
+  ranks = {}
+  stats = {}
+  for name in modelNames:
+    # Setup args
+    args.modelName = name
+    args.modelDir = os.path.join(args.experimentDir, name)
+    if runningAllModels and name == "htm":
+      # Need to specify network config for htm models
+      try:
+        htmModelInfo = htmConfigs.pop()
+      except KeyError:
+        print "Not enough HTM configs, so skipping the HTM model."
+        continue
+      name = htmModelInfo[0]
+      args.networkConfigPath = htmModelInfo[1]
+
+    # Run the junit test, update metrics dicts
+    ar, r, s = runExperiment(args)
+    allRanks.update({name:ar})
+    ranks.update({name:r})
+    stats.update({name:s})
+
+  plotResults(allRanks, ranks, maxRank=NUMBER_OF_DOCS, testName="JUnit Test 3")
 
 
 
@@ -68,9 +111,9 @@ if __name__ == "__main__":
                       default="htm",
                       type=str,
                       help="Name of model class. Options: [keywords,htm]")
-  parser.add_argument("--modelDir",
-                      default="MODELNAME.checkpoint",
-                      help="Model will be saved in this directory.")
+  parser.add_argument("--experimentDir",
+                      default="junit3_checkpoints",
+                      help="Model(s) will be saved in this directory.")
   parser.add_argument("--retina",
                       default="en_associative_64_univ",
                       type=str,
@@ -84,16 +127,10 @@ if __name__ == "__main__":
                       default=1,
                       type=int,
                       help="verbosity 0 will print out experiment steps, "
-                           "verbosity 1 will include results, and verbosity > "
-                           "1 will print out preprocessed tokens and kNN "
-                           "inference metrics.")
+                           "verbosity 1 will include train and test data.")
   args = parser.parse_args()
-
-  # By default set checkpoint directory name based on model name
-  if args.modelDir == "MODELNAME.checkpoint":
-    args.modelDir = args.modelName + ".checkpoint"
 
   # Default dataset for this unit test
   args.dataPath = "data/junit/unit_test_3.csv"
 
-  model = runExperiment(args)
+  run(args)

--- a/projects/nlp/junit_test4.py
+++ b/projects/nlp/junit_test4.py
@@ -32,9 +32,17 @@ helpStr = """
 """
 
 import argparse
+import os
 
 from htmresearch.support.junit_testing import (
-  printRankResults, setupExperiment, testModel)
+  htmConfigs, nlpModelTypes, plotResults, printRankResults, setupExperiment,
+  testModel,
+)
+
+
+# Dataset info
+CATEGORY_SIZE = 5
+NUMBER_OF_DOCS = 50
 
 
 
@@ -46,13 +54,49 @@ def runExperiment(args):
 
   model, dataSet = setupExperiment(args)
 
-  ranks = testModel(model,
+  allRanks, avgRanks, avgStats = testModel(model,
                     [d for d in dataSet if d[2]%100==0],
-                    categorySize=5,
+                    categorySize=CATEGORY_SIZE,
                     verbosity=args.verbosity)
-  printRankResults("JUnit4", ranks)
+  printRankResults("JUnit4", avgRanks, avgStats)
 
-  return model
+  return allRanks, avgRanks, avgStats
+
+
+
+def run(args):
+  """ Method to handle scenarios for running a single model or all of them."""
+  if args.modelName == "all":
+    modelNames = nlpModelTypes
+    runningAllModels = True
+  else:
+    modelNames = [args.modelName]
+    runningAllModels = False
+
+  allRanks = {}
+  ranks = {}
+  stats = {}
+  for name in modelNames:
+    # Setup args
+    args.modelName = name
+    args.modelDir = os.path.join(args.experimentDir, name)
+    if runningAllModels and name == "htm":
+      # Need to specify network config for htm models
+      try:
+        htmModelInfo = htmConfigs.pop()
+      except KeyError:
+        print "Not enough HTM configs, so skipping the HTM model."
+        continue
+      name = htmModelInfo[0]
+      args.networkConfigPath = htmModelInfo[1]
+
+    # Run the junit test, update metrics dicts
+    ar, r, s = runExperiment(args)
+    allRanks.update({name:ar})
+    ranks.update({name:r})
+    stats.update({name:s})
+
+  plotResults(allRanks, ranks, maxRank=NUMBER_OF_DOCS, testName="JUnit Test 4")
 
 
 
@@ -71,9 +115,9 @@ if __name__ == "__main__":
                       default="htm",
                       type=str,
                       help="Name of model class. Options: [keywords,htm]")
-  parser.add_argument("--modelDir",
-                      default="MODELNAME.checkpoint",
-                      help="Model will be saved in this directory.")
+  parser.add_argument("--experimentDir",
+                      default="junit4_checkpoints",
+                      help="Model(s) will be saved in this directory.")
   parser.add_argument("--retina",
                       default="en_associative_64_univ",
                       type=str,
@@ -87,16 +131,10 @@ if __name__ == "__main__":
                       default=1,
                       type=int,
                       help="verbosity 0 will print out experiment steps, "
-                           "verbosity 1 will include results, and verbosity > "
-                           "1 will print out preprocessed tokens and kNN "
-                           "inference metrics.")
+                           "verbosity 1 will include train and test data.")
   args = parser.parse_args()
-
-  # By default set checkpoint directory name based on model name
-  if args.modelDir == "MODELNAME.checkpoint":
-    args.modelDir = args.modelName + ".checkpoint"
 
   # Default dataset for this unit test
   args.dataPath = "data/junit/unit_test_4.csv"
 
-  model = runExperiment(args)
+  run(args)


### PR DESCRIPTION
Adds the ability to run all models at once so we can aggregate the results into a histogram (for each unit test) -- e.g. [junit test 2b](https://plot.ly/~alavin/4362/junit-test-2b-where-are-the-true-positives/).
@subutai 