### PR TITLE
Use predictedActive Cells for clustering analysis

### DIFF
--- a/htmresearch/frameworks/clustering/distances.py
+++ b/htmresearch/frameworks/clustering/distances.py
@@ -57,6 +57,10 @@ def clusterDistDirected(c1, c2):
   minDists = []
   for sdr1 in c1:
     d = []
+    # ignore SDRs with zero active bits
+    if np.sum(sdr1) == 0:
+      continue
+
     for sdr2 in c2:
       d.append(1 - percentOverlap(sdr1, sdr2))
     minDists.append(min(d))

--- a/projects/classification/sensor/artificial_data/analyze_sdr_clusters.py
+++ b/projects/classification/sensor/artificial_data/analyze_sdr_clusters.py
@@ -153,12 +153,6 @@ if __name__ == "__main__":
   # vizCellStates(traces, cellsType, numCells, startFrom=100)
 
   clusters = assignClusters(traces)
-  tmActiveCellsClusters = [convertNonZeroToSDR(clusters['tmActiveCells'][i])
-                           for i in range(3)]
-  
-  c0 = tmActiveCellsClusters[0]
-  c1 = tmActiveCellsClusters[1]
-  c2 = tmActiveCellsClusters[2]
 
 
   # compare c1 - c2 distance over time
@@ -180,9 +174,9 @@ if __name__ == "__main__":
     idx2 = np.logical_and(np.array(traces['actualCategory']) == 2,
                           repetition == rpt)
 
-    c0slice = [traces['tmActiveCells'][i] for i in range(len(idx0)) if idx0[i]]
-    c1slice = [traces['tmActiveCells'][i] for i in range(len(idx1)) if idx1[i]]
-    c2slice = [traces['tmActiveCells'][i] for i in range(len(idx2)) if idx2[i]]
+    c0slice = [traces['tmPredictedActiveCells'][i] for i in range(len(idx0)) if idx0[i]]
+    c1slice = [traces['tmPredictedActiveCells'][i] for i in range(len(idx1)) if idx1[i]]
+    c2slice = [traces['tmPredictedActiveCells'][i] for i in range(len(idx2)) if idx2[i]]
 
     if includeNoiseCategory:
       SDRclusters.append(c0slice)


### PR DESCRIPTION
@marionleborgne 

Summary
* Ignore empty SDRs when calculating cluster distance
* use Predicted Active Cells for clustering

![image](https://cloud.githubusercontent.com/assets/5067931/18405808/420292ca-76aa-11e6-868b-af0d3c891664.png)

![image](https://cloud.githubusercontent.com/assets/5067931/18405803/3f9098ca-76aa-11e6-9c1e-e8a365d3106d.png)
