### PR TITLE
Fix CLAModel_custom to work with latest network API

### DIFF
--- a/htmresearch/frameworks/opf/clamodel_custom.py
+++ b/htmresearch/frameworks/opf/clamodel_custom.py
@@ -44,6 +44,7 @@ class CLAModel_custom(CLAModel):
     sp.setParameter('learningMode', self._spLearningEnabled)
     sp.prepareInputs()
     sp.compute()
+    sp.purgeInputLinkBufferHeads()
 
   # overide _tpCompute
   def _tpCompute(self):
@@ -63,3 +64,4 @@ class CLAModel_custom(CLAModel):
     tp.setParameter('learningMode', self._tpLearningEnabled)
     tp.prepareInputs()
     tp.compute()
+    tp.purgeInputLinkBufferHeads()


### PR DESCRIPTION
This follows the approach of the CLAModel change
https://github.com/numenta/nupic/commit/97e329f0d2a9a2ccff54ffc88434bcf234511f09

@ywcui1990 I think this should solve the issue. The SP is now receiving the encoder output.

@vitaly-krugl FYI, here's a `CLAModel_custom` class.