### PR TITLE
RES-395 Implement logging as a decorator for general use

### DIFF
--- a/htmresearch/support/logging_decorator.py
+++ b/htmresearch/support/logging_decorator.py
@@ -1,0 +1,114 @@
+# ----------------------------------------------------------------------
+# Numenta Platform for Intelligent Computing (NuPIC)
+# Copyright (C) 2016, Numenta, Inc.  Unless you have an agreement
+# with Numenta, Inc., for a separate license for this software code, the
+# following terms and conditions apply:
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# See the GNU Affero Public License for more details.
+#
+# You should have received a copy of the GNU Affero Public License
+# along with this program.  If not, see http://www.gnu.org/licenses.
+#
+# http://numenta.org/licenses/
+# ----------------------------------------------------------------------
+
+import cPickle
+
+
+
+class LoggingDecorator(object):
+  """
+  Decorator class for logging calls to be used to debug and reconstruct
+  experiments.
+
+  Usage:
+
+  class Foo(object):
+    @LoggingDecorator()
+    def __init__(self, logCalls=False):
+      # Calls to this method are logged
+      self.logCalls = logCalls
+
+    @LoggingDecorator()
+    def bar(self, *args, **kwargs):
+      # Calls to this method are logged
+      pass
+
+    def baz(self):
+      # Calls to this method are NOT logged
+      pass
+
+
+  foo = Foo(logCalls=True)
+  foo.bar(1, two=2)
+  foo.baz()
+
+  print "\n========== CALL LOG ==============="
+
+  for call in foo.callLog:
+    print call
+    print
+
+  print "=====================================\n"
+
+  LoggingDecorator.save(foo.callLog, "callLog.pkl")
+
+  for call in LoggingDecorator.load("callLog.pkl"):
+    print call
+    print
+
+  print "=====================================\n"
+
+  """
+
+  @staticmethod
+  def __call__(fn):
+    """ Returns decorated function that logs calls
+    """
+    def _fn(instance, *args, **kwargs):
+      if not hasattr(instance, "callLog"):
+        instance.callLog = []
+
+      # Log if, and only if logCalls is set to True, either as an attr on instance
+      # or as a kwarg to the called function (e.g. constructor/__init__) AND
+      # call originated internally
+      if getattr(instance, "logCalls", kwargs.get("logCalls", False)):
+        instance.callLog.append([fn.__name__, {"args": args, "kwargs": kwargs}])
+
+      return fn(instance, *args, **kwargs)
+
+
+    return _fn
+
+
+  @staticmethod
+  def save(callLog, logFilename):
+    """
+    Save the call log history into this file.
+
+    @param  logFilename (path)
+            Filename in which to save a pickled version of the call logs.
+
+    """
+    with open(logFilename, "wb") as outp:
+      cPickle.dump(callLog, outp)
+
+
+  @staticmethod
+  def load(logFilename):
+    """
+    Load a previously saved call log history from file, returns new
+    LoggingDecorator instance separate from singleton.
+
+    @param  logFilename (path)
+            Filename from which to load a pickled version of the call logs.
+    """
+    with open(logFilename, "rb") as inp:
+      return cPickle.load(inp)

--- a/projects/l2_pooling/thing_debug.py
+++ b/projects/l2_pooling/thing_debug.py
@@ -25,7 +25,7 @@ This file is used to debug specific Thing experiments.
 import pprint
 import cPickle
 from htmresearch.frameworks.layers.l2_l4_inference import (
-  L4L2Experiment, rerunExperimentFromLogfile)
+  L4L2Experiment, rerunExperimentFromLogfile, LoggingDecorator)
 
 thingObjects = {
   "Capsule":[
@@ -98,7 +98,8 @@ def createExperiment(logFilename):
   # Typically this would be done by Thing
   exp = L4L2Experiment("shared_features", logCalls=True)
   exp.learnObjects(thingObjects)
-  exp.saveLog(logFilename)
+
+  LoggingDecorator().save(logFilename)
 
 
 def debugExperiment(logFile):
@@ -181,9 +182,8 @@ if __name__ == "__main__":
 
   # Print out the log
   print "\n========== CALL LOG ==============="
-  with open("callLog.pkl","rb") as f:
-    callLog = cPickle.load(f)
-  for call in callLog:
+
+  for call in LoggingDecorator.load("callLog.pkl").callLog:
     print call
     print
   print "=====================================\n"

--- a/projects/l2_pooling/thing_debug.py
+++ b/projects/l2_pooling/thing_debug.py
@@ -23,9 +23,9 @@ This file is used to debug specific Thing experiments.
 """
 
 import pprint
-import cPickle
+from htmresearch.support.logging_decorator import LoggingDecorator
 from htmresearch.frameworks.layers.l2_l4_inference import (
-  L4L2Experiment, rerunExperimentFromLogfile, LoggingDecorator)
+  L4L2Experiment, rerunExperimentFromLogfile)
 
 thingObjects = {
   "Capsule":[
@@ -99,7 +99,7 @@ def createExperiment(logFilename):
   exp = L4L2Experiment("shared_features", logCalls=True)
   exp.learnObjects(thingObjects)
 
-  LoggingDecorator().save(logFilename)
+  LoggingDecorator.save(exp.callLog, logFilename)
 
 
 def debugExperiment(logFile):
@@ -183,10 +183,12 @@ if __name__ == "__main__":
   # Print out the log
   print "\n========== CALL LOG ==============="
 
-  for call in LoggingDecorator.load("callLog.pkl").callLog:
+  for call in LoggingDecorator.load("callLog.pkl"):
     print call
     print
   print "=====================================\n"
 
   # Recreate class from log and debug experiment
   debugExperiment("callLog.pkl")
+
+


### PR DESCRIPTION
This moves the logging functionality into a decorator class that can be re-used elsewhere, removes inline logging logic.