### PR TITLE
optimize package should be imported seperately

### DIFF
--- a/htmresearch/algorithms/sdr_classifier_batch.py
+++ b/htmresearch/algorithms/sdr_classifier_batch.py
@@ -4,7 +4,7 @@ Training is achieved with gradient descent
 """
 import numpy as np
 import scipy
-
+from scipy import optimize
 
 def L2regularization(w, regularizationLambda):
   dW = np.zeros(w.shape)


### PR DESCRIPTION
It turns out I have to import optimize seperately in this module.
`import scipy` does not import optimize but uses optimize package and error pops when I use scripts which require this module.
`from scipy import optimize` fixed it and I found the reason why at these links:
[docs] (https://docs.scipy.org/doc/scipy/reference/tutorial/general.html#scipy-organization) and [issue] (https://github.com/scipy/scipy/issues/4005) here.