### PR TITLE
Continuous location object machine - first pass

### DIFF
--- a/htmresearch/frameworks/layers/continuous_location_object_machine.py
+++ b/htmresearch/frameworks/layers/continuous_location_object_machine.py
@@ -1,0 +1,362 @@
+# ----------------------------------------------------------------------
+# Numenta Platform for Intelligent Computing (NuPIC)
+# Copyright (C) 2016, Numenta, Inc.  Unless you have an agreement
+# with Numenta, Inc., for a separate license for this software code, the
+# following terms and conditions apply:
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# See the GNU Affero Public License for more details.
+#
+# You should have received a copy of the GNU Affero Public License
+# along with this program.  If not, see http://www.gnu.org/licenses.
+#
+# http://numenta.org/licenses/
+# ----------------------------------------------------------------------
+
+import math
+import random
+
+import numpy as np
+import matplotlib.pyplot as plt
+
+from nupic.encoders.coordinate import CoordinateEncoder
+from htmresearch.frameworks.layers.object_machine_base import ObjectMachineBase
+
+
+
+class ContinuousLocationObjectMachine(ObjectMachineBase):
+  """
+  This implementation of the object machine uses continuous locations instead
+  of discrete random ones. They are created using a CoordinateEncoder.
+  """
+
+  def __init__(self,
+               numInputBits=41,
+               sensorInputSize=2048,
+               externalInputSize=2048,
+               numCorticalColumns=1,
+               numFeatures=400,
+               dimension=3,
+               seed=42):
+    """
+    At creation, the SimpleObjectMachine creates a pool of locations and
+    features SDR's.
+
+    Parameters:
+    ----------------------------
+    @param   numInputBits (int)
+             Number of ON bits in the input. Note: it should be uneven as the
+             encoder only accepts uneven number of bits.
+
+    @param   sensorInputSize (int)
+             Total number of bits in the sensory input
+
+    @param   externalInputSize (int)
+             Total number of bits the external (location) input
+
+    @param   numCorticalColumns (int)
+             Number of cortical columns used in the experiment
+
+    @param   dimension (int)
+             Dimension of the locations. Will typically be 3.
+
+    @param   numFeatures (int)
+             Number of feature SDRs to generate per cortical column. There is
+             typically no need to not use the default value, unless the user
+             knows he will use more than 400 patterns.
+
+    @param   seed (int)
+             Seed to be used in the machine
+
+    """
+    super(ContinuousLocationObjectMachine, self).__init__(numInputBits,
+                                                          sensorInputSize,
+                                                          externalInputSize,
+                                                          numCorticalColumns,
+                                                          seed)
+
+    # location and features pool
+    self.numFeatures = numFeatures
+    self._generateFeatures()
+
+    self.dimension = dimension
+    self.locationEncoder = CoordinateEncoder(
+      w=numInputBits,
+      n=externalInputSize,
+      name="locationEncoder"
+    )
+
+
+  def provideObjectsToLearn(self, learningConfig, plot=False):
+    """
+    Returns the objects in a canonical format to be sent to an experiment.
+
+    The returned format is a a dictionary where the keys are object names, and
+    values are lists of sensations, each sensation being a mapping from
+    cortical column index to a pair of SDR's (one location and one feature).
+
+    The input, learningConfig, should have the following format. It is a
+    mapping from object to a list of locations to sample from, those and
+    the number of points to sample from each location. Note at these objects
+    should be first added with .addObjects()
+
+    learningConfig = {
+      "cube": [("face", 5), ("edge", 5)]
+      "cylinder": [(feature, 5) for feature in cylinder.getLocations()]
+    }
+
+    Note: instead of those tuples, an explicit location can be provided, e.g.:
+      "cube": [(10, 22, 33), (12, 45, 31)]
+
+    Parameters:
+    ----------------------------
+    @param   learningConfig (dict)
+             Configuration for learning, as described above.
+
+    """
+    objects = {}
+
+    for objectName, locationList in learningConfig.iteritems():
+
+      sensationList = []
+      physicalObject = self.objects[objectName]
+      if plot:
+        fig, ax = physicalObject.plot()
+
+      for element in locationList:
+
+        #  location name and number of points
+        if len(element) == 2:
+          featureName, numLocations = element
+          for _ in xrange(numLocations):
+            location = physicalObject.sampleLocationFromFeature(featureName)
+            sensationList.append(
+              self._getSDRPairs(
+                [(location,
+                  physicalObject.getFeatureID(location))] * self.numColumns
+              )
+            )
+            if plot:
+              x, y, z = tuple(location)
+              ax.scatter(x, y, z, marker="v", s=100, c="r")
+
+        # explicit location
+        elif len(element) == 3:
+          location = list(element)
+          sensationList.append(
+            self._getSDRPairs(
+              [(location,
+                physicalObject.getFeatureID(location))] * self.numColumns
+            )
+          )
+          if plot:
+            x, y, z = tuple(location)
+            ax.scatter(x, y, z, marker="v", s=100, c="r")
+
+        else:
+          raise ValueError("Unsupported type for location spec")
+
+      objects[objectName] = sensationList
+      if plot:
+        plt.title("Learning points for object {}".format(objectName))
+        plt.savefig("learn_{}.png".format(objectName))
+        plt.close()
+
+    self._checkObjectsToLearn(objects)
+    return objects
+
+
+  def provideObjectToInfer(self, inferenceConfig, plot=False):
+    """
+    Returns the sensations in a canonical format to be sent to an experiment.
+
+    The input inferenceConfig should be a dict with the following form:
+    {
+      "numSteps": 2  # number of sensations
+      "noiseLevel": 0.05  # noise to add to sensations (optional)
+      "objectName": 0  # optional
+      "pairs": {
+        0: ["random" 2), ("face", 2)]  # locations for cortical column 0
+        1: [(12, 32, 34), (23, 23, 32)]  # locations for cortical column 1
+      }
+    }
+
+    Again, the locations can be explicitly provided.
+
+    The returned format is a a lists of sensations, each sensation being a
+    mapping from cortical column index to a pair of SDR's (one location and
+    one feature).
+
+    Parameters:
+    ----------------------------
+    @param   inferenceConfig (dict)
+             Inference spec for experiment (cf above for format)
+
+    """
+    if "numSteps" in inferenceConfig:
+      numSteps = inferenceConfig["numSteps"]
+    else:
+      numSteps = len(inferenceConfig["pairs"][0])
+
+    if "noiseLevel" in inferenceConfig:
+      noise = inferenceConfig["noiseLevel"]
+    else:
+      noise = None
+
+    # some checks
+    if numSteps == 0:
+      raise ValueError("No inference steps were provided")
+    for col in xrange(self.numColumns):
+      if len(inferenceConfig["pairs"][col]) != numSteps:
+        raise ValueError("Incompatible numSteps and actual inference steps")
+
+    if "objectName" in inferenceConfig:
+      physicalObject = self.objects[inferenceConfig["objectName"]]
+    else:
+      physicalObject = None
+    if plot:
+      # don't use if object is not known
+      fig, ax = physicalObject.plot()
+      colors = plt.cm.rainbow(np.linspace(0, 1, numSteps))
+
+    sensationSteps = []
+    for step in xrange(numSteps):
+      pairs = [
+        inferenceConfig["pairs"][col][step] for col in xrange(self.numColumns)
+      ]
+      for i in xrange(len(pairs)):
+        if isinstance(pairs[i], str):
+          location = physicalObject.sampleLocationFromFeature(pairs[i])
+          pairs[i] = (
+            location,
+            physicalObject.getFeatureID(location)
+          )
+        else:
+          location = pairs[i]
+          pairs[i] = (
+            location,
+            physicalObject.getFeatureID(location)
+          )
+        if plot:
+          x, y, z = tuple(location)
+          ax.scatter(x, y, z, marker="v", s=100, c=colors[step])
+
+      sensationSteps.append(self._getSDRPairs(pairs, noise=noise))
+
+    if plot:
+      plt.title("Inference points for object {}".format(
+        inferenceConfig["objectName"])
+      )
+      plt.savefig("infer_{}.png".format( inferenceConfig["objectName"]))
+      plt.close()
+
+    self._checkObjectToInfer(sensationSteps)
+    return sensationSteps
+
+
+  def addObject(self, object, name=None):
+    """
+    Adds an object to the Machine.
+
+    Objects should be PhysicalObjects.
+    """
+    if name is None:
+      name = len(self.objects)
+
+    self.objects[name] = object
+
+
+  def _getSDRPairs(self, pairs, noise=None):
+    """
+    This method takes a list of (location, feature) pairs (one pair per
+    cortical column), and returns a sensation dict in the correct format,
+    adding noise if necessary.
+
+    In each pair, the location is an actual integer location to be encoded,
+    and the feature is just an index.
+    """
+    sensations = {}
+    for col in xrange(self.numColumns):
+      location, featureID = pairs[col]
+      location = [int(coord) for coord in location]
+
+      location = self.locationEncoder.encode(
+        (np.array(location, dtype="int32"), self._getRadius(location))
+      )
+      location = set(location.nonzero()[0])
+
+      # generate empty feature if requested
+      if featureID == -1:
+        feature = set()
+      # generate union of features if requested
+      elif isinstance(featureID, tuple):
+        feature = set()
+        for idx in list(featureID):
+          feature = feature | self.features[col][idx]
+      else:
+        feature = self.features[col][featureID]
+
+      if noise is not None:
+        location = self._addNoise(location, noise)
+        feature = self._addNoise(feature, noise)
+
+      sensations[col] = (location, feature)
+
+    return sensations
+
+
+  def _getRadius(self, location):
+    """
+    Returns the radius associated with the given location.
+    """
+    # TODO: find better heuristic
+    return int(math.sqrt(sum([coord ** 2 for coord in location])))
+
+
+  def _addNoise(self, pattern, noiseLevel):
+    """
+    Adds noise the given list of patterns and returns a list of noisy copies.
+    """
+    if pattern is None:
+      return None
+
+    newBits = []
+    for bit in pattern:
+      if random.random() < noiseLevel:
+        newBits.append(random.randint(0, max(pattern)))
+      else:
+        newBits.append(bit)
+
+    return set(newBits)
+
+
+  def _generatePattern(self, numBits, totalSize):
+    """
+    Generates a random SDR with specified number of bits and total size.
+    """
+    cellsIndices = range(totalSize)
+    random.shuffle(cellsIndices)
+    return set(cellsIndices[:numBits])
+
+
+  def _generateFeatures(self):
+    """
+    Generates a pool of features to be used for the experiments.
+
+    For each index, numColumns SDR's are created, as locations for the same
+    feature should be different for each column.
+    """
+    size = self.sensorInputSize
+    bits = self.numInputBits
+
+    self.features = []
+    for _ in xrange(self.numColumns):
+      self.features.append(
+        [self._generatePattern(bits, size) for _ in xrange(self.numFeatures)]
+    )

--- a/htmresearch/frameworks/layers/object_machine_base.py
+++ b/htmresearch/frameworks/layers/object_machine_base.py
@@ -79,7 +79,7 @@ class ObjectMachineBase(object):
 
 
   @abstractmethod
-  def provideObjectsToLearn(self, objectNames=None):
+  def provideObjectsToLearn(self, *args, **kwargs):
     """
     This method provides the specified objects in an acceptable form for
     experiments, for the learning part.

--- a/htmresearch/frameworks/layers/object_machine_factory.py
+++ b/htmresearch/frameworks/layers/object_machine_factory.py
@@ -26,6 +26,9 @@ Factory for creating object machines.
 from htmresearch.frameworks.layers.simple_object_machine import (
   SimpleObjectMachine
 )
+from htmresearch.frameworks.layers.continuous_location_object_machine import (
+  ContinuousLocationObjectMachine
+)
 
 
 
@@ -35,6 +38,7 @@ class ObjectMachineTypes(object):
   """
 
   simple = SimpleObjectMachine
+  continuous = ContinuousLocationObjectMachine
 
 
   @classmethod

--- a/htmresearch/frameworks/layers/physical_object_base.py
+++ b/htmresearch/frameworks/layers/physical_object_base.py
@@ -1,0 +1,84 @@
+# ----------------------------------------------------------------------
+# Numenta Platform for Intelligent Computing (NuPIC)
+# Copyright (C) 2016, Numenta, Inc.  Unless you have an agreement
+# with Numenta, Inc., for a separate license for this software code, the
+# following terms and conditions apply:
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# See the GNU Affero Public License for more details.
+#
+# You should have received a copy of the GNU Affero Public License
+# along with this program.  If not, see http://www.gnu.org/licenses.
+#
+# http://numenta.org/licenses/
+# ----------------------------------------------------------------------
+
+from abc import ABCMeta, abstractmethod
+
+
+
+class PhysicalObject(object):
+  """
+  Base class to create physical objects, for L4-L2 inference experiments.
+  It is assumed that objects have continuous locations (that will be encoded
+  by a coordinate encoder), and that features are constant over ranges of
+  locations. Features are defined as feature indices (which will be mapped
+  to random SDR's by the object machine.
+
+  All objects should implement the three abstract methods defined below.
+  """
+
+  __metaclass__ = ABCMeta
+
+  # typical feature indices
+  EMPTY_FEATURE = -1
+  FLAT = 0
+  EDGE = 1
+  SPHERICAL_SURFACE = 2
+  CYLINDER_SURFACE = 3
+  CYLINDER_EDGE = 4
+  POINTY = 5
+
+  # default resolution to use for matching locations (to avoid having a zero
+  # null probability of sampling an edge)
+  DEFAULT_EPSILON = 2
+
+  @abstractmethod
+  def getFeatureID(self, location):
+    """
+    Returns the feature index associated with the provided location.
+
+    If the location is not valid (i.e. not on the object's surface), -1 is
+    returned, which will yield an empty sensory input.
+    """
+
+  @abstractmethod
+  def contains(self, location):
+    """
+    Checks that the object contains the provided location, i.e. that it is on
+    the object's surface (at epsilon's precision).
+    """
+
+
+  @abstractmethod
+  def sampleLocation(self):
+    """
+    Sample a location from the object. The locations should be sampled
+    uniformly whenever is possible.
+    """
+
+
+  def almostEqual(self, number, other):
+    """
+    Checks that the two provided number are equal with a precision of epsilon.
+
+    Epsilon should be specified at construction, otherwise a default value
+    will be used.
+    """
+    return abs(number - other) <= self.epsilon

--- a/htmresearch/frameworks/layers/physical_object_base.py
+++ b/htmresearch/frameworks/layers/physical_object_base.py
@@ -21,6 +21,12 @@
 
 from abc import ABCMeta, abstractmethod
 
+try:
+  from mpl_toolkits.mplot3d import Axes3D
+except ImportError:
+  print "Update matplotlib or don't use plotting functions."
+import matplotlib.pyplot as plt
+
 
 
 class PhysicalObject(object):
@@ -88,3 +94,34 @@ class PhysicalObject(object):
     will be used.
     """
     return abs(number - other) <= self.epsilon
+
+
+  def getFeatures(self):
+    """
+    Returns the list of object feature spans, from which the user can sample.
+    """
+    return self.features
+
+
+  def plot(self, numPoints=100):
+    """
+    Plots the object in a 3D scatter.
+
+    This method should be overriden when possible. This default behavior simply
+    samples numPoints points from the object and plots them in a 3d scatter.
+    """
+    fig = plt.figure()
+    ax = fig.add_subplot(111, projection='3d')
+
+    for feature in self.features:
+
+      for _ in xrange(numPoints):
+        x, y, z = tuple(self.sampleLocationFromFeature(feature))
+        ax.scatter(x, y, z, marker=".")
+
+      ax.set_xlabel('X')
+      ax.set_ylabel('Y')
+      ax.set_zlabel('Z')
+
+    plt.title("{}".format(self))
+    return fig, ax

--- a/htmresearch/frameworks/layers/physical_object_base.py
+++ b/htmresearch/frameworks/layers/physical_object_base.py
@@ -47,7 +47,7 @@ class PhysicalObject(object):
 
   # default resolution to use for matching locations (to avoid having a zero
   # null probability of sampling an edge)
-  DEFAULT_EPSILON = 2
+  DEFAULT_EPSILON = 1
 
   @abstractmethod
   def getFeatureID(self, location):
@@ -71,6 +71,12 @@ class PhysicalObject(object):
     """
     Sample a location from the object. The locations should be sampled
     uniformly whenever is possible.
+    """
+
+  @abstractmethod
+  def sampleLocationFromFeature(self, feature):
+    """
+    Samples a location from the provided specific feature.
     """
 
 

--- a/htmresearch/frameworks/layers/physical_object_base.py
+++ b/htmresearch/frameworks/layers/physical_object_base.py
@@ -96,7 +96,7 @@ class PhysicalObject(object):
     return abs(number - other) <= self.epsilon
 
 
-  def getFeatures(self):
+  def getLocations(self):
     """
     Returns the list of object feature spans, from which the user can sample.
     """

--- a/htmresearch/frameworks/layers/physical_objects.py
+++ b/htmresearch/frameworks/layers/physical_objects.py
@@ -248,6 +248,10 @@ class Cube(Box):
   def __init__(self, width, dimension=3, epsilon=None):
     """
     We simply pass the width as every dimension.
+
+    Example:
+      cube = Cube(width=100, dimension=3, epsilon=2)
+
     """
     dimensions = [width] * dimension
     super(Cube, self).__init__(dimensions, dimension, epsilon)

--- a/htmresearch/frameworks/layers/physical_objects.py
+++ b/htmresearch/frameworks/layers/physical_objects.py
@@ -201,7 +201,7 @@ class Cylinder(PhysicalObject):
     """
     Simple method to sample uniformly from a cylinder.
     """
-    areaRatio = self.radius ** 2 / (self.radius ** 2 + self.height)
+    areaRatio = self.radius / (self.radius + self.height)
     if random.random() < areaRatio:
       return self._sampleLocationOnDisc()
     else:

--- a/htmresearch/frameworks/layers/physical_objects.py
+++ b/htmresearch/frameworks/layers/physical_objects.py
@@ -107,7 +107,7 @@ class Cylinder(PhysicalObject):
 
     """
     self.radius = radius
-    self.height = 2
+    self.height = height
     self.dimension = 3  # no choice for cylinder dimension
 
     if epsilon is None:
@@ -144,9 +144,9 @@ class Cylinder(PhysicalObject):
     Checks that the provided point is on the cylinder.
     """
     if self.almostEqual(location[0] ** 2 + location[1] ** 2, self.radius ** 2):
-      return True
+      return abs(location[2]) < self.height / 2.
     if self.almostEqual(location[2], self.height / 2.):
-      return True
+      return location[0] ** 2 + location[1] ** 2 < self.radius ** 2
     return False
 
 
@@ -178,7 +178,7 @@ class Cylinder(PhysicalObject):
     """
     z = random.uniform(-1, 1) * self.height / 2.
     sampledAngle = 2 * random.random() * pi
-    x, y = cos(sampledAngle), sin(sampledAngle)
+    x, y = self.radius * cos(sampledAngle), self.radius * sin(sampledAngle)
     return [x, y, z]
 
 
@@ -282,6 +282,7 @@ class Cube(Box):
       cube = Cube(width=100, dimension=3, epsilon=2)
 
     """
+    self.width = width
     dimensions = [width] * dimension
     super(Cube, self).__init__(dimensions, dimension, epsilon)
 
@@ -291,4 +292,4 @@ class Cube(Box):
     Custom representation.
     """
     template = self.__class__.__name__ + "(width={})"
-    return template.format(self.dimension)
+    return template.format(self.width)

--- a/htmresearch/frameworks/layers/physical_objects.py
+++ b/htmresearch/frameworks/layers/physical_objects.py
@@ -19,6 +19,13 @@
 # http://numenta.org/licenses/
 # ----------------------------------------------------------------------
 
+"""
+Actual implementation of physical objects.
+
+Note that because locations are integers, rather large object sizes should be
+used.
+"""
+
 import random
 from math import pi, cos, sin, sqrt
 
@@ -38,13 +45,29 @@ class Sphere(PhysicalObject):
   Example:
     sphere = Sphere(radius=20, dimension=3, epsilon=1)
 
+  It's only feature is its surface.
+
   """
+
+  _FEATURES = ["surface"]
 
   def __init__(self, radius, dimension=3, epsilon=None):
     """
     The only key parameter to provide is the sphere's radius.
 
     Supports arbitrary dimensions.
+
+    Parameters:
+    ----------------------------
+    @param    radius (int)
+              Sphere radius.
+
+    @param    dimension (int)
+              Space dimension. Typically 3.
+
+    @param    epsilon (float)
+              Object resolution. Defaults to self.DEFAULT_EPSILON
+
     """
     self.radius = radius
     self.dimension = dimension
@@ -53,8 +76,6 @@ class Sphere(PhysicalObject):
       self.epsilon = self.DEFAULT_EPSILON
     else:
       self.epsilon = epsilon
-
-    self.features = ["surface"]
 
 
   def getFeatureID(self, location):
@@ -80,9 +101,9 @@ class Sphere(PhysicalObject):
 
   def sampleLocation(self):
     """
-    Gaussian method to sample uniformly from a sphere.
+    Samples from the only available feature.
     """
-    return self.sampleLocationFromFeature(self.features[0])
+    return self.sampleLocationFromFeature(self._FEATURES[0])
 
 
   def sampleLocationFromFeature(self, feature):
@@ -139,7 +160,16 @@ class Sphere(PhysicalObject):
 class Cylinder(PhysicalObject):
   """
   A classic cylinder.
+
+  Example:
+    cyl = Cylinder(height=20, radius=5, epsilon=1)
+
+  It has five different features to sample locations from: topDisc, bottomDisc,
+  topEdge, bottomEdge, and side.
   """
+
+  _FEATURES = ["topDisc", "bottomDisc", "topEdge", "bottomEdge", "side"]
+
 
   def __init__(self, height, radius, epsilon=None):
     """
@@ -147,8 +177,19 @@ class Cylinder(PhysicalObject):
 
     Does not support arbitrary dimensions.
 
-    Example:
-      cyl = Cylinder(height=20, radius=5, epsilon=1)
+    Parameters:
+    ----------------------------
+    @param    height (int)
+              Cylinder height.
+
+    @param    radius (int)
+              Cylinder radius.
+
+    @param    dimension (int)
+              Space dimension. Typically 3.
+
+    @param    epsilon (float)
+              Object resolution. Defaults to self.DEFAULT_EPSILON
 
     """
     self.radius = radius
@@ -159,8 +200,6 @@ class Cylinder(PhysicalObject):
       self.epsilon = self.DEFAULT_EPSILON
     else:
       self.epsilon = epsilon
-
-    self.features = ["topDisc", "bottomDisc", "topEdge", "bottomEdge", "side"]
 
 
   def getFeatureID(self, location):
@@ -309,15 +348,31 @@ class Cylinder(PhysicalObject):
 class Box(PhysicalObject):
   """
   A box is a classic cuboid.
+
+  Example:
+    box = Box(dimensions=[10, 10, 5], dimension=3, epsilon=1)
+
+  It has three features to sample locations from: face, edge, and vertex.
   """
+
+  _FEATURES = ["face", "edge", "vertex"]
+
 
   def __init__(self, dimensions, dimension=3, epsilon=None):
     """
     The only key parameter is the list (or tuple) of dimensions, which can be
     of any size as long as its length is equal to the "dimension" parameter.
 
-    Example:
-      box = Box(dimensions=[10, 10, 5], dimension=3, epsilon=1)
+    Parameters:
+    ----------------------------
+    @param    dimensions (list(int))
+              List of the box's dimensions.
+
+    @param    dimension (int)
+              Space dimension. Typically 3.
+
+    @param    epsilon (float)
+              Object resolution. Defaults to self.DEFAULT_EPSILON
 
     """
     self.dimensions = dimensions
@@ -327,8 +382,6 @@ class Box(PhysicalObject):
       self.epsilon = self.DEFAULT_EPSILON
     else:
       self.epsilon = epsilon
-
-    self.features = ["face", "edge", "vertex"]
 
 
   def getFeatureID(self, location):
@@ -478,14 +531,27 @@ class Box(PhysicalObject):
 class Cube(Box):
   """
   A cube is a particular box where all dimensions have equal length.
+
+
+  Example:
+    cube = Cube(width=100, dimension=3, epsilon=2)
   """
+
 
   def __init__(self, width, dimension=3, epsilon=None):
     """
     We simply pass the width as every dimension.
 
-    Example:
-      cube = Cube(width=100, dimension=3, epsilon=2)
+    Parameters:
+    ----------------------------
+    @param    width (int)
+              Cube width.
+
+    @param    dimension (int)
+              Space dimension. Typically 3.
+
+    @param    epsilon (float)
+              Object resolution. Defaults to self.DEFAULT_EPSILON
 
     """
     self.width = width

--- a/htmresearch/frameworks/layers/physical_objects.py
+++ b/htmresearch/frameworks/layers/physical_objects.py
@@ -1,0 +1,253 @@
+# ----------------------------------------------------------------------
+# Numenta Platform for Intelligent Computing (NuPIC)
+# Copyright (C) 2016, Numenta, Inc.  Unless you have an agreement
+# with Numenta, Inc., for a separate license for this software code, the
+# following terms and conditions apply:
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# See the GNU Affero Public License for more details.
+#
+# You should have received a copy of the GNU Affero Public License
+# along with this program.  If not, see http://www.gnu.org/licenses.
+#
+# http://numenta.org/licenses/
+# ----------------------------------------------------------------------
+
+import random
+from math import pi, cos, sin, sqrt
+
+from htmresearch.frameworks.layers.physical_object_base import PhysicalObject
+
+
+
+class Sphere(PhysicalObject):
+  """
+  A classic sphere.
+
+  It's particularity is that it has only one feature.
+
+  Example:
+    sphere = Sphere(radius=20, dimension=3, epsilon=1)
+
+  """
+
+  def __init__(self, radius, dimension=3, epsilon=None):
+    """
+    The only key parameter to provide is the sphere's radius.
+
+    Supports arbitrary dimensions.
+    """
+    self.radius = radius
+    self.dimension = dimension
+
+    if epsilon is None:
+      self.epsilon = self.DEFAULT_EPSILON
+    else:
+      self.epsilon = epsilon
+
+
+  def getFeatureID(self, location):
+    """
+    Returns the feature index associated with the provided location.
+
+    In the case of a sphere, it is always the same if the location is valid.
+    """
+    if not self.contains(location):
+      return self.EMPTY_FEATURE
+
+    return self.SPHERICAL_SURFACE
+
+
+  def contains(self, location):
+    """
+    Checks that the provided point is on the sphere.
+    """
+    return self.almostEqual(sum([coord ** 2 for coord in location]),
+                            self.radius)
+
+  def sampleLocation(self):
+    """
+    Gaussian method to sample uniformly from a sphere.
+    """
+    coordinates = [random.gauss(0, 1.) for _ in xrange(self.dimension)]
+    norm = sum([coord ** 2 for coord in coordinates])
+    return tuple([int(coord / norm) for coord in coordinates])
+
+
+
+class Cylinder(PhysicalObject):
+  """
+  A classic cylinder.
+  """
+
+  def __init__(self, height, radius, epsilon=None):
+    """
+    The two key parameters are height and radius.
+
+    Does not support arbitrary dimensions.
+
+    Example:
+      cyl = Cylinder(height=20, radius=5, epsilon=1)
+
+    """
+    self.radius = radius
+    self.height = 2
+    self.dimension = 3  # no choice for cylinder dimension
+
+    if epsilon is None:
+      self.epsilon = self.DEFAULT_EPSILON
+    else:
+      self.epsilon = epsilon
+
+
+  def getFeatureID(self, location):
+    """
+    Returns the feature index associated with the provided location.
+
+    Three possibilities:
+      - top discs
+      - edges
+      - lateral surface
+
+    """
+    if not self.contains(location):
+      return self.EMPTY_FEATURE
+
+    if self.almostEqual(abs(location[2]), self.height / 2.):
+      if self.almostEqual(location[0] ** 2 + location[1] ** 2, self.radius):
+        return self.CYLINDER_EDGE
+      else:
+        return self.FLAT
+    else:
+      return self.CYLINDER_SURFACE
+
+
+  def contains(self, location):
+    """
+    Checks that the provided point is on the cylinder.
+    """
+    if not self.almostEqual(location[0] ** 2 + location[1] ** 2, self.radius):
+      return False
+    if not self.almostEqual(location[2], self.height / 2.):
+      return False
+    return
+
+
+  def sampleLocation(self):
+    """
+    Simple method to sample uniformly from a cylinder.
+    """
+    areaRatio = self.radius ** 2 / (self.radius ** 2 + self.height)
+    if random.random() < areaRatio:
+      return self._sampleLocationOnDiscs()
+    else:
+      return self._sampleLocationOnSide()
+
+
+  def _sampleLocationOnDiscs(self):
+    """
+    Helper method to sample from the top and bottom discs of a cylinder.
+    """
+    z = random.choice([-1, 1]) * self.height / 2.
+    sampledAngle = 2 * random.random() * pi
+    sampledRadius = self.radius * sqrt(random.random())
+    x, y = sampledRadius * cos(sampledAngle), sampledRadius * sin(sampledAngle)
+    return (x, y, z)
+
+
+  def _sampleLocationOnSide(self):
+    """
+    Helper method to sample from the lateral surface of a cylinder.
+    """
+    z = random.uniform(-1, 1) * self.height / 2.
+    x, y = cos(2 * random.random() * pi), sin(2 * random.random() * pi)
+    return (x, y, z)
+
+
+
+class Box(PhysicalObject):
+  """
+  A box is a classic cuboid.
+  """
+
+  def __init__(self, dimensions, dimension=3, epsilon=None):
+    """
+    The only key parameter is the list (or tuple) of dimensions, which can be
+    of any size as long as its length is equal to the "dimension" parameter.
+
+    Example:
+      box = Box(dimensions=[10, 10, 5], dimension=3, epsilon=1)
+
+    """
+    self.dimensions = dimensions
+    self.dimension = dimension
+
+    if epsilon is None:
+      self.epsilon = self.DEFAULT_EPSILON
+    else:
+      self.epsilon = epsilon
+
+
+  def getFeatureID(self, location):
+    """
+    There are three possible features for a box:
+      - flat for a face
+      - pointy for a vertex
+      - edge
+
+    """
+    if not self.contains(location):
+      return self.EMPTY_FEATURE  # random feature
+
+    numFaces = sum(
+      [self.almostEqual(coord, self.dimensions[i] / 2.) \
+       for i, coord in enumerate(location)]
+    )
+
+    if numFaces == 1:
+      return self.FLAT
+    if numFaces == 2:
+      return self.EDGE
+    if numFaces == 3:
+      return self.POINTY
+
+
+  def contains(self, location):
+    """
+    A location is on the box if one of the dimension is "satured").
+    """
+    for i, coord in enumerate(location):
+      if self.almostEqual(abs(coord), self.dimensions[i] / 2.):
+        return True
+    return False
+
+
+  def sampleLocation(self):
+    """
+    We start by sampling a dimension to "max out", then sample the sign and
+    the other dimensions' values.
+    """
+    maxedOutDim = random.choice(range(self.dimension))
+    coordinates = [random.uniform(-1, 1) * dim for dim in self.dimensions]
+    coordinates[maxedOutDim] = random.choice(-1, 1)
+    return coordinates
+
+
+
+class Cube(Box):
+  """
+  A cube is a particular box where all dimensions have equal length.
+  """
+
+  def __init__(self, width, dimension=3, epsilon=None):
+    """
+    We simply pass the width as every dimension.
+    """
+    dimensions = [width] * dimension
+    super(Cube, self).__init__(dimensions, dimension, epsilon)

--- a/htmresearch/frameworks/layers/physical_objects.py
+++ b/htmresearch/frameworks/layers/physical_objects.py
@@ -22,6 +22,9 @@
 import random
 from math import pi, cos, sin, sqrt
 
+import numpy as np
+import matplotlib.pyplot as plt
+
 from htmresearch.frameworks.layers.physical_object_base import PhysicalObject
 
 
@@ -92,8 +95,36 @@ class Sphere(PhysicalObject):
       coordinates = [random.gauss(0, 1.) for _ in xrange(self.dimension)]
       norm = sqrt(sum([coord ** 2 for coord in coordinates]))
       return [self.radius * coord / norm for coord in coordinates]
+    elif feature == "random":
+      return self.sampleLocation()
     else:
       raise NameError("No such feature in {}: {}".format(self, feature))
+
+
+  def plot(self, numPoints=100):
+    """
+    Specific plotting method for cylinders.
+    """
+    fig = plt.figure()
+    ax = fig.add_subplot(111, projection='3d')
+
+    # generate sphere
+    phi, theta = np.meshgrid(
+      np.linspace(0, pi, numPoints),
+      np.linspace(0, 2 * pi, numPoints)
+    )
+    x = self.radius * np.sin(phi) * np.cos(theta)
+    y = self.radius * np.sin(phi) * np.sin(theta)
+    z = self.radius * np.cos(phi)
+
+    # plot
+    ax.plot_surface(x, y, z, alpha=0.2, rstride=20, cstride=10)
+    ax.set_xlabel("X")
+    ax.set_ylabel("Y")
+    ax.set_zlabel("Z")
+
+    plt.title("{}".format(self))
+    return fig, ax
 
 
   def __repr__(self):
@@ -191,6 +222,8 @@ class Cylinder(PhysicalObject):
       return self._sampleLocationOnEdge(top=False)
     elif feature == "side":
       return self._sampleLocationOnSide()
+    elif feature == "random":
+      return self.sampleLocation()
     else:
       raise NameError("No such feature in {}: {}".format(self, feature))
 
@@ -238,6 +271,30 @@ class Cylinder(PhysicalObject):
     sampledAngle = 2 * random.random() * pi
     x, y = self.radius * cos(sampledAngle), self.radius * sin(sampledAngle)
     return [x, y, z]
+
+
+  def plot(self, numPoints=100):
+    """
+    Specific plotting method for cylinders.
+    """
+    fig = plt.figure()
+    ax = fig.add_subplot(111, projection='3d')
+
+    # generate cylinder
+    x = np.linspace(- self.radius, self.radius, numPoints)
+    z = np.linspace(- self.height / 2., self.height / 2., numPoints)
+    Xc, Zc = np.meshgrid(x, z)
+    Yc = np.sqrt(self.radius ** 2 - Xc ** 2)
+
+    # plot
+    ax.plot_surface(Xc, Yc, Zc, alpha=0.2, rstride=20, cstride=10)
+    ax.plot_surface(Xc, -Yc, Zc, alpha=0.2, rstride=20, cstride=10)
+    ax.set_xlabel("X")
+    ax.set_ylabel("Y")
+    ax.set_zlabel("Z")
+
+    plt.title("{}".format(self))
+    return fig, ax
 
 
   def __repr__(self):
@@ -327,6 +384,8 @@ class Box(PhysicalObject):
       return self._sampleFromEdges()
     elif feature == "vertex":
       return self._sampleFromVertices()
+    elif feature == "random":
+      return self.sampleLocation()
     else:
       raise NameError("No such feature in {}: {}".format(self, feature))
 
@@ -367,6 +426,44 @@ class Box(PhysicalObject):
       self.dimensions[2] / 2. * random.choice([-1, 1]),
     ]
     return coordinates
+
+  def plot(self, numPoints=100):
+    """
+    Specific plotting method for boxes.
+
+    Only supports 3-dimensional objects.
+    """
+    fig = plt.figure()
+    ax = fig.add_subplot(111, projection='3d')
+
+    # generate cylinder
+    x = np.linspace(- self.dimensions[0]/2., self.dimensions[0]/2., numPoints)
+    y = np.linspace(- self.dimensions[1]/2., self.dimensions[1]/2., numPoints)
+    z = np.linspace(- self.dimensions[2]/2., self.dimensions[2]/2., numPoints)
+
+    # plot
+    Xc, Yc = np.meshgrid(x, y)
+    ax.plot_surface(Xc, Yc, -self.dimensions[2]/2,
+                    alpha=0.2, rstride=20, cstride=10)
+    ax.plot_surface(Xc, Yc, self.dimensions[2]/2,
+                    alpha=0.2, rstride=20, cstride=10)
+    Yc, Zc = np.meshgrid(y, z)
+    ax.plot_surface(-self.dimensions[0]/2, Yc, Zc,
+                    alpha=0.2, rstride=20, cstride=10)
+    ax.plot_surface(self.dimensions[0]/2, Yc, Zc,
+                    alpha=0.2, rstride=20, cstride=10)
+    Xc, Zc = np.meshgrid(x, z)
+    ax.plot_surface(Xc, -self.dimensions[1]/2, Zc,
+                    alpha=0.2, rstride=20, cstride=10)
+    ax.plot_surface(Xc, self.dimensions[1]/2, Zc,
+                    alpha=0.2, rstride=20, cstride=10)
+
+    ax.set_xlabel("X")
+    ax.set_ylabel("Y")
+    ax.set_zlabel("Z")
+
+    plt.title("{}".format(self))
+    return fig, ax
 
 
   def __repr__(self):

--- a/htmresearch/frameworks/layers/physical_objects.py
+++ b/htmresearch/frameworks/layers/physical_objects.py
@@ -68,16 +68,26 @@ class Sphere(PhysicalObject):
     """
     Checks that the provided point is on the sphere.
     """
-    return self.almostEqual(sum([coord ** 2 for coord in location]),
-                            self.radius)
+    return self.almostEqual(
+      sum([coord ** 2 for coord in location]), self.radius ** 2
+    )
+
 
   def sampleLocation(self):
     """
     Gaussian method to sample uniformly from a sphere.
     """
     coordinates = [random.gauss(0, 1.) for _ in xrange(self.dimension)]
-    norm = sum([coord ** 2 for coord in coordinates])
-    return tuple([int(coord / norm) for coord in coordinates])
+    norm = sqrt(sum([coord ** 2 for coord in coordinates]))
+    return [self.radius * coord / norm for coord in coordinates]
+
+
+  def __repr__(self):
+    """
+    Custom representation.
+    """
+    template = self.__class__.__name__ + "(R={})"
+    return template.format(self.radius)
 
 
 
@@ -120,7 +130,8 @@ class Cylinder(PhysicalObject):
       return self.EMPTY_FEATURE
 
     if self.almostEqual(abs(location[2]), self.height / 2.):
-      if self.almostEqual(location[0] ** 2 + location[1] ** 2, self.radius):
+      if self.almostEqual(location[0] ** 2 + location[1] ** 2,
+                          self.radius ** 2):
         return self.CYLINDER_EDGE
       else:
         return self.FLAT
@@ -132,11 +143,11 @@ class Cylinder(PhysicalObject):
     """
     Checks that the provided point is on the cylinder.
     """
-    if not self.almostEqual(location[0] ** 2 + location[1] ** 2, self.radius):
-      return False
-    if not self.almostEqual(location[2], self.height / 2.):
-      return False
-    return
+    if self.almostEqual(location[0] ** 2 + location[1] ** 2, self.radius ** 2):
+      return True
+    if self.almostEqual(location[2], self.height / 2.):
+      return True
+    return False
 
 
   def sampleLocation(self):
@@ -158,7 +169,7 @@ class Cylinder(PhysicalObject):
     sampledAngle = 2 * random.random() * pi
     sampledRadius = self.radius * sqrt(random.random())
     x, y = sampledRadius * cos(sampledAngle), sampledRadius * sin(sampledAngle)
-    return (x, y, z)
+    return [x, y, z]
 
 
   def _sampleLocationOnSide(self):
@@ -166,8 +177,17 @@ class Cylinder(PhysicalObject):
     Helper method to sample from the lateral surface of a cylinder.
     """
     z = random.uniform(-1, 1) * self.height / 2.
-    x, y = cos(2 * random.random() * pi), sin(2 * random.random() * pi)
-    return (x, y, z)
+    sampledAngle = 2 * random.random() * pi
+    x, y = cos(sampledAngle), sin(sampledAngle)
+    return [x, y, z]
+
+
+  def __repr__(self):
+    """
+    Custom representation.
+    """
+    template = self.__class__.__name__ + "(H={}, R={})"
+    return template.format(self.height, self.radius)
 
 
 
@@ -206,7 +226,7 @@ class Box(PhysicalObject):
       return self.EMPTY_FEATURE  # random feature
 
     numFaces = sum(
-      [self.almostEqual(coord, self.dimensions[i] / 2.) \
+      [self.almostEqual(abs(coord), self.dimensions[i] / 2.) \
        for i, coord in enumerate(location)]
     )
 
@@ -234,9 +254,18 @@ class Box(PhysicalObject):
     the other dimensions' values.
     """
     maxedOutDim = random.choice(range(self.dimension))
-    coordinates = [random.uniform(-1, 1) * dim for dim in self.dimensions]
-    coordinates[maxedOutDim] = random.choice(-1, 1)
+    coordinates = [random.uniform(-1, 1) * dim / 2. for dim in self.dimensions]
+    coordinates[maxedOutDim] = self.dimensions[maxedOutDim] / 2. * \
+                               random.choice([-1, 1])
     return coordinates
+
+
+  def __repr__(self):
+    """
+    Custom representation.
+    """
+    template = self.__class__.__name__ + "(dim=({}))"
+    return template.format(", ".join([str(dim) for dim in self.dimensions]))
 
 
 
@@ -255,3 +284,11 @@ class Cube(Box):
     """
     dimensions = [width] * dimension
     super(Cube, self).__init__(dimensions, dimension, epsilon)
+
+
+  def __repr__(self):
+    """
+    Custom representation.
+    """
+    template = self.__class__.__name__ + "(width={})"
+    return template.format(self.dimension)

--- a/projects/l2_pooling/continuous_location.py
+++ b/projects/l2_pooling/continuous_location.py
@@ -71,8 +71,8 @@ def runBasic(noiseLevel=None, profile=False):
     "sphere": [("surface", 10)],
     # the two learning config below will be exactly the same
     "box": [("face", 5), ("edge", 5), ("vertex", 5)],
-    "cube": [(feature, 5) for feature in objects["cube"].getLocations()],
-    "cylinder": [(feature, 5) for feature in objects["cylinder"].getLocations()]
+    "cube": [(feature, 5) for feature in objects["cube"].getFeatures()],
+    "cylinder": [(feature, 5) for feature in objects["cylinder"].getFeatures()]
   }
 
   exp.learnObjects(

--- a/projects/l2_pooling/continuous_location.py
+++ b/projects/l2_pooling/continuous_location.py
@@ -1,0 +1,112 @@
+# ----------------------------------------------------------------------
+# Numenta Platform for Intelligent Computing (NuPIC)
+# Copyright (C) 2016, Numenta, Inc.  Unless you have an agreement
+# with Numenta, Inc., for a separate license for this software code, the
+# following terms and conditions apply:
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# See the GNU Affero Public License for more details.
+#
+# You should have received a copy of the GNU Affero Public License
+# along with this program.  If not, see http://www.gnu.org/licenses.
+#
+# http://numenta.org/licenses/
+# ----------------------------------------------------------------------
+
+"""
+This file creates simple experiment to test an L4-L2 network on physical
+objects.
+"""
+
+from htmresearch.frameworks.layers.l2_l4_inference import L4L2Experiment
+from htmresearch.frameworks.layers.object_machine_factory import (
+  createObjectMachine
+)
+from htmresearch.frameworks.layers.physical_objects import *
+
+
+
+def runBasic(noiseLevel=None, profile=False):
+  """
+  Runs a basic experiment on continuous locations, learning a few locations on
+  four basic objects, and inferring one of them.
+
+  This experiment is mostly used for testing the pipeline, as the learned
+  locations are too random and sparse to actually perform inference.
+
+  Parameters:
+  ----------------------------
+  @param    noiseLevel (float)
+            Noise level to add to the locations and features during inference
+
+  @param    profile (bool)
+            If True, the network will be profiled after learning and inference
+
+  """
+  exp = L4L2Experiment(
+    "basic_continuous",
+    numCorticalColumns=2
+  )
+
+  objects = createObjectMachine(
+    machineType="continuous",
+    numInputBits=21,
+    sensorInputSize=1024,
+    externalInputSize=1024,
+    numCorticalColumns=2,
+  )
+
+  objects.addObject(Sphere(radius=20), name="sphere")
+  objects.addObject(Cylinder(height=50, radius=20), name="cylinder")
+  objects.addObject(Box(dimensions=[10, 20, 30,]), name="box")
+  objects.addObject(Cube(width=20), name="cube")
+
+  learnConfig = {
+    "sphere": [("surface", 10)],
+    # the two learning config below will be exactly the same
+    "box": [("face", 5), ("edge", 5), ("vertex", 5)],
+    "cube": [(feature, 5) for feature in objects["cube"].getLocations()],
+    "cylinder": [(feature, 5) for feature in objects["cylinder"].getLocations()]
+  }
+
+  exp.learnObjects(
+    objects.provideObjectsToLearn(learnConfig, plot=True),
+    reset=True
+  )
+  if profile:
+    exp.printProfile()
+
+  inferConfig = {
+    "numSteps": 4,
+    "noiseLevel": noiseLevel,
+    "objectName": "cube",
+    "pairs": {
+      0: ["face", "face", "edge", "edge"],
+      1: ["edge", "face", "face", "edge"]
+    }
+  }
+
+  exp.infer(
+    objects.provideObjectToInfer(inferConfig, plot=True),
+    objectName="cube",
+    reset=True
+  )
+  if profile:
+    exp.printProfile()
+
+  exp.plotInferenceStats(
+    fields=["L2 Representation",
+            "Overlap L2 with object",
+            "L4 Representation"],
+  )
+
+
+
+if __name__ == "__main__":
+  runBasic()

--- a/projects/l2_pooling/single_column.py
+++ b/projects/l2_pooling/single_column.py
@@ -19,7 +19,7 @@
 # ----------------------------------------------------------------------
 
 """
-This file creates simple experiment to test a single column L4-L2 network.
+This file creates simple experiments to test a single column L4-L2 network.
 """
 
 from htmresearch.frameworks.layers.object_machine_factory import (

--- a/tests/layers/physical_objects_test.py
+++ b/tests/layers/physical_objects_test.py
@@ -105,7 +105,7 @@ class PhysicalObjectsTest(unittest.TestCase):
       ax.set_xlabel('X')
       ax.set_ylabel('Y')
       ax.set_zlabel('Z')
-      plt.title("Sampled point from {}".format(objects[i]))
+      plt.title("Sampled points from {}".format(objects[i]))
       plt.savefig("object{}.png".format(str(i)))
 
 
@@ -127,10 +127,10 @@ class PhysicalObjectsTest(unittest.TestCase):
           x, y, z = tuple(objects[i].sampleLocationFromFeature(feature))
           ax.scatter(x, y, z)
 
-        ax.set_xlabel('X Label')
-        ax.set_ylabel('Y Label')
-        ax.set_zlabel('Z Label')
-        plt.title("Sampled point on {} from {}".format(feature, objects[i]))
+        ax.set_xlabel('X')
+        ax.set_ylabel('Y')
+        ax.set_zlabel('Z')
+        plt.title("Sampled points on {} from {}".format(feature, objects[i]))
         plt.savefig("object_{}_{}.png".format(str(i), feature))
 
 

--- a/tests/layers/physical_objects_test.py
+++ b/tests/layers/physical_objects_test.py
@@ -21,6 +21,7 @@
 
 import unittest
 
+from mpl_toolkits.mplot3d import Axes3D
 import matplotlib.pyplot as plt
 
 from htmresearch.frameworks.layers.physical_objects import (

--- a/tests/layers/physical_objects_test.py
+++ b/tests/layers/physical_objects_test.py
@@ -107,6 +107,7 @@ class PhysicalObjectsTest(unittest.TestCase):
       ax.set_zlabel('Z')
       plt.title("Sampled points from {}".format(objects[i]))
       plt.savefig("object{}.png".format(str(i)))
+      plt.close()
 
 
   def testPlotSampleFeatures(self):
@@ -132,6 +133,7 @@ class PhysicalObjectsTest(unittest.TestCase):
         ax.set_zlabel('Z')
         plt.title("Sampled points on {} from {}".format(feature, objects[i]))
         plt.savefig("object_{}_{}.png".format(str(i), feature))
+        plt.close()
 
 
 

--- a/tests/layers/physical_objects_test.py
+++ b/tests/layers/physical_objects_test.py
@@ -1,0 +1,112 @@
+# ----------------------------------------------------------------------
+# Numenta Platform for Intelligent Computing (NuPIC)
+# Copyright (C) 2016, Numenta, Inc.  Unless you have an agreement
+# with Numenta, Inc., for a separate license for this software code, the
+# following terms and conditions apply:
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# See the GNU Affero Public License for more details.
+#
+# You should have received a copy of the GNU Affero Public License
+# along with this program.  If not, see http://www.gnu.org/licenses.
+#
+# http://numenta.org/licenses/
+# ----------------------------------------------------------------------
+
+import unittest
+
+import matplotlib.pyplot as plt
+
+from htmresearch.frameworks.layers.physical_objects import (
+  Sphere, Cylinder, Box, Cube
+)
+
+
+
+class PhysicalObjectsTest(unittest.TestCase):
+  """Unit tests for physical objects."""
+
+  def testInitParams(self):
+    """Simple construction test."""
+    sphere = Sphere(radius=5, dimension=6)
+    cylinder = Cylinder(height=50, radius=100, epsilon=5)
+    box = Box(dimensions=[1, 2, 3, 4], dimension=4)
+    cube = Cube(width=10, dimension=2)
+
+    self.assertEqual(sphere.radius, 5)
+    self.assertEqual(sphere.dimension, 6)
+    self.assertEqual(sphere.epsilon, sphere.DEFAULT_EPSILON)
+
+    self.assertEqual(cylinder.radius, 100)
+    self.assertEqual(cylinder.height, 50)
+    self.assertEqual(cylinder.dimension, 3)
+    self.assertEqual(cylinder.epsilon, 5)
+
+    self.assertEqual(box.dimensions, [1, 2, 3, 4])
+    self.assertEqual(box.dimension, 4)
+    self.assertEqual(box.epsilon, box.DEFAULT_EPSILON)
+
+    self.assertEqual(cube.dimensions, [10, 10])
+    self.assertEqual(cube.width, 10)
+    self.assertEqual(cube.dimension, 2)
+    self.assertEqual(sphere.epsilon, cube.DEFAULT_EPSILON)
+
+
+  def testSampleContains(self):
+    """Samples points from the objects and test contains."""
+    sphere = Sphere(radius=20, dimension=6)
+    cylinder = Cylinder(height=50, radius=100, epsilon=2)
+    box = Box(dimensions=[10, 20, 30, 40], dimension=4)
+    cube = Cube(width=20, dimension=2)
+
+    for i in xrange(50):
+      self.assertTrue(sphere.contains(sphere.sampleLocation()))
+      self.assertTrue(cylinder.contains(cylinder.sampleLocation()))
+      self.assertTrue(box.contains(box.sampleLocation()))
+      self.assertTrue(cube.contains(cube.sampleLocation()))
+
+    # inside
+    self.assertFalse(sphere.contains([1] * sphere.dimension))
+    self.assertFalse(cube.contains([1] * cube.dimension))
+    self.assertFalse(cylinder.contains([1] * cylinder.dimension))
+    self.assertFalse(box.contains([1] * box.dimension))
+
+    # outside
+    self.assertFalse(sphere.contains([100] * sphere.dimension))
+    self.assertFalse(cube.contains([100] * cube.dimension))
+    self.assertFalse(cylinder.contains([100] * cylinder.dimension))
+    self.assertFalse(box.contains([100] * box.dimension))
+
+
+  def testPlotSample(self):
+    """Samples points from objects and plots them in a 3D scatter."""
+    objects = []
+    objects.append(Sphere(radius=20, dimension=3))
+    objects.append(Cylinder(height=50, radius=100, epsilon=2))
+    objects.append(Box(dimensions=[10, 20, 30], dimension=3))
+    objects.append(Cube(width=20, dimension=3))
+    numPoints = 500
+
+    for i in xrange(4):
+      fig = plt.figure()
+      ax = fig.add_subplot(111, projection='3d')
+      for _ in xrange(numPoints):
+        x, y, z = tuple(objects[i].sampleLocation())
+        ax.scatter(x, y, z)
+
+      ax.set_xlabel('X Label')
+      ax.set_ylabel('Y Label')
+      ax.set_zlabel('Z Label')
+      plt.title("Sampled point from {}".format(objects[i]))
+      plt.savefig("object{}.png".format(str(i)))
+
+
+
+if __name__ == "__main__":
+  unittest.main()

--- a/tests/layers/physical_objects_test.py
+++ b/tests/layers/physical_objects_test.py
@@ -33,6 +33,7 @@ from htmresearch.frameworks.layers.physical_objects import (
 class PhysicalObjectsTest(unittest.TestCase):
   """Unit tests for physical objects."""
 
+
   def testInitParams(self):
     """Simple construction test."""
     sphere = Sphere(radius=5, dimension=6)
@@ -85,7 +86,7 @@ class PhysicalObjectsTest(unittest.TestCase):
     self.assertFalse(box.contains([100] * box.dimension))
 
 
-  def testPlotSample(self):
+  def testPlotSampleLocations(self):
     """Samples points from objects and plots them in a 3D scatter."""
     objects = []
     objects.append(Sphere(radius=20, dimension=3))
@@ -101,11 +102,36 @@ class PhysicalObjectsTest(unittest.TestCase):
         x, y, z = tuple(objects[i].sampleLocation())
         ax.scatter(x, y, z)
 
-      ax.set_xlabel('X Label')
-      ax.set_ylabel('Y Label')
-      ax.set_zlabel('Z Label')
+      ax.set_xlabel('X')
+      ax.set_ylabel('Y')
+      ax.set_zlabel('Z')
       plt.title("Sampled point from {}".format(objects[i]))
       plt.savefig("object{}.png".format(str(i)))
+
+
+  def testPlotSampleFeatures(self):
+    """Samples points from objects and plots them in a 3D scatter."""
+    objects = []
+    objects.append(Sphere(radius=20, dimension=3))
+    objects.append(Cylinder(height=50, radius=100, epsilon=2))
+    objects.append(Box(dimensions=[10, 20, 30], dimension=3))
+    objects.append(Cube(width=20, dimension=3))
+    numPoints = 500
+
+    for i in xrange(4):
+
+      for feature in objects[i].features:
+        fig = plt.figure()
+        ax = fig.add_subplot(111, projection='3d')
+        for _ in xrange(numPoints):
+          x, y, z = tuple(objects[i].sampleLocationFromFeature(feature))
+          ax.scatter(x, y, z)
+
+        ax.set_xlabel('X Label')
+        ax.set_ylabel('Y Label')
+        ax.set_zlabel('Z Label')
+        plt.title("Sampled point on {} from {}".format(feature, objects[i]))
+        plt.savefig("object_{}_{}.png".format(str(i), feature))
 
 
 


### PR DESCRIPTION
This pull request adds the possibility to experiment with continuous locations on physical objects for the L2-L4 experiments.

This new object machine still sends sensations in the same canonical format to the experiment, but it has a different definition of objects. Objects are now objects from the class `PhysicalObjects`, which should be subclassed with any new object. Those objects have methods to sample from various types of locations (e.g., "face", "edge", and "vertex" for a cube). Each type of location has the same feature everywhere, which is represented, as in the `SimpleObjectMachine`, by an index (the enum of indices are in the base class `PhysicalObject`.

The object machine as well as the physical objects provide methods to represent the objects and sampled locations for sanity checks.

@subutai 