### PR TITLE
Fix the regions to match API change in nupic.core

### DIFF
--- a/htmresearch/regions/ColumnPoolerRegion.py
+++ b/htmresearch/regions/ColumnPoolerRegion.py
@@ -315,7 +315,7 @@ class ColumnPoolerRegion(PyRegion):
     PyRegion.__init__(self, **kwargs)
 
 
-  def initialize(self, inputs, outputs):
+  def initialize(self):
     """
     Initialize the internal objects.
     """

--- a/htmresearch/regions/CoordinateSensorRegion.py
+++ b/htmresearch/regions/CoordinateSensorRegion.py
@@ -203,6 +203,6 @@ class CoordinateSensorRegion(PyRegion):
     else:
       raise Exception("Unknown output {}.".format(name))
 
-  def initialize(self, inputs, outputs):
+  def initialize(self):
     """ Initialize the Region - nothing to do here. """
     pass

--- a/htmresearch/regions/ExtendedTMRegion.py
+++ b/htmresearch/regions/ExtendedTMRegion.py
@@ -351,7 +351,7 @@ class ExtendedTMRegion(PyRegion):
     self._tm = None
 
 
-  def initialize(self, dims, splitterMaps):
+  def initialize(self):
     """
     Initialize the self._tm if not already initialized. We need to figure out
     the constructor parameters for each class, and send it to that constructor.

--- a/htmresearch/regions/LanguageSensor.py
+++ b/htmresearch/regions/LanguageSensor.py
@@ -125,7 +125,7 @@ class LanguageSensor(PyRegion):
     return spec
 
 
-  def initialize(self, inputs, outputs):
+  def initialize(self):
     """Initialize the node after the network is fully linked."""
     if self.encoder is None:
       raise Exception("Unable to initialize LanguageSensor -- "

--- a/htmresearch/regions/RawSensor.py
+++ b/htmresearch/regions/RawSensor.py
@@ -183,7 +183,7 @@ class RawSensor(PyRegion):
       raise Exception("Unknown output {}.".format(name))
 
 
-  def initialize(self, inputs, outputs):
+  def initialize(self):
     """ Initialize the Region - nothing to do here. """
     pass
 

--- a/htmresearch/regions/TMRegion.py
+++ b/htmresearch/regions/TMRegion.py
@@ -343,7 +343,7 @@ class TMRegion(PyRegion):
     self._tm = None
 
 
-  def initialize(self, inputs, outputs):
+  def initialize(self):
     """
     Initialize the self._tm if not already initialized. We need to figure out
     the constructor parameters for each class, and send it to that constructor.

--- a/htmresearch/regions/TemporalPoolerRegion.py
+++ b/htmresearch/regions/TemporalPoolerRegion.py
@@ -308,7 +308,7 @@ class TemporalPoolerRegion(PyRegion):
     self._pooler = None
 
 
-  def initialize(self, inputs, outputs):
+  def initialize(self):
     """
     Initialize the self._poolerClass
     """


### PR DESCRIPTION
Currently we get `TypeError: initialize() takes exactly 3 arguments (1 given)` when running any L2-L4 experiments.

This change matches https://github.com/numenta/nupic/pull/3494, but for nupic.research

FYI @oxtopus 