### PR TITLE
New L2 noise experiment with scatterplots

### DIFF
--- a/htmresearch/algorithms/column_pooler.py
+++ b/htmresearch/algorithms/column_pooler.py
@@ -264,7 +264,8 @@ class ColumnPooler(object):
     # If necessary, activate some of the previously active cells
     if len(chosenCells) < minNumActiveCells:
       remainingCandidates = [cell for cell in prevActiveCells
-                             if cell not in feedforwardSupportedCells]
+                             if cell not in feedforwardSupportedCells
+                             if numActiveSegmentsByCell[cell] > 0]
       chosenCells.extend(self._chooseCells(remainingCandidates,
                                            minNumActiveCells - len(chosenCells),
                                            numActiveSegmentsByCell))

--- a/projects/l2_pooling/noise_tolerance_isolated_l2.py
+++ b/projects/l2_pooling/noise_tolerance_isolated_l2.py
@@ -27,6 +27,7 @@ sample sizes.
 """
 
 from collections import defaultdict
+import json
 import math
 import random
 import os
@@ -90,7 +91,7 @@ def noisy(pattern, noiseLevel, totalNumCells):
 
 
 def doExperiment(numColumns, l2Overrides, objectDescriptions, noiseMu,
-                 noiseSigma, numInitialTraversals):
+                 noiseSigma, numInitialTraversals, noiseEverywhere):
   """
   Touch every point on an object 'numInitialTraversals' times, then evaluate
   whether it has inferred the object by touching every point once more and
@@ -118,6 +119,11 @@ def doExperiment(numColumns, l2Overrides, objectDescriptions, noiseMu,
   @param numInitialTraversals (int)
   The number of times to traverse the object before testing whether the object
   has been inferred.
+
+  @param noiseEverywhere (bool)
+  If true, add noise to every column's input, and record accuracy of every
+  column. If false, add noise to one column's input, and only record accuracy
+  of that column.
   """
 
   # For each column, keep a mapping from feature-location names to their SDRs
@@ -166,7 +172,12 @@ def doExperiment(numColumns, l2Overrides, objectDescriptions, noiseMu,
     # traversals" into a "number of touches" according to the number of sensors.
     numTouchesPerTraversal = len(featureLocations) / float(numColumns)
     numInitialTouches = int(math.ceil(numInitialTraversals * numTouchesPerTraversal))
-    numTestTouches = int(math.ceil(1 * numTouchesPerTraversal))
+
+    if noiseEverywhere:
+      numTestTouches = int(math.ceil(1 * numTouchesPerTraversal))
+    else:
+      numTestTouches = len(featureLocations)
+
     for touch in xrange(numInitialTouches + numTestTouches):
       sensorPositions = next(sensorPositionsIterator)
 
@@ -175,13 +186,14 @@ def doExperiment(numColumns, l2Overrides, objectDescriptions, noiseMu,
       for _ in xrange(3):
         allLateralInputs = [l2.getActiveCells() for l2 in l2Columns]
         for columnNumber, l2 in enumerate(l2Columns):
-          noiseLevel = random.gauss(noiseMu, noiseSigma)
-          noiseLevel = max(0.0, min(1.0, noiseLevel))
-
           position = sensorPositions[columnNumber]
           featureLocationName = featureLocations[position]
           feedforwardInput = featureLocationSDRs[columnNumber][featureLocationName]
-          feedforwardInput = noisy(feedforwardInput, noiseLevel, L4_CELL_COUNT)
+
+          if noiseEverywhere or columnNumber == 0:
+            noiseLevel = random.gauss(noiseMu, noiseSigma)
+            noiseLevel = max(0.0, min(1.0, noiseLevel))
+            feedforwardInput = noisy(feedforwardInput, noiseLevel, L4_CELL_COUNT)
 
           lateralInputs = [lateralInput
                            for i, lateralInput in enumerate(allLateralInputs)
@@ -190,17 +202,22 @@ def doExperiment(numColumns, l2Overrides, objectDescriptions, noiseMu,
           l2.compute(feedforwardInput, lateralInputs, learn=False)
 
       if touch >= numInitialTouches:
-        for columnNumber, l2 in enumerate(l2Columns):
-          activeCells = set(l2.getActiveCells())
-          correctCells = objectL2Representations[objectName][columnNumber]
-
+        if noiseEverywhere:
+          for columnNumber, l2 in enumerate(l2Columns):
+            activeCells = set(l2.getActiveCells())
+            correctCells = objectL2Representations[objectName][columnNumber]
+            results.append((len(activeCells & correctCells),
+                            len(activeCells - correctCells)))
+        else:
+          activeCells = set(l2Columns[0].getActiveCells())
+          correctCells = objectL2Representations[objectName][0]
           results.append((len(activeCells & correctCells),
                           len(activeCells - correctCells)))
 
   return results
 
 
-def varyNumColumns(noiseSigma):
+def plotSuccessRate_varyNumColumns(noiseSigma, noiseEverywhere):
   """
   Run and plot the experiment, varying the number of cortical columns.
   """
@@ -214,7 +231,7 @@ def varyNumColumns(noiseSigma):
 
   results = defaultdict(list)
 
-  for trial in xrange(5):
+  for trial in xrange(1):
     print "trial", trial
     objectDescriptions = createRandomObjectDescriptions(10, 10)
 
@@ -222,7 +239,8 @@ def varyNumColumns(noiseSigma):
       print "numColumns", numColumns
       for noiseLevel in noiseLevels:
         r = doExperiment(numColumns, l2Overrides, objectDescriptions,
-                         noiseLevel, noiseSigma, numInitialTraversals=6)
+                         noiseLevel, noiseSigma, numInitialTraversals=6,
+                         noiseEverywhere=noiseEverywhere)
         results[(numColumns, noiseLevel)].extend(r)
 
   #
@@ -266,7 +284,7 @@ def varyNumColumns(noiseSigma):
   print "Saved file %s" % plotPath
 
 
-def varyDistalSampleSize(noiseSigma):
+def plotSuccessRate_varyDistalSampleSize(noiseSigma, noiseEverywhere):
   """
   Run and plot the experiment, varying the distal sample size.
   """
@@ -281,7 +299,7 @@ def varyDistalSampleSize(noiseSigma):
 
   results = defaultdict(list)
 
-  for trial in xrange(5):
+  for trial in xrange(1):
     print "trial", trial
     objectDescriptions = createRandomObjectDescriptions(10, 10)
 
@@ -290,7 +308,8 @@ def varyDistalSampleSize(noiseSigma):
       l2Overrides = {"sampleSizeDistal": sampleSizeDistal}
       for noiseLevel in noiseLevels:
         r = doExperiment(numColumns, l2Overrides, objectDescriptions,
-                         noiseLevel, noiseSigma, numInitialTraversals=6)
+                         noiseLevel, noiseSigma, numInitialTraversals=6,
+                         noiseEverywhere=noiseEverywhere)
         results[(sampleSizeDistal, noiseLevel)].extend(r)
 
   #
@@ -334,7 +353,7 @@ def varyDistalSampleSize(noiseSigma):
   print "Saved file %s" % plotPath
 
 
-def varyProximalSampleSize(noiseSigma):
+def plotSuccessRate_varyProximalSampleSize(noiseSigma, noiseEverywhere):
   """
   Run and plot the experiment, varying the proximal sample size.
   """
@@ -349,7 +368,7 @@ def varyProximalSampleSize(noiseSigma):
 
   results = defaultdict(list)
 
-  for trial in xrange(5):
+  for trial in xrange(1):
     print "trial", trial
     objectDescriptions = createRandomObjectDescriptions(10, 10)
 
@@ -358,7 +377,8 @@ def varyProximalSampleSize(noiseSigma):
       l2Overrides = {"sampleSizeProximal": sampleSizeProximal}
       for noiseLevel in noiseLevels:
         r = doExperiment(numColumns, l2Overrides, objectDescriptions,
-                         noiseLevel, noiseSigma, numInitialTraversals=6)
+                         noiseLevel, noiseSigma, numInitialTraversals=6,
+                         noiseEverywhere=noiseEverywhere)
         results[(sampleSizeProximal, noiseLevel)].extend(r)
 
   #
@@ -402,25 +422,81 @@ def varyProximalSampleSize(noiseSigma):
   print "Saved file %s" % plotPath
 
 
+def logCellActivity_varyNumColumns(noiseSigma, noiseEverywhere):
+  """
+  Run the experiment, varying the column counts, and save each
+    [# correctly active cells, # incorrectly active cells]
+  pair to a JSON file that can be visualized.
+  """
+  noiseLevels = [0.30, 0.40, 0.45, 0.50, 0.55, 0.60, 0.65, 0.70, 0.75, 0.80, 0.85, 0.90]
+  l2Overrides = {"sampleSizeDistal": 20}
+  columnCounts = [1, 2, 3, 4, 5]
+
+  results = defaultdict(list)
+
+  for trial in xrange(1):
+    print "trial", trial
+    objectDescriptions = createRandomObjectDescriptions(10, 10)
+
+    for numColumns in columnCounts:
+      print "numColumns", numColumns
+      for noiseLevel in noiseLevels:
+        r = doExperiment(numColumns, l2Overrides, objectDescriptions,
+                         noiseLevel, noiseSigma, numInitialTraversals=6,
+                         noiseEverywhere=noiseEverywhere)
+        results[(numColumns, noiseLevel)].extend(r)
+
+  d = []
+  for (numColumns, noiseLevel), cellCounts in results.iteritems():
+    d.append({"numColumns": numColumns,
+              "noiseLevel": noiseLevel,
+              "results": cellCounts})
+
+  filename = os.path.join("plots",
+                          "varyColumns_sigma%.2f_%s.json"
+                          % (noiseSigma, time.strftime("%Y%m%d-%H%M%S")))
+  with open(filename, "w") as fout:
+    json.dump(d, fout)
+
+  print "Wrote to", filename
+  print "Visualize this file at: http://numenta.github.io/nupic.research/visualizations/grid-of-scatterplots/L2-columns-with-noise.html"
+
+
 
 if __name__ == "__main__":
 
   # Plot the accuracy of inference when noise is added, varying the number of
-  # cortical columns. We find that when noise is a Gaussian random variable that
-  # is independently applied to different columns, the accuracy improves with
-  # more cortical columns.
-  varyNumColumns(noiseSigma=0.0)
-  varyNumColumns(noiseSigma=0.1)
-  varyNumColumns(noiseSigma=0.2)
+  # cortical columns. We find that when noise is applied at a constant equal
+  # rate for each column, the accuracy only improves slightly with more cortical
+  # columns.
+  plotSuccessRate_varyNumColumns(noiseSigma=0.0, noiseEverywhere=True)
+
+  # Change noise to a Gaussian random variable that is independently applied to
+  # different columns. We find that the accuracy now improves with more cortical
+  # columns. This means that noisy sensors benefit from having lateral input
+  # from non-noisy sensors. The sensors that happen to have high noise levels
+  # take advantage of the sensors that happen to have low noise levels, so the
+  # array as a whole can partially guard itself from noise.
+  plotSuccessRate_varyNumColumns(noiseSigma=0.1, noiseEverywhere=True)
+  plotSuccessRate_varyNumColumns(noiseSigma=0.2, noiseEverywhere=True)
 
   # Plot the accuracy of inference when noise is added, varying the ratio of the
   # proximal threshold to the proximal synapse sample size. We find that this
   # ratio does more than any other parameter to determine at what noise level
   # the accuracy drop-off occurs.
-  varyProximalSampleSize(noiseSigma=0.1)
+  plotSuccessRate_varyProximalSampleSize(noiseSigma=0.1, noiseEverywhere=True)
 
   # Plot the accuracy of inference when noise is added, varying the ratio of the
   # distal segment activation threshold to the distal synapse sample size. We
   # find that increasing this ratio provides additional noise tolerance on top
   # of the noise tolerance provided by proximal connections.
-  varyDistalSampleSize(noiseSigma=0.1)
+  plotSuccessRate_varyDistalSampleSize(noiseSigma=0.1, noiseEverywhere=True)
+
+  # Observe the impact of columns without noisy input on columns with noisy
+  # input. Add constant noise to one column's input, and don't add noise for the
+  # other columns. Observe what happens as more non-noisy columns are added. We
+  # find that the lateral input from other columns can help correctly active
+  # cells inhibit cells that shouldn't be active, but it doesn't help increase
+  # the number of correctly active cells. So the accuracy of inference is
+  # improved, but the confidence of the inference isn't.
+  logCellActivity_varyNumColumns(noiseSigma=0.0, noiseEverywhere=False)

--- a/projects/l2_pooling/noise_tolerance_l2.py
+++ b/projects/l2_pooling/noise_tolerance_l2.py
@@ -1,5 +1,5 @@
 # Numenta Platform for Intelligent Computing (NuPIC)
-# Copyright (C) 2016, Numenta, Inc.  Unless you have an agreement
+# Copyright (C) 2016 - 2017, Numenta, Inc.  Unless you have an agreement
 # with Numenta, Inc., for a separate license for this software code, the
 # following terms and conditions apply:
 #

--- a/projects/l2_pooling/noise_tolerance_l2_l4.py
+++ b/projects/l2_pooling/noise_tolerance_l2_l4.py
@@ -1,0 +1,357 @@
+# Numenta Platform for Intelligent Computing (NuPIC)
+# Copyright (C) 2017, Numenta, Inc.  Unless you have an agreement
+# with Numenta, Inc., for a separate license for this software code, the
+# following terms and conditions apply:
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# See the GNU Affero Public License for more details.
+#
+# You should have received a copy of the GNU Affero Public License
+# along with this program.  If not, see http://www.gnu.org/licenses.
+#
+# http://numenta.org/licenses/
+# ----------------------------------------------------------------------
+
+"""
+Test the noise tolerance of Layer 2 + Layer 4.
+
+Perform an experiment to see if L2 eventually recognizes an object.
+Test with various noise levels and with various column counts.
+"""
+
+from collections import defaultdict
+import json
+import math
+import random
+import os
+import time
+
+import numpy as np
+
+from htmresearch.frameworks.layers.l2_l4_inference import L4L2Experiment
+from htmresearch.frameworks.layers.sensor_placement import greedySensorPositions
+
+
+TIMESTEPS_PER_SENSATION = 3
+
+
+def withDropout(pattern, dropoutPercent):
+  """
+  Take the input pattern and suppress a portion of its active bits.
+
+  @param pattern (sequence)
+  Sequence of active indices
+
+  @return
+  A new pattern consisting of the previous pattern with some active bits removed
+  """
+  n = int(len(pattern) * (1.0 - dropoutPercent))
+
+  return set(random.sample(pattern, n))
+
+
+def createRandomObjects(numObjects, locationsPerObject, featurePoolSize):
+  """
+  Generate random objects.
+
+  @param numObjects (int)
+  The number of objects to generate
+
+  @param locationsPerObject (int)
+  The number of points on each object
+
+  @param featurePoolSize (int)
+  The number of possible features
+
+  @return
+  For example, { 0: [0, 1, 2],
+                 1: [0, 2, 1],
+                 2: [2, 0, 1], }
+  is 3 objects. The first object has Feature 0 and Location 0, Feature 1 at
+  Location 1, Feature 2 at location 2, etc.
+  """
+
+  allFeatures = range(featurePoolSize)
+  allLocations = range(locationsPerObject)
+  objects = dict((name,
+                     [random.choice(allFeatures) for _ in xrange(locationsPerObject)])
+                    for name in xrange(numObjects))
+
+  return objects
+
+
+
+def doExperiment(numColumns, objects, l2Overrides, noiseLevels, numInitialTraversals,
+                 featureDropout, locationDropout):
+  """
+  Touch every point on an object 'numInitialTraversals' times, then evaluate
+  whether it has inferred the object by touching every point once more and
+  checking the number of correctly active and incorrectly active cells.
+
+  @param numColumns (int)
+  The number of sensors to use
+
+  @param l2Overrides (dict)
+  Parameters for the ColumnPooler
+
+  @param objects (dict)
+  A mapping of object names to their features.
+  See 'createRandomObjects'.
+
+  @param noiseLevels (list of floats)
+  The noise levels to experiment with. The experiment is run once per noise
+  level. Noise is applied at a constant rate to exactly one cortical column.
+  It's applied to the same cortical column every time, and this is the cortical
+  column that is measured.
+
+  @param featureDropout (bool)
+  Whether to use a noisy feature
+
+  @param locationDropout (bool)
+  Whether to use a noisy location
+  """
+
+  featureSDR = lambda : set(random.sample(xrange(2048), 40))
+  locationSDR = lambda : set(random.sample(xrange(1024), 40))
+
+  featureSDRsByColumn = [defaultdict(featureSDR) for _ in xrange(numColumns)]
+  locationSDRsByColumn = [defaultdict(locationSDR) for _ in xrange(numColumns)]
+
+  exp = L4L2Experiment(
+    "Experiment",
+    numCorticalColumns=numColumns,
+    externalInputSize=1024,
+    seed=random.randint(2048, 4096)
+  )
+
+  exp.learnObjects(
+    dict((objectName,
+          [dict((column,
+                 (locationSDRsByColumn[column][location],
+                  featureSDRsByColumn[column][features[location]]))
+                for column in xrange(numColumns))
+           for location in xrange(len(features))])
+         for objectName, features in objects.iteritems()))
+
+  if locationDropout:
+    # Now that the objects are learned, allow bursting L4 minicolumns to
+    # activate cells in L2.
+    exp.L4Columns[0].setParameter("defaultOutputType", 0, "active")
+
+  results = defaultdict(list)
+
+  for noiseLevel in noiseLevels:
+    # Try to infer the objects
+    for objectName, features in objects.iteritems():
+      exp.sendReset()
+
+      inferredL2 = exp.objectL2Representations[objectName]
+
+      sensorPositionsIterator = greedySensorPositions(numColumns, len(features))
+
+      # Touch each location at least numInitialTouches times, and then touch it
+      # once more, testing it. For each traversal, touch each point on the object
+      # ~once. Not once per sensor -- just once. So we translate the "number of
+      # traversals" into a "number of touches" according to the number of sensors.
+      numTouchesPerTraversal = len(features) / float(numColumns)
+      numInitialTouches = int(math.ceil(numInitialTraversals * numTouchesPerTraversal))
+      numTestTouches = len(features)
+
+      for touch in xrange(numInitialTouches + numTestTouches):
+        sensorPositions = next(sensorPositionsIterator)
+
+        sensation = dict(
+          (column,
+           (locationSDRsByColumn[column][sensorPositions[column]],
+            featureSDRsByColumn[column][features[sensorPositions[column]]]))
+          for column in xrange(1, numColumns))
+
+        for _ in xrange(TIMESTEPS_PER_SENSATION):
+          # Add noise to the first column.
+          featureSDR = featureSDRsByColumn[0][features[sensorPositions[0]]]
+          if featureDropout:
+            featureSDR = withDropout(featureSDR, noiseLevel)
+
+          locationSDR = locationSDRsByColumn[0][sensorPositions[0]]
+          if locationDropout:
+            locationSDR = withDropout(locationSDR, noiseLevel)
+
+          sensation[0] = (locationSDR, featureSDR)
+
+          exp.infer([sensation], reset=False, objectName=objectName)
+
+        if touch >= numInitialTouches:
+          activeCells = exp.getL2Representations()[0]
+          correctCells = inferredL2[0]
+          results[noiseLevel].append((len(activeCells & correctCells),
+                                      len(activeCells - correctCells)))
+
+  return results
+
+
+def logCellActivity_featureDropout_varyNumColumns(name="cellActivity"):
+  """
+  Run the experiment, varying the column counts, and save each
+    [# correctly active cells, # incorrectly active cells]
+  pair to a JSON file that can be visualized.
+  """
+  noiseLevels = [0.0, 0.30, 0.40, 0.45, 0.50, 0.55, 0.60, 0.65, 0.70, 0.75, 0.80, 0.85, 0.90]
+  l2Overrides = {"sampleSizeDistal": 20}
+  columnCounts = [1, 2, 3, 4]
+
+  results = defaultdict(list)
+
+  for trial in xrange(1):
+    print "trial", trial
+
+    objects = createRandomObjects(10, 10, 10)
+
+    for numColumns in columnCounts:
+      print "numColumns", numColumns
+      r = doExperiment(numColumns, objects, l2Overrides, noiseLevels,
+                       numInitialTraversals=6, featureDropout=True,
+                       locationDropout=False)
+
+      for noiseLevel, counts in r.iteritems():
+        results[(numColumns, noiseLevel)].extend(counts)
+
+  d = []
+  for (numColumns, noiseLevel), cellCounts in results.iteritems():
+    d.append({"numColumns": numColumns,
+              "noiseLevel": noiseLevel,
+              "results": cellCounts})
+
+  filename = os.path.join("plots",
+                          "%s_%s.json"
+                          % (name, time.strftime("%Y%m%d-%H%M%S")))
+  with open(filename, "w") as fout:
+    json.dump(d, fout)
+
+  print "Wrote to", filename
+  print "Visualize this file at: http://numenta.github.io/nupic.research/visualizations/grid-of-scatterplots/L2-columns-with-noise.html"
+
+
+def logCellActivity_locationDropout_varyNumColumns(name, objects):
+  """
+  Run the experiment, varying the column counts, and save each
+    [# correctly active cells, # incorrectly active cells]
+  pair to a JSON file that can be visualized.
+  """
+  noiseLevels = [0.0, 0.5, 1.0]
+  l2Overrides = {"sampleSizeDistal": 20}
+  columnCounts = [1]
+
+  results = defaultdict(list)
+
+  for trial in xrange(1):
+    print "trial", trial
+
+    for numColumns in columnCounts:
+      print "numColumns", numColumns
+      r = doExperiment(numColumns, objects, l2Overrides, noiseLevels, numInitialTraversals=6,
+                       featureDropout=False, locationDropout=True)
+
+      for noiseLevel, counts in r.iteritems():
+        results[(numColumns, noiseLevel)].extend(counts)
+
+  d = []
+  for (numColumns, noiseLevel), cellCounts in results.iteritems():
+    d.append({"numColumns": numColumns,
+              "noiseLevel": noiseLevel,
+              "results": cellCounts})
+
+  filename = os.path.join("plots",
+                          "%s_%s.json"
+                          % (name, time.strftime("%Y%m%d-%H%M%S")))
+  with open(filename, "w") as fout:
+    json.dump(d, fout)
+
+  print "Wrote to", filename
+  print "Visualize this file at: http://numenta.github.io/nupic.research/visualizations/grid-of-scatterplots/L2-columns-with-noise.html"
+
+
+
+if __name__ == "__main__":
+  # Suppress active minicolumns in the L4 feature SDR, observing the impact on
+  # L2. Suppress a constant percent of the minicolumns in one cortical column,
+  # but leave the other cortical columns untouched. Observe what happens as more
+  # untouched columns are added.
+  #
+  # We find that the lateral input from other columns can help correctly active
+  # cells inhibit cells that shouldn't be active, but it doesn't help increase
+  # the number of correctly active cells. So the accuracy of inference is
+  # improved, but the confidence of the inference isn't.
+  print "Test: Suppress the L4 minicolumn SDR"
+  logCellActivity_featureDropout_varyNumColumns(name="suppressFeatureSDR")
+
+
+  # Suppress active bits in L4's location input, observing the impact on
+  # L2. Suppress a constant percent of the location input to one cortical
+  # column, but leave the other cortical columns untouched.
+  #
+  # We find that:
+  # - After the L4 loses a sufficient amount of its location input, the L2 + L4
+  #   becomes a classifier of bags-of-features. So any object that has a unique
+  #   set of features (irrespective of location) can still be classified by the
+  #   L2. L2 will infer a union of all objects that have the observed set of
+  #   features.
+  # - As we add cortical columns, the suppressed column quickly becomes able to
+  #   infer any object. The lateral input causes the union of objects in L2 to
+  #   narrow down to the correct object. So it's not totally necessary for every
+  #   cortical column to receive location input.
+
+  # Random objects with a small feature pool. Once noisy, a single column never
+  # infers an object, since most objects contain the exact same 3 features.
+
+  print ("Test: Suppress the L4 location SDR, "
+         "using random objects with a feature pool size of 3")
+  logCellActivity_locationDropout_varyNumColumns(
+    "smallFeaturePool", createRandomObjects(numObjects=10,
+                                            locationsPerObject=10,
+                                            featurePoolSize=3))
+
+
+  # A larger feature pool. Once noisy, a single column infers an object > 75% of
+  # the time, since many objects are unique in their set of features.
+
+  print ("Test: Suppress the L4 location SDR, "
+         "using random objects with a feature pool size of 10")
+  logCellActivity_locationDropout_varyNumColumns(
+    "mediumFeaturePool", createRandomObjects(numObjects=10,
+                                             locationsPerObject=10,
+                                             featurePoolSize=10))
+
+
+  # Hand-crafted objects that use only the same features. With a noisy location,
+  # the object is never inferred with a single column. L2 always infers the
+  # union of the 3 objects.
+
+  print ("Test: Suppress the L4 location SDR, "
+         "using hand-crafted objects made of the same features")
+  logCellActivity_locationDropout_varyNumColumns(
+    name="sameBagsOfFeatures",
+    objects={
+    0: [0, 1, 2],
+    1: [0, 2, 1],
+    2: [2, 0, 1],
+  })
+
+
+  # Hand-crafted objects that are each a unique combination of features. The
+  # object is always inferred with a single column.
+
+  print ("Test: Suppress the L4 location SDR, "
+         "using hand-crafted objects made of the unique sets of features")
+  logCellActivity_locationDropout_varyNumColumns(
+    name="uniqueBagsOfFeatures",
+    objects={
+    0: [0, 1, 2],
+    1: [1, 2, 3],
+    2: [2, 3, 0],
+  })


### PR DESCRIPTION
@ywcui1990 Here are some tweaks on the existing noise tolerance file. The visualization is generated by [this code](https://github.com/numenta/nupic.research/tree/55e7b32aef768443c04632c359e63c9407b31c42/visualizations/grid-of-scatterplots) which is hosted at http://numenta.github.io/nupic.research/visualizations/grid-of-scatterplots/L2-columns-with-noise.html

I'm gonna try and change that page so that it lets us export the SVG. (But that can be done independent of this PR)

Here's a figure when it's run with 5 trials:

![image](https://cloud.githubusercontent.com/assets/364113/21871263/e177de74-d815-11e6-9898-e5b729b99ebe.png)
