### PR TITLE
NLP network params

### DIFF
--- a/projects/nlp/data/network_configs/imbu_sensor_tm_knn.json
+++ b/projects/nlp/data/network_configs/imbu_sensor_tm_knn.json
@@ -1,0 +1,40 @@
+{
+  "sensorRegionConfig": {
+    "regionEnabled": true,
+    "regionName": "sensor",
+    "regionType": "py.LanguageSensor",
+    "regionParams": {
+      "verbosity": 0,
+      "numCategories": 1
+      },
+    "encoders": {}
+  },
+  "tmRegionConfig": {
+    "regionEnabled": true,
+    "regionName": "TM",
+    "regionType": "py.TMRegion",
+    "regionParams": {
+      "columnCount": 4096,
+      "cellsPerColumn": 16,
+      "seed": 1960,
+      "temporalImp": "tm",
+      "maxNewSynapseCount": 40,
+      "initialPermanence": 0.21,
+      "connectedPermanence": 0.3,
+      "permanenceIncrement": 0.1,
+      "permanenceDecrement": 0.1,
+      "minThreshold": 20,
+      "activationThreshold": 22
+    }
+  },
+  "classifierRegionConfig": {
+    "regionEnabled": true,
+    "regionName": "classifier",
+    "regionType": "py.KNNClassifierRegion",
+    "regionParams": {
+      "k": 13,
+      "distanceMethod": "pctOverlapOfInput",
+      "maxCategoryCount": 1
+    }
+  }
+}


### PR DESCRIPTION
Adds a param file for Imbu to use TM.
@subutai I tried adding params from tm_knn_4k_retina that Yuwei has tuned a bit for NLP data to the tm2_knn_4k_retina params, but the following params were not added b/c they are unknown parameters for TM region type py.TMRegion: `maxSynapsesPerSegment`, `maxSegmentsPerCell`, `globalDecay`, `maxAge`, and `outputType`.