### PR TITLE
Fixes reindexing bug in ETM

### DIFF
--- a/htmresearch/algorithms/extended_temporal_memory.py
+++ b/htmresearch/algorithms/extended_temporal_memory.py
@@ -86,9 +86,8 @@ class ExtendedTemporalMemory(TemporalMemory):
     if activeApicalCells is None:
       activeApicalCells = set()
 
-    activeExternalCells = self._reindexActiveExternalCells(activeExternalCells)
-    activeApicalCells = self._reindexActiveApicalCells(activeApicalCells,
-                                                       len(activeExternalCells))
+    activeExternalCells = self._reindexActiveCells(activeExternalCells)
+    activeApicalCells = self._reindexActiveCells(activeApicalCells)
 
     (activeCells,
      winnerCells,
@@ -505,22 +504,15 @@ class ExtendedTemporalMemory(TemporalMemory):
     return self.predictedActiveCells
 
 
-  def _reindexActiveExternalCells(self, activeExternalCells):
+  def _reindexActiveCells(self, activeCells):
     """
-    Move sensorimotor input indices to outside the range of valid cell indices
+    Move sensorimotor or apical input indices to outside the range of valid
+    cell indices
 
-    @params activeExternalCells (set) Indices of active external cells in `t`
+    @params activeCells (set) Indices of active external cells in `t`
     """
     numCells = self.numberOfCells()
-    return set([index + numCells for index in activeExternalCells])
-
-
-  def _reindexActiveApicalCells(self, activeApicalCells, numExtCells):
-    """
-    @params activeApicalCells (set) Indices of active apical cells in `t`
-    """
-    numCells = self.numberOfCells() + numExtCells
-    return set([index + numCells for index in activeApicalCells])
+    return set([index + numCells for index in activeCells])
 
 
   def calculatePredictiveCells(self, predictiveDistalCells,

--- a/tests/extended_temporal_memory/etm_unit_test.py
+++ b/tests/extended_temporal_memory/etm_unit_test.py
@@ -776,7 +776,7 @@ class ExtendedTemporalMemoryTest(unittest.TestCase):
 
     activeColumns = set([1, 3])
     activeExternalCells = set([1])  # will be re-indexed to 41
-    activeApicalCells = set([1, 2])  # will be re-indexed to 42, 43
+    activeApicalCells = set([2, 3])  # will be re-indexed to 42, 43
 
     tm.compute(
       activeColumns,


### PR DESCRIPTION
Fixes #565, using the same reindexing for external and apical inputs, as their respective synapses are handle by different Connections object.

Also updates one unit test as it is dependent on the reindexing scheme.

@subutai @mrcslws 