### PR TITLE
Test C++ and Python ETM with "algorithm" (not "extensive") tests

### DIFF
--- a/htmresearch/algorithms/extended_temporal_memory.py
+++ b/htmresearch/algorithms/extended_temporal_memory.py
@@ -548,3 +548,11 @@ class ExtendedTemporalMemory(TemporalMemory):
         predictiveCells.add(candidate)
 
     return predictiveCells
+
+
+  def getLearnOnOneCell(self):
+    return self.learnOnOneCell
+
+
+  def setLearnOnOneCell(self, learnOnOneCell):
+    self.learnOnOneCell = learnOnOneCell

--- a/tests/extended_temporal_memory/etm_algorithm_cpp_test.py
+++ b/tests/extended_temporal_memory/etm_algorithm_cpp_test.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env python
+# ----------------------------------------------------------------------
+# Numenta Platform for Intelligent Computing (NuPIC)
+# Copyright (C) 2016, Numenta, Inc.  Unless you have an agreement
+# with Numenta, Inc., for a separate license for this software code, the
+# following terms and conditions apply:
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# See the GNU Affero Public License for more details.
+#
+# You should have received a copy of the GNU Affero Public License
+# along with this program.  If not, see http://www.gnu.org/licenses.
+#
+# http://numenta.org/licenses/
+# ----------------------------------------------------------------------
+
+import unittest
+
+import nupic.bindings.experimental
+from etm_algorithm_test_base import ExtendedTemporalMemoryAlgorithmTest
+
+
+
+class ExtendedTemporalMemoryAlgorithmTestCPP(
+        ExtendedTemporalMemoryAlgorithmTest, unittest.TestCase):
+  def getTMClass(self):
+    return nupic.bindings.experimental.ExtendedTemporalMemory

--- a/tests/extended_temporal_memory/etm_algorithm_py_test.py
+++ b/tests/extended_temporal_memory/etm_algorithm_py_test.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env python
+# ----------------------------------------------------------------------
+# Numenta Platform for Intelligent Computing (NuPIC)
+# Copyright (C) 2016, Numenta, Inc.  Unless you have an agreement
+# with Numenta, Inc., for a separate license for this software code, the
+# following terms and conditions apply:
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# See the GNU Affero Public License for more details.
+#
+# You should have received a copy of the GNU Affero Public License
+# along with this program.  If not, see http://www.gnu.org/licenses.
+#
+# http://numenta.org/licenses/
+# ----------------------------------------------------------------------
+
+import unittest
+
+from htmresearch.algorithms.extended_temporal_memory import ExtendedTemporalMemory
+from etm_algorithm_test_base import ExtendedTemporalMemoryAlgorithmTest
+
+
+
+class ExtendedTemporalMemoryAlgorithmTestPY(
+        ExtendedTemporalMemoryAlgorithmTest, unittest.TestCase):
+  def getTMClass(self):
+    return ExtendedTemporalMemory

--- a/tests/extended_temporal_memory/etm_algorithm_test_base.py
+++ b/tests/extended_temporal_memory/etm_algorithm_test_base.py
@@ -26,11 +26,8 @@ import random
 from nupic.data.generators.pattern_machine import PatternMachine
 from nupic.support.unittesthelpers.abstract_temporal_memory_test import AbstractTemporalMemoryTest
 
-from htmresearch.algorithms.extended_temporal_memory import ExtendedTemporalMemory
 
-
-class ExtensiveExtendedTemporalMemoryTest(AbstractTemporalMemoryTest,
-                                          unittest.TestCase):
+class ExtendedTemporalMemoryAlgorithmTest(AbstractTemporalMemoryTest):
   """
   Tests the specific aspects of extended temporal memory (external and apical
   input, learning on one cell, etc.
@@ -1740,10 +1737,6 @@ class ExtensiveExtendedTemporalMemoryTest(AbstractTemporalMemoryTest,
   # Overrides
   # ==============================
 
-  def getTMClass(self):
-    return ExtendedTemporalMemory
-
-
   def getPatternMachine(self):
     return PatternMachine(self.n, self.w, num=300)
 
@@ -1782,7 +1775,7 @@ class ExtensiveExtendedTemporalMemoryTest(AbstractTemporalMemoryTest,
 
 
   def setUp(self):
-    super(ExtensiveExtendedTemporalMemoryTest, self).setUp()
+    super(ExtendedTemporalMemoryAlgorithmTest, self).setUp()
 
     print ("\n"
            "======================================================\n"
@@ -1821,7 +1814,7 @@ class ExtensiveExtendedTemporalMemoryTest(AbstractTemporalMemoryTest,
     self.tm.reset()
 
     if activeApicalCellsSequence is None and activeExternalCellsSequence is None:
-      return super(ExtensiveExtendedTemporalMemoryTest, self).feedTM(sequence,
+      return super(ExtendedTemporalMemoryAlgorithmTest, self).feedTM(sequence,
                                                                      learn=learn,
                                                                      num=num)
 

--- a/tests/extended_temporal_memory/extensive_etm_test.py
+++ b/tests/extended_temporal_memory/extensive_etm_test.py
@@ -402,7 +402,7 @@ class ExtensiveExtendedTemporalMemoryTest(AbstractTemporalMemoryTest,
     representations in ABC and ADC.
     """
     self.init({"learnOnOneCell": False})
-    self.assertFalse(self.tm.learnOnOneCell)
+    self.assertFalse(self.tm.getLearnOnOneCell())
 
     numbers = self.sequenceMachine.generateNumbers(1, 10)
     numbers[0] = 50
@@ -433,7 +433,7 @@ class ExtensiveExtendedTemporalMemoryTest(AbstractTemporalMemoryTest,
     Train on ABCADC, check that C has the same representation in ADC and ABC.
     """
     self.init({"learnOnOneCell": True})
-    self.assertTrue(self.tm.learnOnOneCell)
+    self.assertTrue(self.tm.getLearnOnOneCell())
 
     numbers = self.sequenceMachine.generateNumbers(1, 10)
     numbers[0] = 50
@@ -464,7 +464,7 @@ class ExtensiveExtendedTemporalMemoryTest(AbstractTemporalMemoryTest,
     representations in ABC and ADC.
     """
     self.init({"learnOnOneCell": False})
-    self.assertFalse(self.tm.learnOnOneCell)
+    self.assertFalse(self.tm.getLearnOnOneCell())
 
     numbers = self.sequenceMachine.generateNumbers(1, 10)
     numbers[0] = 50
@@ -503,7 +503,7 @@ class ExtensiveExtendedTemporalMemoryTest(AbstractTemporalMemoryTest,
     ADC and ABC.
     """
     self.init({"learnOnOneCell": True})
-    self.assertTrue(self.tm.learnOnOneCell)
+    self.assertTrue(self.tm.getLearnOnOneCell())
 
     numbers = self.sequenceMachine.generateNumbers(1, 10)
     numbers[0] = 50
@@ -543,7 +543,7 @@ class ExtensiveExtendedTemporalMemoryTest(AbstractTemporalMemoryTest,
     can cause some bursting.
     """
     self.init({"learnOnOneCell": True})
-    self.assertTrue(self.tm.learnOnOneCell)
+    self.assertTrue(self.tm.getLearnOnOneCell())
 
     numbers = self.sequenceMachine.generateNumbers(1, 50)
     proximalInputA = self.sequenceMachine.generateFromNumbers(numbers)
@@ -566,14 +566,14 @@ class ExtensiveExtendedTemporalMemoryTest(AbstractTemporalMemoryTest,
     between patterns.
     """
     self.init({"learnOnOneCell": True, "cellsPerColumn": 8})
-    self.assertTrue(self.tm.learnOnOneCell)
+    self.assertTrue(self.tm.getLearnOnOneCell())
 
     numbers = self.sequenceMachine.generateNumbers(1, 50)
     proximalInputA = self.sequenceMachine.generateFromNumbers(numbers)
     numbers = self.sequenceMachine.generateNumbers(1, 50)
     externalInputA = self.sequenceMachine.generateFromNumbers(numbers)
 
-    for _ in xrange(self.tm.cellsPerColumn + 1):
+    for _ in xrange(self.tm.getCellsPerColumn() + 1):
       self.feedTM(proximalInputA, activeExternalCellsSequence=externalInputA)
 
     self._testTM(proximalInputA, activeExternalCellsSequence=externalInputA)
@@ -1659,7 +1659,7 @@ class ExtensiveExtendedTemporalMemoryTest(AbstractTemporalMemoryTest,
     Same test as A13, with external input, and using learnOnOneCell.
     """
     self.init({"learnOnOneCell": True})
-    self.assertTrue(self.tm.learnOnOneCell)
+    self.assertTrue(self.tm.getLearnOnOneCell())
 
     # A B C D E
     numbers = self.sequenceMachine.generateNumbers(1, 5)


### PR DESCRIPTION
Two changes:

- Change "extensive extended temporal memory tests" to "extended temporal memory algorithm tests".
- Run them on both C++ and Python ETMs, using the same OOP `getTMClass` strategy that I used in the similar NuPIC tests.