### PR TITLE
Fix active cell initialization bug in column pooler

### DIFF
--- a/htmresearch/algorithms/column_pooler.py
+++ b/htmresearch/algorithms/column_pooler.py
@@ -543,7 +543,8 @@ def _rightVecSumAtNZGtThreshold_sparse(sparseMatrix,
   an eventual C implementation would.
   """
   denseArray = numpy.zeros(sparseMatrix.nCols(), dtype=GetNTAReal())
-  denseArray[sparseBinaryArray] = 1
+  if len(sparseBinaryArray) > 0:
+    denseArray[numpy.array(sparseBinaryArray)] = 1
   return sparseMatrix.rightVecSumAtNZGtThreshold(denseArray, threshold)
 
 

--- a/htmresearch/algorithms/column_pooler.py
+++ b/htmresearch/algorithms/column_pooler.py
@@ -238,22 +238,19 @@ class ColumnPooler(object):
     prevActiveCells = self.activeCells
 
     # Calculate the feedforward supported cells
-    overlaps = _rightVecSumAtNZGtThreshold_sparse(
-      self.proximalPermanences, sorted(feedforwardInput),
-      self.connectedPermanenceProximal)
+    overlaps = self.proximalPermanences.rightVecSumAtNZGteThresholdSparse(
+      list(feedforwardInput), self.connectedPermanenceProximal)
     feedforwardSupportedCells = set(
       numpy.where(overlaps >= self.minThresholdProximal)[0])
 
     # Calculate the number of active segments on each cell
     numActiveSegmentsByCell = numpy.zeros(self.cellCount, dtype="int")
-    overlaps = _rightVecSumAtNZGtThreshold_sparse(
-      self.internalDistalPermanences, prevActiveCells,
-      self.connectedPermanenceDistal)
+    overlaps = self.internalDistalPermanences.rightVecSumAtNZGteThresholdSparse(
+      list(prevActiveCells), self.connectedPermanenceDistal)
     numActiveSegmentsByCell[overlaps >= self.activationThresholdDistal] += 1
     for i, lateralInput in enumerate(lateralInputs):
-      overlaps = _rightVecSumAtNZGtThreshold_sparse(
-        self.distalPermanences[i], sorted(lateralInput),
-        self.connectedPermanenceDistal)
+      overlaps = self.distalPermanences[i].rightVecSumAtNZGteThresholdSparse(
+        list(lateralInput), self.connectedPermanenceDistal)
       numActiveSegmentsByCell[overlaps >= self.activationThresholdDistal] += 1
 
     # Activate some of the feedforward supported cells
@@ -526,26 +523,6 @@ def _sampleRange(rng, start, end, step, k):
   rng.sample(numpy.arange(start, end, step, dtype="uint32"), array)
   return array
 
-
-def _rightVecSumAtNZGtThreshold_sparse(sparseMatrix,
-                                       sparseBinaryArray,
-                                       threshold):
-  """
-  For each row in 'sparseMatrix', computes the sum of ones in 'sparseBinaryArray'
-  for all indices i where sparseMatrix[row, i] >= threshold.
-
-  This is like rightVecSumAtNZGtThreshold, but it supports sparse binary arrays.
-
-  @param sparseBinaryArray (sorted sequence)
-  A sorted list of indices.
-
-  Note: this Python implementation doesn't require the list to be sorted, but
-  an eventual C implementation would.
-  """
-  denseArray = numpy.zeros(sparseMatrix.nCols(), dtype=GetNTAReal())
-  if len(sparseBinaryArray) > 0:
-    denseArray[numpy.array(sparseBinaryArray)] = 1
-  return sparseMatrix.rightVecSumAtNZGtThreshold(denseArray, threshold)
 
 
 def _countWhereGreaterEqualInRows(sparseMatrix, rows, threshold):

--- a/htmresearch/frameworks/layers/l2_l4_network_creation.py
+++ b/htmresearch/frameworks/layers/l2_l4_network_creation.py
@@ -301,6 +301,7 @@ def createMultipleL4L2Columns(network, networkConfig):
 
   # Now connect the L2 columns laterally
   for i in range(networkConfig["numCorticalColumns"]):
+    network.setPhases("L2Column_{}".format(i), [i+3])
     suffixSrc = "_" + str(i)
     for j in range(networkConfig["numCorticalColumns"]):
       suffixDest = "_" + str(j)

--- a/htmresearch/frameworks/layers/l2_l4_network_creation.py
+++ b/htmresearch/frameworks/layers/l2_l4_network_creation.py
@@ -303,12 +303,21 @@ def createMultipleL4L2Columns(network, networkConfig):
   for i in range(networkConfig["numCorticalColumns"]):
     suffixSrc = "_" + str(i)
     for j in range(networkConfig["numCorticalColumns"]):
-      if i != j:
-        suffixDest = "_" + str(j)
+      suffixDest = "_" + str(j)
+      if i < j:
+        # use delayed link for lateral connections because c_i is computed
+        # before c_j
         network.link(
-            "L2Column" + suffixSrc, "L2Column" + suffixDest,
-            "UniformLink", "",
-            srcOutput="feedForwardOutput", destInput="lateralInput")
+          "L2Column" + suffixSrc, "L2Column" + suffixDest,
+          "UniformLink", "",
+          srcOutput="feedForwardOutput", destInput="lateralInput",
+          propagationDelay=1)
+      elif i > j:
+        network.link(
+          "L2Column" + suffixSrc, "L2Column" + suffixDest,
+          "UniformLink", "",
+          srcOutput="feedForwardOutput", destInput="lateralInput",
+          propagationDelay=0)
 
   enableProfiling(network)
 


### PR DESCRIPTION
@mrcslws I noticed a bug in the  column pooler. 
During initialization, there is
`self.activeCells = ()` which should correspond to no previously active cells. 

However, if I do this in numpy, 
```
arr = numpy.zeros((10, ))
arr[()] = 1
print arr
```
I filled the entire array with ones. This means at the very first step during inference, the network labeled all cells as "previously active". I tried to fix it in this PR.