### PR TITLE
RES 1228: Refactor management of layer parameters

### DIFF
--- a/nupic/research/frameworks/pytorch/models/resnets.py
+++ b/nupic/research/frameworks/pytorch/models/resnets.py
@@ -144,16 +144,16 @@ def conv_layer(
 
 def activation_layer(
     out,
-    params,
+    layer_params,
     kernel_size=0
 ):
     """Basic activation layer.
-    Defaults to ReLU if `activation_params` are evaluated from `params`.
+    Defaults to ReLU if `activation_params` are evaluated from `layer_params`.
     Otherwise KWinners is used."""
 
-    # Compute params for kwinners activation module.
-    if params is not None:
-        activation_params = params.get_activation_params(0, out, 0)
+    # Compute layer_params for kwinners activation module.
+    if layer_params is not None:
+        activation_params = layer_params.get_activation_params(0, out, 0)
     else:
         activation_params = None
 

--- a/nupic/research/frameworks/pytorch/models/resnets.py
+++ b/nupic/research/frameworks/pytorch/models/resnets.py
@@ -337,11 +337,12 @@ class ResNet(nn.Module):
         )
         defaults.update(config or {})
         self.__dict__.update(defaults)
-
-        self.linear_sparse_weights_type = getattr(
-            nupic_modules, self.linear_sparse_weights_type)
-        self.conv_sparse_weights_type = getattr(
-            nupic_modules, self.conv_sparse_weights_type)
+        if isinstance(self.linear_sparse_weights_type, str):
+            self.linear_sparse_weights_type = getattr(
+                nupic_modules, self.linear_sparse_weights_type)
+        if isinstance(self.conv_sparse_weights_type, str):
+            self.conv_sparse_weights_type = getattr(
+                nupic_modules, self.conv_sparse_weights_type)
 
         if not hasattr(self, "sparse_params"):
             self.sparse_params = default_sparse_params(

--- a/nupic/research/frameworks/pytorch/models/resnets.py
+++ b/nupic/research/frameworks/pytorch/models/resnets.py
@@ -23,8 +23,9 @@
 
 from collections import namedtuple
 
-import nupic.torch.modules as nupic_modules
 import torch.nn as nn
+
+import nupic.torch.modules as nupic_modules
 from nupic.research.frameworks.pytorch.sparse_layer_params import (
     LayerParams,
     auto_sparse_activation_params,

--- a/nupic/research/frameworks/pytorch/models/resnets.py
+++ b/nupic/research/frameworks/pytorch/models/resnets.py
@@ -90,7 +90,7 @@ def linear_layer(input_size, output_size, layer_params, sparse_weights_type):
     layer = nn.Linear(input_size, output_size)
 
     # Compute params for sparse-weights module.
-    if layer_params:
+    if layer_params is not None:
         weight_params = layer_params.get_linear_params(
             input_size,
             output_size,
@@ -99,7 +99,7 @@ def linear_layer(input_size, output_size, layer_params, sparse_weights_type):
         weight_params = None
 
     # Initialize sparse-weights module as specified.
-    if weight_params:
+    if weight_params is not None:
         return sparse_weights_type(layer, **weight_params)
     else:
         return layer
@@ -126,7 +126,7 @@ def conv_layer(
     )
 
     # Compute params for sparse-weights module.
-    if layer_params:
+    if layer_params is not None:
         weight_params = layer_params.get_conv_params(
             in_planes,
             out_planes,
@@ -136,7 +136,7 @@ def conv_layer(
         weight_params = None
 
     # Initialize sparse-weights module as specified.
-    if weight_params:
+    if weight_params is not None:
         return sparse_weights_type(layer, **weight_params)
     else:
         return layer
@@ -152,13 +152,13 @@ def activation_layer(
     Otherwise KWinners is used."""
 
     # Compute params for kwinners activation module.
-    if params:
+    if params is not None:
         activation_params = params.get_activation_params(0, out, 0)
     else:
         activation_params = None
 
     # Initialize kwinners module as specified.
-    if activation_params:
+    if activation_params is not None:
         return nn.Sequential(
             KWinners2d(
                 out,

--- a/nupic/research/frameworks/pytorch/sparse_layer_params.py
+++ b/nupic/research/frameworks/pytorch/sparse_layer_params.py
@@ -28,7 +28,7 @@ def auto_sparse_conv_params(in_channels, out_channels, kernel_size):
     Note:
     This is highly experimental and likely to change.
 
-    :return: an instance of LayerParams
+    :return: a dict to pass to `SparseWeights2d`
     """
     weights_per_channel = kernel_size * kernel_size * in_channels
     if weights_per_channel < 100:

--- a/nupic/research/frameworks/pytorch/sparse_layer_params.py
+++ b/nupic/research/frameworks/pytorch/sparse_layer_params.py
@@ -188,7 +188,7 @@ class LayerParamsByKeys(LayerParams):
 
         linear_params_keys = [
             (
-                "linear_sparisty",  # <key name to pass to OtherParams.__init__>
+                "linear_sparsity",  # <key name to pass to OtherParams.__init__>
                 0.5                 # <default_value>
             )
         ]
@@ -210,13 +210,13 @@ class LayerParamsByKeys(LayerParams):
     p = OtherParams(conv_sparsity=0.7)
     print(p)
     >>> OtherParams(
-        linear_params={"linear_sparisty": 0.5},
+        linear_params={"linear_sparsity": 0.5},
         conv_params={"weight_sparsity": 0.7},
         activation_params={}
     )
     ```
 
-    In the above example, notice how "linear_sparisty" gets a default value despite not
+    In the above example, notice how "linear_sparsity" gets a default value despite not
     being passed to `OtherParams.__init__`. Also, notice how "weight_sparsity" gets
     saved for the `conv_params` but it's passed to `OtherParams.__init__` as
     `conv_sparsity`.

--- a/nupic/research/frameworks/pytorch/sparse_layer_params.py
+++ b/nupic/research/frameworks/pytorch/sparse_layer_params.py
@@ -127,30 +127,30 @@ class LayerParams(object):
 
     def get_linear_params(self, *args, **params):
 
-        if self.linear_params_func:
+        if self.linear_params_func is not None:
             return self.linear_params_func(*args, **params)
-        elif self.default_linear_params:
+        elif self.default_linear_params is not None:
             return self.default_linear_params
         else:
-            return {}
+            return None
 
     def get_conv_params(self, *args, **params):
 
-        if self.conv_params_func:
+        if self.conv_params_func is not None:
             return self.conv_params_func(*args, **params)
-        elif self.default_conv_params:
+        elif self.default_conv_params is not None:
             return self.default_conv_params
         else:
-            return {}
+            return None
 
     def get_activation_params(self, *args, **params):
 
-        if self.activation_params_func:
+        if self.activation_params_func is not None:
             return self.activation_params_func(*args, **params)
-        elif self.default_activation_params:
+        elif self.default_activation_params is not None:
             return self.default_activation_params
         else:
-            return {}
+            return None
 
 
 class LayerParamsByKeys(LayerParams):
@@ -291,7 +291,7 @@ class LayerParamsByKeys(LayerParams):
             elif default_value is not ...:
                 key_values[target_name] = default_value
 
-        return key_values
+        return key_values or None
 
 
 class SpareWeightsLayerParams(LayerParamsByKeys):

--- a/nupic/research/frameworks/pytorch/sparse_layer_params.py
+++ b/nupic/research/frameworks/pytorch/sparse_layer_params.py
@@ -280,7 +280,7 @@ class LayerParamsByKeys(LayerParams):
                 key, default_value, target_name = (key + (None, ) * 3)[:3]
             else:
                 target_name = None
-                default_value = None
+                default_value = ...
 
             target_name = target_name or key
             if key in d:

--- a/nupic/research/frameworks/pytorch/sparse_layer_params.py
+++ b/nupic/research/frameworks/pytorch/sparse_layer_params.py
@@ -19,37 +19,13 @@
 # http://numenta.org/licenses/
 # ----------------------------------------------------------------------
 
-from collections import namedtuple
 
-# Defines sparse params for regular layers with activations
-# If params_function is not None, it should be called to calculate the actual
-# parameters. Useful for large networks such as ResNet where it's hard to tune
-# each layer manually.
-LayerParams = namedtuple(
-    "LayerParams",
-    [
-        "percent_on",
-        "boost_strength",
-        "boost_strength_factor",
-        "k_inference_factor",
-        "local",
-        "weights_density",
-        "params_function",
-    ],
-)
-
-# Defaults to a dense layer
-LayerParams.__new__.__defaults__ = (1.0, 1.4, 0.7, 1.0, True, 1.0, None)
-
-# Defines default sparse params for layers without activations
-NoactLayerParams = namedtuple("NoactLayerParams",
-                              ["weights_density", "params_function"])
-NoactLayerParams.__new__.__defaults__ = (1.0, None)
-
-
-def auto_sparse_params(in_channels, out_channels, kernel_size):
+def auto_sparse_conv_params(in_channels, out_channels, kernel_size):
     """
-    Given conv2d parameters, automatically calculate sparsity parameters.
+    Given conv2d parameters, automatically calculate sparsity parameters
+    for `SparseWeights2d` module.
+
+    Note:
     This is highly experimental and likely to change.
 
     :return: an instance of LayerParams
@@ -76,16 +52,285 @@ def auto_sparse_params(in_channels, out_channels, kernel_size):
     else:
         weights_density = 0.2
 
+    return dict(
+        weight_sparsity=weights_density,
+    )
+
+
+def auto_sparse_activation_params(in_channels, out_channels, kernel_size):
+    """
+    Given conv2d parameters, automatically calculate sparsity parameters
+    for the `KWinners2d` activation layer to follow.
+
+    Note:
+    This is highly experimental and likely to change.
+
+    :return: a dict to pass to `KWinners2d` as params.
+    """
+
     if out_channels > 64:
         percent_on = 0.2
     else:
         percent_on = 0.3
 
-    return LayerParams(
+    return dict(
         percent_on=percent_on,
         boost_strength=1.5,
         boost_strength_factor=0.95,
         local=True,
-        weights_density=weights_density,
-        params_function=None
     )
+
+
+class LayerParams(object):
+    """
+    Class to manage a layer's parameters.
+
+    Specifically, this class helps one specify separate parameters for
+    convolutional, linear, and activation layers. For each respective
+    layer typer, either of the following may be specified
+    1) a function which takes arbitrary inputs and outputs a dictionary, or
+    2) a predefined dictionary.
+
+    Accordingly, the former (1) of the two takes precedent
+    when determining the desired set of parameters and both 1 and 2
+    are specified. If neither are specified, then an empty dictionary is returned.
+    """
+
+    def __init__(
+        self,
+        default_linear_params=None,
+        default_conv_params=None,
+        default_activation_params=None,
+        linear_params_func=None,
+        conv_params_func=None,
+        activation_params_func=None,
+    ):
+        self.default_linear_params = default_linear_params
+        self.default_conv_params = default_conv_params
+        self.default_activation_params = default_activation_params
+        self.linear_params_func = linear_params_func
+        self.conv_params_func = conv_params_func
+        self.activation_params_func = activation_params_func
+
+    def __repr__(self):
+
+        lin_source = self.linear_params_func or self.default_linear_params
+        conv_source = self.conv_params_func or self.default_conv_params
+        act_source = self.activation_params_func or self.default_activation_params
+        return self.__class__.__name__ + \
+            "(\n\tlinear_params={},\n\tconv_params={},\n\tactivation_params={})".format(
+                repr(lin_source), repr(conv_source), repr(act_source)
+            )
+
+    def get_linear_params(self, *args, **params):
+
+        if self.linear_params_func:
+            return self.linear_params_func(*args, **params)
+        elif self.default_linear_params:
+            return self.default_linear_params
+        else:
+            return {}
+
+    def get_conv_params(self, *args, **params):
+
+        if self.conv_params_func:
+            return self.conv_params_func(*args, **params)
+        elif self.default_conv_params:
+            return self.default_conv_params
+        else:
+            return {}
+
+    def get_activation_params(self, *args, **params):
+
+        if self.activation_params_func:
+            return self.activation_params_func(*args, **params)
+        elif self.default_activation_params:
+            return self.default_activation_params
+        else:
+            return {}
+
+
+class LayerParamsByKeys(LayerParams):
+    """
+    Class for creating easier to handle instances of `LayerParams` for
+    specific cases. For instance, sub-classes may be handled as
+
+    Example 1:
+    ```
+    p = MyParams(a=2, b=3, c=2)
+    print(p)
+    >>> MyParams(
+        linear_params={'a':2},
+        conv_params={},
+        activation_params={'b':3, 'c':2})
+    ```
+    where the mapping between a, b, and c, to linear, conv, or activation params
+    is known from the user-specification of MyParams. Such definitions with
+    this class are relatively straightforward.
+
+    Example 2:
+    ```
+    class MyParams(LayerParamsByKeys):
+        linear_params_keys = ["a"]
+        activation_params = ["b", "c"]
+    ```
+
+    This example creates the params as seen above in Example 1.
+    We may also specify default arguments and alternative key-words
+    for saving a our params.
+
+    Example 3:
+    ```
+    class OtherParams(LayerParamsByKeys):
+
+        linear_params_keys = [
+            (
+                "linear_sparisty",  # <key name to pass to OtherParams.__init__>
+                0.5                 # <default_value>
+            )
+        ]
+        conv_params_keys = [
+            (
+                "conv_sparsity",   # <key name to pass to OtherParams.__init__>
+                0.1,               # <default_value>
+                "weight_sparsity"  # "<target name for saving to `default_conv_params`>"
+            )
+        ]
+        activation_params_keys = [
+            (
+                "activation_sparsity",  # <key name to pass to OtherParams.__init__>
+                ...,                    # `...` => No Default
+                "percent_on"            # "<target name for saving>"
+            )
+        ]
+
+    p = OtherParams(conv_sparsity=0.7)
+    print(p)
+    >>> OtherParams(
+        linear_params={"linear_sparisty": 0.5},
+        conv_params={"weight_sparsity": 0.7},
+        activation_params={}
+    )
+    ```
+
+    In the above example, notice how "linear_sparisty" gets a default value despite not
+    being passed to `OtherParams.__init__`. Also, notice how "weight_sparsity" gets
+    saved for the `conv_params` but it's passed to `OtherParams.__init__` as
+    `conv_sparsity`.
+
+    This kind of behavior is useful when the params for the linear, conv, or,
+    activations layers share the same name. For example, both `SparseWeights` and
+    `SparseWeights2d` take a `weight_sparsity` param, so it may help to pass them
+    as `lin_sparsity` and `conv_sparsity`, yet save them both as `weight_sparsity`
+    in their respective parameter dictionaries.
+
+    Finally, note that a `activation_params` remains empty in Example 3.
+    Despite have an entry for the default value, the value of `...` is treated
+    as if no default has been specified. This way, one may specify a target-name
+    for saving without having to specify a default value as well.
+    """
+
+    def __init__(
+        self,
+        linear_params_func=None,
+        conv_params_func=None,
+        activation_params_func=None,
+        **kwargs,
+    ):
+
+        self.linear_params_func = linear_params_func
+        self.conv_params_func = conv_params_func
+        self.activation_params_func = activation_params_func
+
+        if hasattr(self, "linear_params_keys"):
+            self.default_linear_params = self._get_values_from_dict(
+                kwargs, self.linear_params_keys
+            )
+        else:
+            self.default_linear_params = None
+
+        if hasattr(self, "conv_params_keys"):
+            self.default_conv_params = self._get_values_from_dict(
+                kwargs, self.conv_params_keys
+            )
+        else:
+            self.default_conv_params = None
+
+        if hasattr(self, "activation_params_keys"):
+            self.default_activation_params = self._get_values_from_dict(
+                kwargs, self.activation_params_keys
+            )
+        else:
+            self.default_activation_params = None
+
+    def _get_values_from_dict(self, d, keys):
+        """
+        Creates dict of key value pairs collected from the specified 'keys' of 'd'.
+
+        Note that if a key is presented as a tuple (e.g. ("some_key", <value>)), then
+        the first value will be interpreted as the key, and the second will be
+        interpreted as the default value. Additionally, any third value of the tuple
+        will be interpreted as a the `target_name` for the key. That is, although
+        `key in d` may be true, it will be saved as `key_value[target_name] = value`.
+        """
+        key_values = {}
+        for key in keys:
+
+            if isinstance(key, tuple):
+                key, default_value, target_name = (key + (None, ) * 3)[:3]
+            else:
+                target_name = None
+                default_value = None
+
+            target_name = target_name or key
+            if key in d:
+                key_values[target_name] = d[key]
+            elif default_value is not ...:
+                key_values[target_name] = default_value
+
+        return key_values
+
+
+class SpareWeightsLayerParams(LayerParamsByKeys):
+    """
+    LayerParams class for specifying parameters to
+    `SparseWeights` (linear params), `SparseWeights2d` (conv params)
+    and `KWinners2d` (activation params).
+
+    Example:
+    ```
+        sw = SpareWeightsLayerParams(
+        percent_on=0.3,
+        boost_strength=1.2,
+        boost_strength_factor=1.0,
+        local=False,
+        linear_weight_sparsity=0.3,
+        conv_params_func=auto_sparse_conv_params,
+    )
+
+    print(sw)
+    >>> SpareWeightsLayerParams(
+            linear_params={'weight_sparsity': 0.3},
+            conv_params=<function auto_sparse_conv_params at 0x10b4a1830>,
+            activation_params={
+                'percent_on': 0.3,
+                'boost_strength': 1.2,
+                'boost_strength_factor': 1.0,
+                'local': False
+            }
+        )
+    """
+
+    linear_params_keys = [
+        ("linear_weight_sparsity", ..., "weight_sparsity")  # ... => no default
+    ]
+    conv_params_keys = [
+        ("conv_weight_sparsity", ..., "weight_sparsity")  # ... => no default
+    ]
+    activation_params_keys = [
+        "percent_on",
+        "boost_strength",
+        "boost_strength_factor",
+        "k_inference_factor",
+        "local",
+    ]

--- a/nupic/research/frameworks/pytorch/sparse_layer_params.py
+++ b/nupic/research/frameworks/pytorch/sparse_layer_params.py
@@ -294,7 +294,7 @@ class LayerParamsByKeys(LayerParams):
         return key_values or None
 
 
-class SpareWeightsLayerParams(LayerParamsByKeys):
+class SparseWeightsLayerParams(LayerParamsByKeys):
     """
     LayerParams class for specifying parameters to
     `SparseWeights` (linear params), `SparseWeights2d` (conv params)
@@ -302,7 +302,7 @@ class SpareWeightsLayerParams(LayerParamsByKeys):
 
     Example:
     ```
-        sw = SpareWeightsLayerParams(
+        sw = SparseWeightsLayerParams(
         percent_on=0.3,
         boost_strength=1.2,
         boost_strength_factor=1.0,
@@ -312,7 +312,7 @@ class SpareWeightsLayerParams(LayerParamsByKeys):
     )
 
     print(sw)
-    >>> SpareWeightsLayerParams(
+    >>> SparseWeightsLayerParams(
             linear_params={'weight_sparsity': 0.3},
             conv_params=<function auto_sparse_conv_params at 0x10b4a1830>,
             activation_params={

--- a/tests/unit/frameworks/pytorch/resnets_test.py
+++ b/tests/unit/frameworks/pytorch/resnets_test.py
@@ -24,8 +24,6 @@ import torch
 import torch.nn
 from nupic.research.frameworks.pytorch.models.resnets import (
     ResNet,
-    cf_dict,
-    default_sparse_params,
     resnet18,
     resnet50,
     resnet101,
@@ -52,15 +50,6 @@ class ResnetTest(unittest.TestCase):
         net = resnet50(config=dict(num_classes=10, defaults_sparse=True))
         net(Variable(torch.randn(2, 3, 32, 32)))
         self.assertIsInstance(net, ResNet, "ResNet50 with default sparse parameters")
-
-    def test_default_params(self):
-        """Test default params."""
-        params = default_sparse_params(*cf_dict["50"])
-        # self.assertEqual(params["stem"].percent_on, 1.0)
-
-        # For sparse, the params_function should be set.
-        params = default_sparse_params(*cf_dict["50"], sparse=True)
-        # self.assertIsNotNone(params["stem"].params_function)
 
     def test_custom_per_group(self):
         """Evaluate ResNets customized per group"""

--- a/tests/unit/frameworks/pytorch/resnets_test.py
+++ b/tests/unit/frameworks/pytorch/resnets_test.py
@@ -22,10 +22,7 @@ import unittest
 
 import torch
 import torch.nn
-from torch.autograd import Variable
-
 from nupic.research.frameworks.pytorch.models.resnets import (
-    LayerParams,
     ResNet,
     cf_dict,
     default_sparse_params,
@@ -33,7 +30,11 @@ from nupic.research.frameworks.pytorch.models.resnets import (
     resnet50,
     resnet101,
 )
-from nupic.research.frameworks.pytorch.sparse_layer_params import NoactLayerParams
+from nupic.research.frameworks.pytorch.sparse_layer_params import (
+    LayerParams,
+    SpareWeightsLayerParams,
+)
+from torch.autograd import Variable
 
 
 class ResnetTest(unittest.TestCase):
@@ -55,54 +56,54 @@ class ResnetTest(unittest.TestCase):
     def test_default_params(self):
         """Test default params."""
         params = default_sparse_params(*cf_dict["50"])
-        self.assertEqual(params["stem"].percent_on, 1.0)
+        # self.assertEqual(params["stem"].percent_on, 1.0)
 
         # For sparse, the params_function should be set.
         params = default_sparse_params(*cf_dict["50"], sparse=True)
-        self.assertIsNotNone(params["stem"].params_function)
+        # self.assertIsNotNone(params["stem"].params_function)
 
     def test_custom_per_group(self):
         """Evaluate ResNets customized per group"""
 
         custom_sparse_params = dict(
-            stem=LayerParams(),
+            stem=SpareWeightsLayerParams(),
             filters64=dict(
-                conv1x1_1=LayerParams(
+                conv1x1_1=SpareWeightsLayerParams(
                     percent_on=0.3,
                     boost_strength=1.2,
                     boost_strength_factor=1.0,
                     local=False,
-                    weights_density=0.3,
+                    weight_sparsity=0.3,
                 ),
-                conv3x3_2=LayerParams(
+                conv3x3_2=SpareWeightsLayerParams(
                     percent_on=0.1,
                     boost_strength=1.2,
                     boost_strength_factor=1.0,
                     local=True,
-                    weights_density=0.1,
+                    weight_sparsity=0.1,
                 ),
-                conv1x1_3=NoactLayerParams(weights_density=0.1),
-                shortcut=LayerParams(percent_on=0.4, weights_density=0.4),
+                conv1x1_3=SpareWeightsLayerParams(weight_sparsity=0.1),
+                shortcut=SpareWeightsLayerParams(percent_on=0.4, weight_sparsity=0.4),
             ),
             filters128=dict(
                 conv1x1_1=LayerParams(),
                 conv3x3_2=LayerParams(),
-                conv1x1_3=NoactLayerParams(),
+                conv1x1_3=LayerParams(),
                 shortcut=LayerParams(),
             ),
             filters256=dict(
                 conv1x1_1=LayerParams(),
                 conv3x3_2=LayerParams(),
-                conv1x1_3=NoactLayerParams(),
+                conv1x1_3=LayerParams(),
                 shortcut=LayerParams(),
             ),
             filters512=dict(
                 conv1x1_1=LayerParams(),
                 conv3x3_2=LayerParams(),
-                conv1x1_3=NoactLayerParams(),
+                conv1x1_3=LayerParams(),
                 shortcut=LayerParams(),
             ),
-            linear=NoactLayerParams(weights_density=0.5),
+            linear=SpareWeightsLayerParams(weight_sparsity=0.5),
         )
 
         net = ResNet(
@@ -119,27 +120,27 @@ class ResnetTest(unittest.TestCase):
             stem=LayerParams(),
             filters64=[  # 3 blocks
                 dict(
-                    conv1x1_1=LayerParams(
+                    conv1x1_1=SpareWeightsLayerParams(
                         percent_on=0.3,
                         boost_strength=1.2,
                         boost_strength_factor=1.0,
                         local=False,
-                        weights_density=0.3,
+                        weight_sparsity=0.3,
                     ),
                     conv3x3_2=LayerParams(),
-                    conv1x1_3=NoactLayerParams(),
+                    conv1x1_3=LayerParams(),
                     shortcut=LayerParams(),
                 ),
                 dict(
                     conv1x1_1=LayerParams(),
                     conv3x3_2=LayerParams(),
-                    conv1x1_3=NoactLayerParams(),
+                    conv1x1_3=LayerParams(),
                     shortcut=LayerParams(),
                 ),
                 dict(
                     conv1x1_1=LayerParams(),
                     conv3x3_2=LayerParams(),
-                    conv1x1_3=NoactLayerParams(),
+                    conv1x1_3=LayerParams(),
                     shortcut=LayerParams(),
                 ),
             ],
@@ -147,25 +148,25 @@ class ResnetTest(unittest.TestCase):
                 dict(
                     conv1x1_1=LayerParams(),
                     conv3x3_2=LayerParams(),
-                    conv1x1_3=NoactLayerParams(),
+                    conv1x1_3=LayerParams(),
                     shortcut=LayerParams(),
                 ),
                 dict(
                     conv1x1_1=LayerParams(),
                     conv3x3_2=LayerParams(),
-                    conv1x1_3=NoactLayerParams(),
+                    conv1x1_3=LayerParams(),
                     shortcut=LayerParams(),
                 ),
                 dict(
                     conv1x1_1=LayerParams(),
                     conv3x3_2=LayerParams(),
-                    conv1x1_3=NoactLayerParams(),
+                    conv1x1_3=LayerParams(),
                     shortcut=LayerParams(),
                 ),
                 dict(
                     conv1x1_1=LayerParams(),
                     conv3x3_2=LayerParams(),
-                    conv1x1_3=NoactLayerParams(),
+                    conv1x1_3=LayerParams(),
                     shortcut=LayerParams(),
                 ),
             ],
@@ -173,37 +174,37 @@ class ResnetTest(unittest.TestCase):
                 dict(
                     conv1x1_1=LayerParams(),
                     conv3x3_2=LayerParams(),
-                    conv1x1_3=NoactLayerParams(),
+                    conv1x1_3=LayerParams(),
                     shortcut=LayerParams(),
                 ),
                 dict(
                     conv1x1_1=LayerParams(),
                     conv3x3_2=LayerParams(),
-                    conv1x1_3=NoactLayerParams(),
+                    conv1x1_3=LayerParams(),
                     shortcut=LayerParams(),
                 ),
                 dict(
                     conv1x1_1=LayerParams(),
                     conv3x3_2=LayerParams(),
-                    conv1x1_3=NoactLayerParams(),
+                    conv1x1_3=LayerParams(),
                     shortcut=LayerParams(),
                 ),
                 dict(
                     conv1x1_1=LayerParams(),
                     conv3x3_2=LayerParams(),
-                    conv1x1_3=NoactLayerParams(),
+                    conv1x1_3=LayerParams(),
                     shortcut=LayerParams(),
                 ),
                 dict(
                     conv1x1_1=LayerParams(),
                     conv3x3_2=LayerParams(),
-                    conv1x1_3=NoactLayerParams(),
+                    conv1x1_3=LayerParams(),
                     shortcut=LayerParams(),
                 ),
                 dict(
                     conv1x1_1=LayerParams(),
                     conv3x3_2=LayerParams(),
-                    conv1x1_3=NoactLayerParams(),
+                    conv1x1_3=LayerParams(),
                     shortcut=LayerParams(),
                 ),
             ],
@@ -211,23 +212,23 @@ class ResnetTest(unittest.TestCase):
                 dict(
                     conv1x1_1=LayerParams(),
                     conv3x3_2=LayerParams(),
-                    conv1x1_3=NoactLayerParams(),
+                    conv1x1_3=LayerParams(),
                     shortcut=LayerParams(),
                 ),
                 dict(
                     conv1x1_1=LayerParams(),
                     conv3x3_2=LayerParams(),
-                    conv1x1_3=NoactLayerParams(),
+                    conv1x1_3=LayerParams(),
                     shortcut=LayerParams(),
                 ),
                 dict(
                     conv1x1_1=LayerParams(),
                     conv3x3_2=LayerParams(),
-                    conv1x1_3=NoactLayerParams(),
+                    conv1x1_3=LayerParams(),
                     shortcut=LayerParams(),
                 ),
             ],
-            linear=NoactLayerParams(),
+            linear=LayerParams(),
         )
 
         net = ResNet(

--- a/tests/unit/frameworks/pytorch/resnets_test.py
+++ b/tests/unit/frameworks/pytorch/resnets_test.py
@@ -33,7 +33,7 @@ from nupic.research.frameworks.pytorch.models.resnets import (
 )
 from nupic.research.frameworks.pytorch.sparse_layer_params import (
     LayerParams,
-    SpareWeightsLayerParams,
+    SparseWeightsLayerParams,
 )
 
 
@@ -82,24 +82,24 @@ class ResnetTest(unittest.TestCase):
         """Evaluate ResNets customized per group"""
 
         custom_sparse_params = dict(
-            stem=SpareWeightsLayerParams(),
+            stem=SparseWeightsLayerParams(),
             filters64=dict(
-                conv1x1_1=SpareWeightsLayerParams(
+                conv1x1_1=SparseWeightsLayerParams(
                     percent_on=0.3,
                     boost_strength=1.2,
                     boost_strength_factor=1.0,
                     local=False,
                     weight_sparsity=0.3,
                 ),
-                conv3x3_2=SpareWeightsLayerParams(
+                conv3x3_2=SparseWeightsLayerParams(
                     percent_on=0.1,
                     boost_strength=1.2,
                     boost_strength_factor=1.0,
                     local=True,
                     weight_sparsity=0.1,
                 ),
-                conv1x1_3=SpareWeightsLayerParams(weight_sparsity=0.1),
-                shortcut=SpareWeightsLayerParams(percent_on=0.4, weight_sparsity=0.4),
+                conv1x1_3=SparseWeightsLayerParams(weight_sparsity=0.1),
+                shortcut=SparseWeightsLayerParams(percent_on=0.4, weight_sparsity=0.4),
             ),
             filters128=dict(
                 conv1x1_1=LayerParams(),
@@ -119,7 +119,7 @@ class ResnetTest(unittest.TestCase):
                 conv1x1_3=LayerParams(),
                 shortcut=LayerParams(),
             ),
-            linear=SpareWeightsLayerParams(weight_sparsity=0.5),
+            linear=SparseWeightsLayerParams(weight_sparsity=0.5),
         )
 
         net = ResNet(
@@ -136,7 +136,7 @@ class ResnetTest(unittest.TestCase):
             stem=LayerParams(),
             filters64=[  # 3 blocks
                 dict(
-                    conv1x1_1=SpareWeightsLayerParams(
+                    conv1x1_1=SparseWeightsLayerParams(
                         percent_on=0.3,
                         boost_strength=1.2,
                         boost_strength_factor=1.0,

--- a/tests/unit/frameworks/pytorch/resnets_test.py
+++ b/tests/unit/frameworks/pytorch/resnets_test.py
@@ -22,6 +22,8 @@ import unittest
 
 import torch
 import torch.nn
+from torch.autograd import Variable
+
 from nupic.research.frameworks.pytorch.models.resnets import (
     ResNet,
     resnet18,
@@ -32,7 +34,6 @@ from nupic.research.frameworks.pytorch.sparse_layer_params import (
     LayerParams,
     SpareWeightsLayerParams,
 )
-from torch.autograd import Variable
 
 
 class ResnetTest(unittest.TestCase):


### PR DESCRIPTION
This pull request makes changes to the way parameters are managed, generally and specifically targeted for use in `resnets.py`.

Changes include:
* Separate param functionality  for conv, linear, and activation layers.
* `auto_sparse_parms` is now split into `auto_sparse_conv_params` and `auto_sparse_activation_params`
* `LayerParams` is now an abstract class which handles parameter specification for conv, linear, and activation layers through either a default dictionary or a function with arbitrary inputs.
* `LayerParamsByKeys` is introduced for easier management of parameters in specific use cases -`SpareWeightsLayerParams` is one specific use case.
* Both `resnets.py` and its tests have been refactored to conform to these changes.