### PR TITLE
added inplace=True to resnet

### DIFF
--- a/nupic/research/frameworks/dynamic_sparse/networks/__init__.py
+++ b/nupic/research/frameworks/dynamic_sparse/networks/__init__.py
@@ -24,6 +24,5 @@ from .hebbian_v0 import GSCHeb as GSCHeb_v0
 from .layers import *
 from .main import *
 from .utils import *
-from .resnet import *
 from .wideresnet import *
 from nupic.research.frameworks.pytorch.models.resnets import resnet50

--- a/nupic/research/frameworks/pytorch/models/resnets.py
+++ b/nupic/research/frameworks/pytorch/models/resnets.py
@@ -68,15 +68,13 @@ def default_sparse_params(group_type, number_layers, sparse=False):
     if sparse:
         layer_params = LayerParams(0.25, 1.4, 0.7, 1.0, True, 0.5)
         noact_layer_params = NoactLayerParams(0.5)
-    else:   
+    else:
         layer_params = LayerParams()
         noact_layer_params = NoactLayerParams()
 
     if group_type == BasicBlock:
         params = dict(
-            conv3x3_1=layer_params,
-            conv3x3_2=noact_layer_params,
-            shortcut=layer_params,
+            conv3x3_1=layer_params, conv3x3_2=noact_layer_params, shortcut=layer_params
         )
     elif group_type == Bottleneck:
         params = dict(
@@ -154,7 +152,7 @@ def activation_layer(
             boost_strength=boost_strength,
             boost_strength_factor=boost_strength_factor,
             k_inference_factor=k_inference_factor,
-            local=local
+            local=local,
         )
 
 
@@ -307,13 +305,15 @@ class ResNet(nn.Module):
             num_classes=1000,
             linear_sparse_weights_type="SparseWeights",
             conv_sparse_weights_type="SparseWeights2d",
-            defaults_sparse=False,            
+            defaults_sparse=False,
         )
         defaults.update(config or {})
         self.__dict__.update(defaults)
 
         if not hasattr(self, "sparse_params"):
-            self.sparse_params = default_sparse_params(*cf_dict[str(self.depth)], sparse=self.defaults_sparse)
+            self.sparse_params = default_sparse_params(
+                *cf_dict[str(self.depth)], sparse=self.defaults_sparse
+            )
 
         self.in_planes = 64
 

--- a/nupic/research/frameworks/pytorch/models/resnets.py
+++ b/nupic/research/frameworks/pytorch/models/resnets.py
@@ -56,7 +56,7 @@ NoactLayerParams = namedtuple("NoactLayerParams", ["weights_density"])
 NoactLayerParams.__new__.__defaults__ = (1.0,)
 
 
-def default_sparse_params(group_type, number_layers):
+def default_sparse_params(group_type, number_layers, sparse=False):
     """Creates dictionary with default parameters.
     If sparse_params is passed to the model, default params are not used.
 
@@ -65,27 +65,34 @@ def default_sparse_params(group_type, number_layers):
 
     :returns dictionary with default parameters
     """
+    if sparse:
+        layer_params = LayerParams(0.25, 1.4, 0.7, 1.0, True, 0.5)
+        noact_layer_params = NoactLayerParams(0.5)
+    else:   
+        layer_params = LayerParams()
+        noact_layer_params = NoactLayerParams()
+
     if group_type == BasicBlock:
         params = dict(
-            conv3x3_1=LayerParams(),
-            conv3x3_2=NoactLayerParams(),
-            shortcut=LayerParams(),
+            conv3x3_1=layer_params,
+            conv3x3_2=noact_layer_params,
+            shortcut=layer_params,
         )
     elif group_type == Bottleneck:
         params = dict(
-            conv1x1_1=LayerParams(),
-            conv3x3_2=LayerParams(),
-            conv1x1_3=NoactLayerParams(),
-            shortcut=LayerParams(),
+            conv1x1_1=layer_params,
+            conv3x3_2=layer_params,
+            conv1x1_3=noact_layer_params,
+            shortcut=layer_params,
         )
 
     return dict(
-        stem=LayerParams(),
+        stem=layer_params,
         filters64=[params] * number_layers[0],
         filters128=[params] * number_layers[1],
         filters256=[params] * number_layers[2],
         filters512=[params] * number_layers[3],
-        linear=NoactLayerParams(),
+        linear=noact_layer_params,
     )
 
 
@@ -139,7 +146,7 @@ def activation_layer(
     """Basic activation layer.
     Defaults to ReLU if percent_on is < 0.5. Otherwise KWinners is used."""
     if percent_on >= 0.5:
-        return nn.ReLU()
+        return nn.ReLU(inplace=True)
     else:
         return KWinners2d(
             out,
@@ -300,12 +307,13 @@ class ResNet(nn.Module):
             num_classes=1000,
             linear_sparse_weights_type="SparseWeights",
             conv_sparse_weights_type="SparseWeights2d",
+            defaults_sparse=False,            
         )
         defaults.update(config or {})
         self.__dict__.update(defaults)
 
         if not hasattr(self, "sparse_params"):
-            self.sparse_params = default_sparse_params(*cf_dict[str(self.depth)])
+            self.sparse_params = default_sparse_params(*cf_dict[str(self.depth)], sparse=self.defaults_sparse)
 
         self.in_planes = 64
 


### PR DESCRIPTION
- Adds inplace=True to resnet (saves about 1.5 gb memory in GPU)
- Adds a second set of options, to be able to easily set all layers to have sparse weights + sparse activations. Parameter `defaults_sparse` is initialized to False, so by default the network will be dense. 