### PR TITLE
LanguageSensor handle new DictReadOnlyWrapper type

### DIFF
--- a/htmresearch/frameworks/nlp/classification_model.py
+++ b/htmresearch/frameworks/nlp/classification_model.py
@@ -74,18 +74,18 @@ class ClassificationModel(object):
 
   ################## CORE METHODS #####################
 
-  def trainToken(self, token, labels, tokenId, reset=0):
+  def trainToken(self, token, labels, tokenId, resetSequence=0):
     """
     Train the model with the given text token, associated labels, and ID
     associated with this token.
 
-    @param token      (str)  The text token to train on
-    @param labels     (list) A list of one or more integer labels associated
-                             with this token.
-    @param tokenId    (int)  An integer ID associated with this token.
-    @param reset      (int)  Should be 0 or 1. If 1, assumes we are at the
-                             end of a sequence. A reset signal will be issued
-                             after the model has been trained on this token.
+    @param token         (str)  The text token to train on
+    @param labels        (list) A list of one or more integer labels associated
+                                with this token.
+    @param tokenId       (int)  An integer ID associated with this token.
+    @param resetSequence (int)  Should be 0 or 1. If 1, assumes we are at the
+                                end of a sequence. A reset signal will be issued
+                                after the model has been trained on this token.
 
     """
     raise NotImplementedError
@@ -109,35 +109,38 @@ class ClassificationModel(object):
     tokenList, _ = self.tokenize(document)
     lastTokenIndex = len(tokenList) - 1
     for i, token in enumerate(tokenList):
-      self.trainToken(token, labels, sampleId, reset=int(i == lastTokenIndex))
+      self.trainToken(
+        token, labels, sampleId, resetSequence=int(i == lastTokenIndex))
 
 
-  def inferToken(self, token, reset=0, returnDetailedResults=False,
+  def inferToken(self, token, resetSequence=0, returnDetailedResults=False,
                  sortResults=True):
     """
     Classify the token (i.e. run inference on the model with this document) and
     return classification results and (optionally) a list of sampleIds and
     distances.   Repeated sampleIds are NOT removed from the results.
 
-    @param token    (str)     The text token to train on
-    @param reset    (int)     Should be 0 or 1. If 1, assumes we are at the
-                              end of a sequence. A reset signal will be issued
-                              after the model has been trained on this token.
+    @param token         (str)    The text token to train on.
+    @param resetSequence (int)    Should be 0 or 1. If 1, assumes we are at the
+                                  end of a sequence. A reset signal will be
+                                  issued after the model has been trained on
+                                  this token.
     @param returnDetailedResults
-                    (bool)    If True will return sampleIds and distances
-                              This could slow things down depending on the
-                              number of stored patterns.
-    @param sortResults (bool) If True the list of sampleIds and distances
-                              will be sorted in order of increasing distances.
+                          (bool)  If True will return sampleIds and distances
+                                  This could slow things down depending on the
+                                  number of stored patterns.
+    @param sortResults    (bool)  If True the list of sampleIds and distances
+                                  will be sorted in order of increasing
+                                  distances.
 
-    @return  (numpy array) An array of size numLabels. Position i contains
-                           the likelihood that this token belongs to the
-                           i'th category. An array containing all zeros
-                           implies no decision could be made.
-             (list)        A list of sampleIds or None if
-                           returnDetailedResults is False.
-             (numpy array) An array of distances from each stored sample or
-                           None if returnDetailedResults is False.
+    @return  (numpy array)    An array of size numLabels. Position i contains
+                              the likelihood that this token belongs to the
+                              i'th category. An array containing all zeros
+                              implies no decision could be made.
+             (list)           A list of sampleIds or None if
+                              returnDetailedResults is False.
+             (numpy array)    An array of distances from each stored sample or
+                              None if returnDetailedResults is False.
     """
     # TODO: Should we specify that distances normalized between 0 and 1?
     # Currently we use whatever the KNN returns.
@@ -186,7 +189,7 @@ class ClassificationModel(object):
     voteCount = 0
     for i, token in enumerate(tokenList):
       votes, _, _ = self.inferToken(token,
-                                    reset=int(i == lastTokenIndex),
+                                    resetSequence=int(i == lastTokenIndex),
                                     returnDetailedResults=False,
                                     sortResults=False)
 

--- a/htmresearch/frameworks/nlp/classify_fingerprint.py
+++ b/htmresearch/frameworks/nlp/classify_fingerprint.py
@@ -71,7 +71,7 @@ class ClassificationModelFingerprint(ClassificationModel):
     self.currentDocument = None
 
 
-  def trainToken(self, token, labels, sampleId, reset=0):
+  def trainToken(self, token, labels, sampleId, resetSequence=0):
     """
     Train the model with the given text token, associated labels, and
     sampleId.
@@ -85,7 +85,7 @@ class ClassificationModelFingerprint(ClassificationModel):
       # accumulate text for this document
       self.currentDocument.append(token)
 
-    if reset == 1:
+    if resetSequence == 1:
       # all text accumulated, proceed w/ training on this document
       document = " ".join(self.currentDocument)
       bitmap = self.encoder.encode(document)["fingerprint"]["positions"]
@@ -102,7 +102,7 @@ class ClassificationModelFingerprint(ClassificationModel):
       self.currentDocument = None
 
 
-  def inferToken(self, token, reset=0, returnDetailedResults=False,
+  def inferToken(self, token, resetSequence=0, returnDetailedResults=False,
                  sortResults=True):
     """
     Classify the token (i.e. run inference on the model with this document) and
@@ -118,10 +118,11 @@ class ClassificationModelFingerprint(ClassificationModel):
       # accumulate text for this document
       self.currentDocument.append(token)
 
-    if reset == 0:
+    if resetSequence == 0:
       return numpy.zeros(self.numLabels), [], numpy.zeros(0)
 
-    # With reset=1, all text accumulated, proceed w/ classifying this document
+    # With resetSequence=1, all text is accumulated, proceed with classifying
+    # this document
     document = " ".join(self.currentDocument)
     bitmap = self.encoder.encode(document)["fingerprint"]["positions"]
 

--- a/htmresearch/frameworks/nlp/classify_htm.py
+++ b/htmresearch/frameworks/nlp/classify_htm.py
@@ -72,7 +72,7 @@ class ClassificationModelHTM(ClassificationNetworkAPI):
     return configureNetwork(None, self.networkConfig, encoder)
 
 
-  def trainToken(self, token, labels, tokenId, reset=0):
+  def trainToken(self, token, labels, tokenId, resetSequence=0):
     """
     Train the model with the given text token, associated labels, and ID
     associated with this token.
@@ -85,18 +85,18 @@ class ClassificationModelHTM(ClassificationNetworkAPI):
     sensor.addDataToQueue(token,
                           categoryList=labels,
                           sequenceId=tokenId,
-                          reset=reset)
+                          reset=resetSequence)
     self.network.run(1)
 
     # Print the outputs of each region
     if self.verbosity >= 2:
       self.printRegionOutputs()
 
-    if reset == 1:
+    if resetSequence == 1:
       self.reset()
 
 
-  def inferToken(self, token, reset=0, returnDetailedResults=False,
+  def inferToken(self, token, resetSequence=0, returnDetailedResults=False,
                  sortResults=True):
     """
     Classify the token (i.e. run inference on the model with this document) and
@@ -110,7 +110,7 @@ class ClassificationModelHTM(ClassificationNetworkAPI):
     sensor = self.sensorRegion.getSelf()
     sensor.addDataToQueue(token,
                           categoryList=[None],
-                          sequenceId=-1, reset=reset)
+                          sequenceId=-1, reset=resetSequence)
     self.network.run(1)
 
     dist = self.classifierRegion.getSelf().getLatestDistances()
@@ -122,7 +122,7 @@ class ClassificationModelHTM(ClassificationNetworkAPI):
     if self.verbosity >= 2:
       self.printRegionOutputs()
 
-    if reset == 1:
+    if resetSequence == 1:
       self.reset()
 
     # If detailed results are not requested just return the category votes

--- a/htmresearch/frameworks/nlp/classify_keywords.py
+++ b/htmresearch/frameworks/nlp/classify_keywords.py
@@ -58,7 +58,7 @@ class ClassificationModelKeywords(ClassificationModel):
     return self.classifier
 
 
-  def trainToken(self, token, labels, tokenId, reset=0):
+  def trainToken(self, token, labels, tokenId, resetSequence=0):
     """
     Train the model with the given text token, associated labels, and ID
     associated with this token.
@@ -77,7 +77,7 @@ class ClassificationModelKeywords(ClassificationModel):
                             partitionId=tokenId)
 
 
-  def inferToken(self, token, reset=0, returnDetailedResults=False,
+  def inferToken(self, token, resetSequence=0, returnDetailedResults=False,
                  sortResults=True):
     """
     Classify the token (i.e. run inference on the model with this document) and

--- a/htmresearch/frameworks/nlp/imbu.py
+++ b/htmresearch/frameworks/nlp/imbu.py
@@ -304,7 +304,7 @@ class ImbuModels(object):
           model.trainToken(token,
                            labels,
                            wordId,
-                           reset=int(i == lastTokenIndex))
+                           resetSequence=int(i == lastTokenIndex))
 
     if savePath:
       self.save(model, savePath)

--- a/htmresearch/regions/LanguageSensor.py
+++ b/htmresearch/regions/LanguageSensor.py
@@ -164,7 +164,7 @@ class LanguageSensor(PyRegion):
     Expects the text data to be in under header "token" from the dataSource.
     """
     if len(self.queue) > 0:
-      # data has been added to the queue, so use it
+      # Data has been added to the queue, so use it
       data = self.queue.pop()
 
     elif self.dataSource is None:
@@ -172,18 +172,14 @@ class LanguageSensor(PyRegion):
                         "and the dataSource is None.")
     else:
       data = self.dataSource.getNextRecordDict()
-      # Keys in data that are not column headers from the data source are standard
-      # of RecordStreamIface objects.
+      # Keys in data that are not column headers from the data source are
+      # standard of RecordStreamIface objects
 
-    # Copy important data input fields over to outputs dict. We set "sourceOut"
-    # explicitly b/c PyRegion.getSpec() won't take an output field w/ type str.
+    # Copy important data input fields over to outputs dict.
     outputs["resetOut"][0] = data["_reset"]
     outputs["sequenceIdOut"][0] = data["_sequenceId"]
-    outputs.update({"sourceOut": data["_token"]})
-    self.populateCategoriesOut(data["_category"], outputs['categoryOut'])
-    # TODO: encodingOut should be an initialized field via the spec
-    encoding = self.encoder.encodeIntoArray(data["_token"], outputs["dataOut"])
-    outputs.update({"encodingOut": encoding})
+    self.populateCategoriesOut(data["_category"], outputs["categoryOut"])
+    self.encoder.encodeIntoArray(data["_token"], outputs["dataOut"])
 
     if self.verbosity > 0:
       print "LanguageSensor outputs:"
@@ -191,7 +187,8 @@ class LanguageSensor(PyRegion):
       print "Categories out: ", outputs['categoryOut']
       print "dataOut: ", outputs["dataOut"].nonzero()[0]
 
-    self._outputValues = copy.deepcopy(outputs)
+    self._outputValues = {field: value for field, value in outputs.iteritems()}
+    self._outputValues["sourceOut"] = data["_token"]
 
     self._iterNum += 1
 
@@ -221,9 +218,7 @@ class LanguageSensor(PyRegion):
 
 
   def getOutputValues(self, outputName):
-    """Return the dictionary of output values. Note that these are normal Python
-    lists, rather than numpy arrays. This is to support lists with mixed scalars
-    and strings, as in the case of records with categorical variables
+    """Return the region's values for outputName.
     """
     return self._outputValues[outputName]
 

--- a/htmresearch/regions/LanguageSensor.py
+++ b/htmresearch/regions/LanguageSensor.py
@@ -162,8 +162,6 @@ class LanguageSensor(PyRegion):
     outputs are as defined in the spec above.
 
     Expects the text data to be in under header "token" from the dataSource.
-
-    TODO: validate we're handling resets correctly
     """
     if len(self.queue) > 0:
       # data has been added to the queue, so use it
@@ -181,16 +179,17 @@ class LanguageSensor(PyRegion):
     # explicitly b/c PyRegion.getSpec() won't take an output field w/ type str.
     outputs["resetOut"][0] = data["_reset"]
     outputs["sequenceIdOut"][0] = data["_sequenceId"]
-    outputs["sourceOut"] = data["_token"]
+    outputs.update({"sourceOut": data["_token"]})
     self.populateCategoriesOut(data["_category"], outputs['categoryOut'])
-    outputs["encodingOut"] = self.encoder.encodeIntoArray(
-      data["_token"], outputs["dataOut"])
+    # TODO: encodingOut should be an initialized field via the spec
+    encoding = self.encoder.encodeIntoArray(data["_token"], outputs["dataOut"])
+    outputs.update({"encodingOut": encoding})
 
     if self.verbosity > 0:
       print "LanguageSensor outputs:"
       print "SeqID: ", outputs["sequenceIdOut"]
       print "Categories out: ", outputs['categoryOut']
-      print "dataOut: ",outputs["dataOut"].nonzero()[0]
+      print "dataOut: ", outputs["dataOut"].nonzero()[0]
 
     self._outputValues = copy.deepcopy(outputs)
 

--- a/htmresearch/regions/LanguageSensor.py
+++ b/htmresearch/regions/LanguageSensor.py
@@ -187,7 +187,11 @@ class LanguageSensor(PyRegion):
       print "Categories out: ", outputs['categoryOut']
       print "dataOut: ", outputs["dataOut"].nonzero()[0]
 
-    self._outputValues = {field: value for field, value in outputs.iteritems()}
+    # Deep copy the outputs so self._outputValues doesn't point to the values
+    # used within the Network API
+    self._outputValues = {
+      field: copy.deepcopy(value) for field, value in outputs.iteritems()
+    }
     self._outputValues["sourceOut"] = data["_token"]
 
     self._iterNum += 1


### PR DESCRIPTION
The LanguageSensor region assigns values to the `outputs` array, and thus fails following the changes in [nupic.core #931](https://github.com/numenta/nupic.core/pull/931). This was caught by the Bamboo builds of Imbu ([log here](https://ci.numenta.com/download/IMBU-IMBU-JOB1/build_logs/IMBU-IMBU-JOB1-186.log)).