### PR TITLE
Res 361 l2 l4 spatial pooling

### DIFF
--- a/htmresearch/frameworks/layers/l2_l4_inference.py
+++ b/htmresearch/frameworks/layers/l2_l4_inference.py
@@ -126,7 +126,9 @@ class L4L2Experiment(object):
                L4Overrides=None,
                numLearningPoints=3,
                seed=42,
-               logCalls = False):
+               logCalls = False,
+               enableLateralSP=False,
+               lateralSPOverrides=None):
     """
     Creates the network.
 
@@ -195,6 +197,11 @@ class L4L2Experiment(object):
       "L4Params": self.getDefaultL4Params(inputSize),
       "L2Params": self.getDefaultL2Params(inputSize),
     }
+
+    if enableLateralSP:
+      self.config["lateralSPParams"] = self.getDefaultLateralSPParams(inputSize)
+      if lateralSPOverrides:
+        self.config["lateralSPParams"].update(lateralSPOverrides)
 
     if L2Overrides is not None:
       self.config["L2Params"].update(L2Overrides)
@@ -616,6 +623,21 @@ class L4L2Experiment(object):
       "maxSynapsesPerDistalSegment": 255,
       "maxSynapsesPerProximalSegment": 2000,
       "seed": self.seed
+    }
+
+  def getDefaultLateralSPParams(self, inputSize):
+    return {
+      "spatialImp": "cpp",
+      "globalInhibition": 1,
+      "columnCount": 1024,
+      "inputWidth": inputSize,
+      "numActiveColumnsPerInhArea": 40,
+      "seed": self.seed,
+      "potentialPct": 0.8,
+      "synPermConnected": 0.1,
+      "synPermActiveInc": 0.0001,
+      "synPermInactiveDec": 0.0005,
+      "maxBoost": 1.0,
     }
 
 

--- a/htmresearch/frameworks/layers/l2_l4_inference.py
+++ b/htmresearch/frameworks/layers/l2_l4_inference.py
@@ -128,7 +128,10 @@ class L4L2Experiment(object):
                seed=42,
                logCalls = False,
                enableLateralSP=False,
-               lateralSPOverrides=None):
+               lateralSPOverrides=None,
+               enableFeedForwardSP=False,
+               feedForwardSPOverrides=None
+               ):
     """
     Creates the network.
 
@@ -163,6 +166,20 @@ class L4L2Experiment(object):
              log can then be saved with saveLogs(). This allows us to recreate
              the complete network behavior using rerunExperimentFromLogfile
              which is very useful for debugging.
+
+    @param   enableLateralSP (bool)
+             If true, Spatial Pooler will be added between external input and
+             L4 lateral input
+
+    @param   lateralSPOverrides
+             Parameters to override in the lateral SP region
+
+    @param   enableFeedForwardSP (bool)
+             If true, Spatial Pooler will be added between external input and
+             L4 feed-forward input
+
+    @param   feedForwardSPOverrides
+             Parameters to override in the feed-forward SP region
 
     """
     # Handle logging - this has to be done first
@@ -202,6 +219,11 @@ class L4L2Experiment(object):
       self.config["lateralSPParams"] = self.getDefaultLateralSPParams(inputSize)
       if lateralSPOverrides:
         self.config["lateralSPParams"].update(lateralSPOverrides)
+
+    if enableFeedForwardSP:
+      self.config["feedForwardSPParams"] = self.getDefaultFeedForwardSPParams(inputSize)
+      if feedForwardSPOverrides:
+        self.config["feedForwardSPParams"].update(feedForwardSPOverrides)
 
     if L2Overrides is not None:
       self.config["L2Params"].update(L2Overrides)
@@ -626,6 +648,21 @@ class L4L2Experiment(object):
     }
 
   def getDefaultLateralSPParams(self, inputSize):
+    return {
+      "spatialImp": "cpp",
+      "globalInhibition": 1,
+      "columnCount": 1024,
+      "inputWidth": inputSize,
+      "numActiveColumnsPerInhArea": 40,
+      "seed": self.seed,
+      "potentialPct": 0.8,
+      "synPermConnected": 0.1,
+      "synPermActiveInc": 0.0001,
+      "synPermInactiveDec": 0.0005,
+      "maxBoost": 1.0,
+    }
+
+  def getDefaultFeedForwardSPParams(self, inputSize):
     return {
       "spatialImp": "cpp",
       "globalInhibition": 1,

--- a/htmresearch/frameworks/layers/laminar_network.py
+++ b/htmresearch/frameworks/layers/laminar_network.py
@@ -92,10 +92,10 @@ def _linkLateralSPRegion(network, networkConfig, externalInputName, L4ColumnName
     return
 
   # Link lateral input to SP input, SP output to L4 lateral input
-
-  network.link(externalInputName, "lateralSPRegion", "UniformLink", "")
-  network.link(externalInputName, L4ColumnName, "UniformLink", "",
-               srcOutput="dataOut", destInput="externalBasalInput")
+  network.link(externalInputName, "lateralSPRegion", "UniformLink", "",
+               srcOutput="dataOut", destInput="bottomUpIn")
+  network.link("lateralSPRegion", L4ColumnName, "UniformLink", "",
+               srcOutput="bottomUpOut", destInput="externalBasalInput")
 
 
 def _setLateralSPPhases(network, networkConfig):

--- a/projects/l2_pooling/single_column_sp.py
+++ b/projects/l2_pooling/single_column_sp.py
@@ -1,0 +1,209 @@
+# Numenta Platform for Intelligent Computing (NuPIC)
+# Copyright (C) 2016, Numenta, Inc.  Unless you have an agreement
+# with Numenta, Inc., for a separate license for this software code, the
+# following terms and conditions apply:
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# See the GNU Affero Public License for more details.
+#
+# You should have received a copy of the GNU Affero Public License
+# along with this program.  If not, see http://www.gnu.org/licenses.
+#
+# http://numenta.org/licenses/
+# ----------------------------------------------------------------------
+
+"""
+This file creates simple experiments to test a single column L4-L2 network.
+"""
+
+from htmresearch.frameworks.layers.object_machine_factory import (
+  createObjectMachine
+)
+from htmresearch.frameworks.layers.l2_l4_inference import L4L2Experiment
+
+
+
+def createThreeObjects():
+  """
+  Helper function that creates a set of three objects used for basic
+  experiments.
+
+  :return:   (list(list(tuple))  List of lists of feature / location pairs.
+  """
+  objectA = zip(range(10), range(10))
+  objectB = [(0, 0), (2, 2), (1, 1), (1, 4), (4, 2), (4, 1)]
+  objectC = [(0, 0), (1, 1), (3, 1), (0, 1)]
+  return [objectA, objectB, objectC]
+
+
+
+def runSharedFeatures(noiseLevel=None, profile=False):
+  """
+  Runs a simple experiment where three objects share a number of location,
+  feature pairs.
+
+  Parameters:
+  ----------------------------
+  @param    noiseLevel (float)
+            Noise level to add to the locations and features during inference
+
+  @param    profile (bool)
+            If True, the network will be profiled after learning and inference
+
+  """
+  exp = L4L2Experiment(
+    "shared_features",
+    enableLateralSP=True
+  )
+
+  pairs = createThreeObjects()
+  objects = createObjectMachine(
+    machineType="simple",
+    numInputBits=20,
+    sensorInputSize=1024,
+    externalInputSize=1024
+  )
+  for object in pairs:
+    objects.addObject(object)
+
+  exp.learnObjects(objects.provideObjectsToLearn())
+  if profile:
+    exp.printProfile()
+
+  inferConfig = {
+    "numSteps": 10,
+    "noiseLevel": noiseLevel,
+    "pairs": {
+      0: zip(range(10), range(10))
+    }
+  }
+
+  exp.infer(objects.provideObjectToInfer(inferConfig), objectName=0)
+  if profile:
+    exp.printProfile()
+
+  exp.plotInferenceStats(
+    fields=["L2 Representation",
+            "Overlap L2 with object",
+            "L4 Representation"],
+  )
+
+
+
+def runUncertainLocations(missingLoc=None, profile=False):
+  """
+  Runs the same experiment as above, with missing locations at some timesteps
+  during inference (if it was not successfully computed by the rest of the
+  network for example).
+
+  @param   missingLoc (dict)
+           A dictionary mapping indices in the object to location index to
+           replace with during inference (-1 means no location, a tuple means
+           an union of locations).
+
+  @param   profile (bool)
+           If True, the network will be profiled after learning and inference
+
+  """
+  if missingLoc is None:
+    missingLoc = {}
+
+  exp = L4L2Experiment(
+    "uncertain_location",
+  )
+
+  pairs = createThreeObjects()
+  objects = createObjectMachine(
+    machineType="simple",
+    numInputBits=20,
+    sensorInputSize=1024,
+    externalInputSize=1024
+  )
+  for object in pairs:
+    objects.addObject(object)
+
+  exp.learnObjects(objects.provideObjectsToLearn())
+
+  # create pairs with missing locations
+  objectA = objects[0]
+  for key, val in missingLoc.iteritems():
+    objectA[key] = (val, key)
+
+  inferConfig = {
+    "numSteps": 10,
+    "pairs": {
+      0: objectA
+    }
+  }
+
+  exp.infer(objects.provideObjectToInfer(inferConfig), objectName=0)
+  if profile:
+    exp.printProfile()
+
+  exp.plotInferenceStats(
+    fields=["L2 Representation",
+            "Overlap L2 with object",
+            "L4 Representation",
+            "L4 Predictive"],
+  )
+
+
+
+def runStretchExperiment(numObjects=25):
+  """
+  Generates a lot of random objects to profile the network.
+
+  Parameters:
+  ----------------------------
+  @param    numObjects (int)
+            Number of objects to create and learn.
+
+  """
+  exp = L4L2Experiment(
+    "profiling_experiment",
+  )
+
+  objects = createObjectMachine(
+    machineType="simple",
+    numInputBits=20,
+    sensorInputSize=1024,
+    externalInputSize=1024
+  )
+  objects.createRandomObjects(numObjects=numObjects, numPoints=10)
+  exp.learnObjects(objects.provideObjectsToLearn())
+  exp.printProfile()
+
+  inferConfig = {
+    "numSteps": len(objects[0]),
+    "pairs": {
+      0: objects[0]
+    }
+  }
+
+  exp.infer(objects.provideObjectToInfer(inferConfig), objectName=0)
+  exp.printProfile()
+
+  exp.plotInferenceStats(
+    fields=["L2 Representation",
+            "Overlap L2 with object",
+            "L4 Representation"]
+  )
+
+
+
+if __name__ == "__main__":
+  # basic experiment with shared features
+  runSharedFeatures()
+
+  # experiment with unions at locations
+  missingLoc = {3: (1,2,3), 6: (6,4,2)}
+  runUncertainLocations(missingLoc=missingLoc)
+
+  # stretch experiment to profile the regions
+  runStretchExperiment()

--- a/projects/l2_pooling/single_column_sp.py
+++ b/projects/l2_pooling/single_column_sp.py
@@ -59,7 +59,8 @@ def runSharedFeatures(noiseLevel=None, profile=False):
   """
   exp = L4L2Experiment(
     "shared_features",
-    enableLateralSP=True
+    enableLateralSP=True,
+    enableFeedForwardSP=True
   )
 
   pairs = createThreeObjects()
@@ -116,7 +117,8 @@ def runUncertainLocations(missingLoc=None, profile=False):
 
   exp = L4L2Experiment(
     "uncertain_location",
-    enableLateralSP = True
+    enableLateralSP = True,
+    enableFeedForwardSP=True
   )
 
   pairs = createThreeObjects()
@@ -168,7 +170,8 @@ def runStretchExperiment(numObjects=25):
   """
   exp = L4L2Experiment(
     "profiling_experiment",
-    enableLateralSP = True
+    enableLateralSP = True,
+    enableFeedForwardSP=True
   )
 
   objects = createObjectMachine(

--- a/projects/l2_pooling/single_column_sp.py
+++ b/projects/l2_pooling/single_column_sp.py
@@ -116,6 +116,7 @@ def runUncertainLocations(missingLoc=None, profile=False):
 
   exp = L4L2Experiment(
     "uncertain_location",
+    enableLateralSP = True
   )
 
   pairs = createThreeObjects()
@@ -167,6 +168,7 @@ def runStretchExperiment(numObjects=25):
   """
   exp = L4L2Experiment(
     "profiling_experiment",
+    enableLateralSP = True
   )
 
   objects = createObjectMachine(
@@ -199,7 +201,7 @@ def runStretchExperiment(numObjects=25):
 
 if __name__ == "__main__":
   # basic experiment with shared features
-  runSharedFeatures()
+  runSharedFeatures(profile=True)
 
   # experiment with unions at locations
   missingLoc = {3: (1,2,3), 6: (6,4,2)}


### PR DESCRIPTION
Adds optional arguments to `createL2L4Column()` to enable SP in lateral input to L4.

`enableLateralSP=True`, enables SP, `lateralSPOverrides={...}` updates return value of `getDefaultLateralSPParams()` default lateral SP params function.

Also adds optional support for enabling SP in feed-forward input.  `enableFeedForwardSP=True`, enables SP, `feedForwardSPOverrides={...}` updates return value of `getDefaultFeedForwardSPParams()` default feed-forward SP params function.

cc @subutai 