### PR TITLE
[RES-279] Track TM stats over learning in classification network

### DIFF
--- a/htmresearch/frameworks/classification/classification_network.py
+++ b/htmresearch/frameworks/classification/classification_network.py
@@ -488,7 +488,8 @@ def _getClassifierInference(classifierRegion):
 
 
 def _inspectTMPredictionQuality(tm, numRecordsToInspect):
-  """Inspect prediction quality of TM over the most recent N records"""
+  """ Inspect prediction quality of TM over the most recent
+  numRecordsToInspect records """
   # correct predictions: predicted -> active columns
   predictedActiveCols = tm.mmGetTracePredictedActiveColumns()
   numPredictedActiveCols = predictedActiveCols.makeCountsTrace().data

--- a/projects/classification/sensor/artificial_data/config/network_config_template.json
+++ b/projects/classification/sensor/artificial_data/config/network_config_template.json
@@ -46,7 +46,7 @@
       "columnCount": 2048,
       "cellsPerColumn": 32,
       "seed": 1960,
-      "temporalImp": "cpp",
+      "temporalImp": "monitored_tm_py",
       "newSynapseCount": 20,
       "maxSynapsesPerSegment": 32,
       "maxSegmentsPerCell": 128,

--- a/projects/classification/sensor/artificial_data/config/network_configs.json
+++ b/projects/classification/sensor/artificial_data/config/network_configs.json
@@ -81,7 +81,7 @@
         "maxAge": 0,
         "newSynapseCount": 20,
         "maxSegmentsPerCell": 128,
-        "temporalImp": "cpp"
+        "temporalImp": "monitored_tm_py"
       },
       "regionType": "py.TPRegion",
       "regionName": "TM"
@@ -169,7 +169,7 @@
         "maxAge": 0,
         "newSynapseCount": 20,
         "maxSegmentsPerCell": 128,
-        "temporalImp": "cpp"
+        "temporalImp": "monitored_tm_py"
       },
       "regionType": "py.TPRegion",
       "regionName": "TM"
@@ -257,7 +257,7 @@
         "maxAge": 0,
         "newSynapseCount": 20,
         "maxSegmentsPerCell": 128,
-        "temporalImp": "cpp"
+        "temporalImp": "monitored_tm_py"
       },
       "regionType": "py.TPRegion",
       "regionName": "TM"
@@ -345,7 +345,7 @@
         "maxAge": 0,
         "newSynapseCount": 20,
         "maxSegmentsPerCell": 128,
-        "temporalImp": "cpp"
+        "temporalImp": "monitored_tm_py"
       },
       "regionType": "py.TPRegion",
       "regionName": "TM"
@@ -433,7 +433,7 @@
         "maxAge": 0,
         "newSynapseCount": 20,
         "maxSegmentsPerCell": 128,
-        "temporalImp": "cpp"
+        "temporalImp": "monitored_tm_py"
       },
       "regionType": "py.TPRegion",
       "regionName": "TM"


### PR DESCRIPTION
@marionleborgne  Please review

Basic stats of TM will be tracked automatically if
* "temporalImp" is set to "monitored_tm_py" in network config
and
* learning is on for TM

Three stats are being tracked, including
* # predicted -> active cols  (correct predictions)
* # predicted -> inactive cols (extra/false predictions)
* # unpredicted -> active cols (unpredicted inputs)

These stats are updated every 100 iterations