### PR TITLE
fix for syntax error: missing comma in 'frameworks/sensorimotor/sensorimotor_experiment_runner.py' #L68

### DIFF
--- a/htmresearch/frameworks/sensorimotor/sensorimotor_experiment_runner.py
+++ b/htmresearch/frameworks/sensorimotor/sensorimotor_experiment_runner.py
@@ -65,7 +65,7 @@ class SensorimotorExperimentRunner(object):
     "permanenceIncrement": 0.1,
     "permanenceDecrement": 0.02,
     "formInternalBasalConnections": True,
-    "basalInputDimensions": (999999,) # Dodge input checking.
+    "basalInputDimensions": (999999,), # Dodge input checking.
 
     # We will force client to override these
     "columnDimensions": "Sorry",


### PR DESCRIPTION
fixes #702 