### PR TITLE
Use the same L4->L2 connection for both inference/learning

### DIFF
--- a/htmresearch/frameworks/layers/l2_l4_inference.py
+++ b/htmresearch/frameworks/layers/l2_l4_inference.py
@@ -609,7 +609,6 @@ class L4L2Experiment(object):
       "predictedSegmentDecrement": 0.0,
       "activationThreshold": activationThreshold,
       "maxNewSynapseCount": maxNewSynapseCount,
-      "defaultOutputType": "predictedActiveCells",
       "implementation": "etm_cpp",
       "seed": self.seed
     }
@@ -689,7 +688,6 @@ class L4L2Experiment(object):
     """
     for column in self.L4Columns:
       column.setParameter("learningMode", 0, False)
-      column.setParameter("defaultOutputType", 0, "active")
     for column in self.L2Columns:
       column.setParameter("learningMode", 0, False)
 
@@ -700,7 +698,6 @@ class L4L2Experiment(object):
     """
     for column in self.L4Columns:
       column.setParameter("learningMode", 0, True)
-      column.setParameter("defaultOutputType", 0, "predictedActiveCells")
     for column in self.L2Columns:
       column.setParameter("learningMode", 0, True)
 

--- a/htmresearch/frameworks/layers/l2_l4_network_creation.py
+++ b/htmresearch/frameworks/layers/l2_l4_network_creation.py
@@ -237,9 +237,14 @@ def createL4L2Column(network, networkConfig, suffix=""):
     _linkLateralSPRegion(network, networkConfig, externalInputName, L4ColumnName)
   _linkFeedForwardSPRegion(network, networkConfig, sensorInputName, L4ColumnName)
 
-  # Link L4 to L2, and L2's feedback to L4
+  # Link L4 to L2
   network.link(L4ColumnName, L2ColumnName, "UniformLink", "",
-               srcOutput="feedForwardOutput", destInput="feedforwardInput")
+               srcOutput="activeCells", destInput="feedforwardInput")
+  network.link(L4ColumnName, L2ColumnName, "UniformLink", "",
+               srcOutput="predictedActiveCells",
+               destInput="feedforwardGrowthCandidates")
+
+  # Link L2 feedback to L4
   network.link(L2ColumnName, L4ColumnName, "UniformLink", "",
                srcOutput="feedForwardOutput", destInput="externalApicalInput")
 

--- a/htmresearch/regions/ColumnPoolerRegion.py
+++ b/htmresearch/regions/ColumnPoolerRegion.py
@@ -66,6 +66,18 @@ class ColumnPoolerRegion(PyRegion):
           isDefaultInput=True,
           requireSplitterMap=False),
 
+        feedforwardGrowthCandidates=dict(
+          description=("An array of 0's and 1's representing feedforward input " +
+                       "that can be learned on new proximal synapses. If this " +
+                       "input isn't provided, the whole feedforwardInput is "
+                       "used."),
+          dataType="Real32",
+          count=0,
+          required=False,
+          regionLevel=True,
+          isDefaultInput=False,
+          requireSplitterMap=False),
+
         lateralInput=dict(
           description="Lateral binary input into this column, presumably from"
                       " other neighboring columns.",
@@ -365,6 +377,12 @@ class ColumnPoolerRegion(PyRegion):
     feedforwardInput = numpy.asarray(inputs["feedforwardInput"].nonzero()[0],
                                      dtype="uint32")
 
+    if "feedforwardGrowthCandidates" in inputs:
+      feedforwardGrowthCandidates = numpy.asarray(
+        inputs["feedforwardGrowthCandidates"].nonzero()[0], dtype="uint32")
+    else:
+      feedforwardGrowthCandidates = feedforwardInput
+
     if "lateralInput" in inputs:
       lateralInputs = tuple(numpy.asarray(singleInput.nonzero()[0],
                                           dtype="uint32")
@@ -376,7 +394,7 @@ class ColumnPoolerRegion(PyRegion):
 
     # Send the inputs into the Column Pooler.
     self._pooler.compute(feedforwardInput, lateralInputs,
-                         learn=self.learningMode)
+                         feedforwardGrowthCandidates, learn=self.learningMode)
 
     # Extract the active / predicted cells and put them into binary arrays.
     outputs["activeCells"][:] = 0

--- a/projects/l2_pooling/noise_tolerance_l2_l4.py
+++ b/projects/l2_pooling/noise_tolerance_l2_l4.py
@@ -161,10 +161,6 @@ def doExperiment(numColumns, objects, l2Overrides, noiseLevels, numInitialTraver
            for location in xrange(len(features))])
          for objectName, features in objects.iteritems()))
 
-  # Now that the objects are learned, allow bursting L4 minicolumns to activate
-  # cells in L2.
-  exp.L4Columns[0].setParameter("defaultOutputType", 0, "active")
-
   results = defaultdict(list)
 
   for noiseLevel in noiseLevels:


### PR DESCRIPTION
Stop toggling the "defaultOutputType" on L4. Instead, distinguish between "feedforwardInput" and "feedforwardGrowthCandidates" in L2.

This requires a small change in the learning logic. `increaseRowNonZeroCountsOnOuterTo` is no longer useful because the number of new synapses should be calculated from the number of existing synapses to active inputs, not from the number of existing synapses to "growth candidate" inputs.

This change depends on https://github.com/numenta/nupic.core/pull/1263