### PR TITLE
ObjectMachine off-by-one bugfix

### DIFF
--- a/htmresearch/frameworks/layers/simple_object_machine.py
+++ b/htmresearch/frameworks/layers/simple_object_machine.py
@@ -208,7 +208,7 @@ class SimpleObjectMachine(ObjectMachineBase):
       locationArray = numpy.random.permutation(locationArray)
       self.addObject(
         [(locationArray[p],
-          numpy.random.randint(0, numFeatures-1)) for p in xrange(numPoints)],
+          numpy.random.randint(0, numFeatures)) for p in xrange(numPoints)],
       )
 
 


### PR DESCRIPTION
`numpy.random` handles its boundaries differently from `random`.