### PR TITLE
Revert "Capacity as a function of cortical column number"

### DIFF
--- a/projects/l2_pooling/capacity_test.py
+++ b/projects/l2_pooling/capacity_test.py
@@ -34,7 +34,6 @@ import multiprocessing
 import os
 import os.path
 
-import matplotlib as mpl
 import matplotlib.pyplot as plt
 import matplotlib.ticker as ticker
 import numpy as np
@@ -44,7 +43,7 @@ from htmresearch.frameworks.layers.object_machine_factory import (
   createObjectMachine
 )
 from htmresearch.frameworks.layers.l2_l4_inference import L4L2Experiment
-mpl.rcParams['pdf.fonttype'] = 42
+
 
 
 NUM_LOCATIONS = 5000
@@ -124,7 +123,6 @@ def getL2Params():
     "activationThresholdDistal": 10,
     "maxNewProximalSynapseCount": 5,
   }
-
 
 
 
@@ -260,11 +258,9 @@ def testOnSingleRandomSDR(objects, exp, numRepeats=100):
                            exp.objectL2Representations[1][0]))
 
   columnPooler = exp.L2Columns[0]._pooler
-  numConnectedProximal = columnPooler.numberOfConnectedProximalSynapses()
-  numConnectedDistal = columnPooler.numberOfConnectedDistalSynapses()
+  numberOfConnectedSynapses = columnPooler.numberOfConnectedSynapses()
 
-  return {"numberOfConnectedProximalSynapses": numConnectedProximal,
-          "numberOfConnectedDistalSynapses": numConnectedDistal,
+  return {"numberOfConnectedSynapses": numberOfConnectedSynapses,
           "numObjects": numObjects,
           "numPointsPerObject": numPointsPerObject,
           "confusion": np.mean(confusion),
@@ -291,7 +287,7 @@ def plotResults(result, ax=None, xaxis="numPointsPerObject",
   ax[0, 0].set_ylabel("Accuracy")
   ax[0, 0].set_xlabel(xlabel)
 
-  ax[0, 1].plot(x, result.numberOfConnectedProximalSynapses, marker)
+  ax[0, 1].plot(x, result.numberOfConnectedSynapses, marker)
   ax[0, 1].set_ylabel("# connected synapses")
   ax[0, 1].set_xlabel("# Pts / Obj")
   ax[0, 1].set_xlabel(xlabel)
@@ -303,7 +299,7 @@ def plotResults(result, ax=None, xaxis="numPointsPerObject",
 
   ax[1, 1].plot(x, result.confusion, marker)
   ax[1, 1].set_ylabel("OverlapFalseObject")
-  ax[1, 1].set_ylim([0, 4])
+  ax[1, 1].set_ylim([0, 41])
   ax[1, 1].set_xlabel(xlabel)
 
   plt.tight_layout()
@@ -444,7 +440,7 @@ def runCapacityTestVaryingObjectNum(numPointsPerObject=10,
              activationThreshold,
              numCorticalColumns)
             for numObjects in np.arange(20, 1371, 150)]
-  print "{} experiments to run".format(len(params))
+
   for testResult in pool.map(invokeRunCapacityTest, params):
     print testResult
 
@@ -455,9 +451,8 @@ def runCapacityTestVaryingObjectNum(numPointsPerObject=10,
     )
 
   resultFileName = _prepareResultsDir(
-    "multiple_column_capacity_varying_object_num_synapses_{}_thresh_{}"
-    "_numColumns_{}.csv"
-      .format(maxNewSynapseCount, activationThreshold, numCorticalColumns),
+    "multiple_column_capacity_varying_object_num_synapses_{}_thresh_{}.csv"
+      .format(maxNewSynapseCount, activationThreshold),
     resultDirName=resultDirName
   )
 
@@ -502,9 +497,8 @@ def runExperiment1(numObjects=2,
     activationThreshold = int(maxNewSynapseCount) - 1
 
     resultFileName = _prepareResultsDir(
-      "multiple_column_capacity_varying_object_size_synapses_{}_thresh_{}"
-      "_numColumns_{}.csv"
-      .format(maxNewSynapseCount, activationThreshold, numCorticalColumns),
+      "multiple_column_capacity_varying_object_size_synapses_{}_thresh_{}.csv"
+      .format(maxNewSynapseCount, activationThreshold),
       resultDirName=resultDirName
     )
 
@@ -570,9 +564,8 @@ def runExperiment2(numCorticalColumns=DEFAULT_NUM_CORTICAL_COLUMNS,
     activationThreshold = int(maxNewSynapseCount) - 1
 
     resultFileName = _prepareResultsDir(
-      "multiple_column_capacity_varying_object_num_synapses_{}_thresh_{}"
-      "_numColumns_{}.csv"
-      .format(maxNewSynapseCount, activationThreshold, numCorticalColumns),
+      "multiple_column_capacity_varying_object_num_synapses_{}_thresh_{}.csv"
+      .format(maxNewSynapseCount, activationThreshold),
       resultDirName=resultDirName
     )
 
@@ -599,60 +592,17 @@ def runExperiment2(numCorticalColumns=DEFAULT_NUM_CORTICAL_COLUMNS,
 
 def runExperiments(numCorticalColumns, resultDirName, plotDirName, cpuCount):
 
-  # # Varying number of pts per objects, two objects
-  # runExperiment1(numCorticalColumns=numCorticalColumns,
-  #                resultDirName=resultDirName,
-  #                plotDirName=plotDirName,
-  #                cpuCount=cpuCount)
+  # Varying number of pts per objects, two objects
+  runExperiment1(numCorticalColumns=numCorticalColumns,
+                 resultDirName=resultDirName,
+                 plotDirName=plotDirName,
+                 cpuCount=cpuCount)
 
   # 10 pts per object, varying number of objects
   runExperiment2(numCorticalColumns=numCorticalColumns,
                  resultDirName=resultDirName,
                  plotDirName=plotDirName,
                  cpuCount=cpuCount)
-
-
-
-def plotCapacityVsColumnNumber(numCorticalColumnsList):
-  """
-  Plot capacity test for L4-L2 with varying number of cortical columns
-
-  You need to run the experiments first with the listed number of columns
-
-  :return:
-  """
-  markers = ("-bo", "-ro", "-co", "-go", "-mo", "-ko", "-yo")
-  ploti = 0
-  fig, ax = plt.subplots(2, 2)
-  st = fig.suptitle(
-    "Capacity vs. Column #", fontsize="x-large")
-
-  legendEntries = []
-  resultDirName = DEFAULT_RESULT_DIR_NAME
-  for numCorticalColumns in numCorticalColumnsList:
-    maxNewSynapseCount = 10
-    activationThreshold = int(maxNewSynapseCount) - 1
-
-    resultFileName = _prepareResultsDir(
-      "multiple_column_capacity_varying_object_num_synapses_{}_thresh_{}"
-      "_numColumns_{}.csv"
-        .format(maxNewSynapseCount, activationThreshold, numCorticalColumns),
-      resultDirName=resultDirName
-    )
-
-    result = pd.read_csv(resultFileName)
-
-    plotResults(result, ax, "numObjects", None, markers[ploti])
-    ploti += 1
-    legendEntries.append('numColumns {}'.format(numCorticalColumns))
-
-  fig.tight_layout()
-
-  # shift subplots down:
-  st.set_y(0.95)
-  fig.subplots_adjust(top=0.85)
-  plt.legend(legendEntries)
-  plt.savefig('plots/capacity_vs_column_number.pdf')
 
 
 
@@ -690,6 +640,3 @@ if __name__ == "__main__":
                  resultDirName=opts.resultDirName,
                  plotDirName=opts.plotDirName,
                  cpuCount=opts.cpuCount)
-
-  # uncomment to plot capacity vs. column number
-  # plotCapacityVsColumnNumber([1, 2, 3, 4, 5])


### PR DESCRIPTION
Reverts numenta/nupic.research#672

It turns out this code depended on some other changes in Column Pooler at #666 not reflected in the original PR.  Meanwhile, #666 has its own conflicts that will need to be resolved.