### PR TITLE
Capacity of small l4 network

### DIFF
--- a/projects/l2_pooling/capacity_test.py
+++ b/projects/l2_pooling/capacity_test.py
@@ -470,9 +470,6 @@ def runCapacityTestVaryingObjectNum(numPointsPerObject=10,
              numInputBits)
             for numObjects in np.arange(20, 1000, 100)] #np.arange(20, 1371, 150)]
 
-  # for param in params:
-  #   testResult = invokeRunCapacityTest(param)
-  #   print testResult
   for testResult in pool.map(invokeRunCapacityTest, params):
     print testResult
 

--- a/projects/l2_pooling/capacity_test.py
+++ b/projects/l2_pooling/capacity_test.py
@@ -128,16 +128,6 @@ def getL2Params():
 
 
 
-def getL4InputBits(l4ColumnCount):
-  numInputBits = int(l4ColumnCount * 0.02)
-  if l4ColumnCount < 512: # use denser activation for small L4
-    numInputBits = int(l4ColumnCount * 0.08)
-  else:
-    numInputBits = int(l4ColumnCount * 0.02)
-  return numInputBits
-
-
-
 def createRandomObjects(numObjects,
                         numPointsPerObject,
                         numLocations,


### PR DESCRIPTION
Summary of code changes

* Add experiment on capacity of small L4 network
* Add the capability to set L4params and numInputBits for individual experiments
* Track number of active cells in L2 and L4
* Fix bug of overlapTrueObj calculation

Summary of results
* The capacity drops rapidly for very small networks (# MC=150). I think we need at least 256 MCs to be able to store several hundreds of objects. 
* When the network hits its capacity limit. The number of active cells in L2 increase rapidly. 
* The capacity increases with sparser L4. It is almost always better to have sparser activity.
![image](https://cloud.githubusercontent.com/assets/5067931/22953864/ee3e7da8-f2c7-11e6-888f-d998763d3f4a.png)
