### PR TITLE
RES-1241: Group trial into nodes as much as possible using custom `RayTrialExecutor`

### DIFF
--- a/nupic/research/frameworks/pytorch/imagenet/imagenet_tune.py
+++ b/nupic/research/frameworks/pytorch/imagenet/imagenet_tune.py
@@ -83,8 +83,10 @@ class AffinityExecutor(RayTrialExecutor):
 
     def _commit_resources(self, resources):
         resources = copy.deepcopy(resources)
-        # FIXME: _commit_resources ignores extra_custom_resources
-        # if key is missing from custom_resources
+        # Make sure "custom_resources" keys match "extra_custom_resources" keys
+        # because `RayTrialExecutor._commit_resources` will only commit
+        # resources from "extra_custom_resources" if the same resource key
+        # is present in the "custom_resources" dict
         for k in resources.extra_custom_resources:
             if k not in resources.custom_resources:
                 resources.custom_resources[k] = 0.0

--- a/nupic/research/frameworks/pytorch/imagenet/imagenet_tune.py
+++ b/nupic/research/frameworks/pytorch/imagenet/imagenet_tune.py
@@ -22,12 +22,146 @@ import os
 from pprint import pprint
 
 import ray
-from ray.tune import Trainable, tune
+from ray import ray_constants
+from ray.resource_spec import ResourceSpec
+from ray.tune import Trainable, tune, TuneError
+from ray.tune.ray_trial_executor import RayTrialExecutor, RESOURCE_REFRESH_PERIOD
 from ray.tune.resources import Resources
 
 from nupic.research.frameworks.pytorch.imagenet import ImagenetExperiment
 
 os.environ["HDF5_USE_FILE_LOCKING"] = "FALSE"
+
+
+def _get_resources_per_node():
+    """
+    Maps node id to available resources on that node
+    :return: dict with available :class:`Resources` for each node
+    """
+    def _is_node_key(k):
+        return k.startswith(ray.resource_spec.NODE_ID_PREFIX)
+
+    # Only consider active/alive nodes
+    nodes = filter(lambda node: node["Alive"], ray.nodes())
+    resources = map(lambda node: node["Resources"], nodes)
+
+    # Group resources by node
+    resources_by_node = {}
+    for item in resources:
+        node_id = next(filter(_is_node_key, item.keys()))
+
+        item = item.copy()
+        num_cpus = item.pop("CPU", 0)
+        num_gpus = item.pop("GPU", 0)
+        memory = ray_constants.from_memory_units(item.pop("memory", 0))
+        object_store_memory = ray_constants.from_memory_units(
+            item.pop("object_store_memory", 0))
+        custom_resources = item
+
+        resources_by_node[node_id] = Resources(
+            int(num_cpus),
+            int(num_gpus),
+            memory=int(memory),
+            object_store_memory=int(object_store_memory),
+            custom_resources=custom_resources)
+
+    return resources_by_node
+
+
+class AffinityExecutor(RayTrialExecutor):
+    """
+    Ray Trial Executor used to set node affinity to node trials.
+    This trial executor will update the trial configuration with one extra
+    parameter (__ray_node_affinity__) that can be used to launch extra workers
+    on the same node.
+    """
+
+    def __init__(self, queue_trials=False, reuse_actors=False, ray_auto_init=False,
+                 refresh_period=RESOURCE_REFRESH_PERIOD):
+        self._resources_by_node = {}
+        super().__init__(queue_trials, reuse_actors, ray_auto_init, refresh_period)
+
+    def _commit_resources(self, resources):
+        resources = copy.deepcopy(resources)
+        # FIXME: _commit_resources ignores extra_custom_resources
+        # if key is missing from custom_resources
+        for k, v in resources.extra_custom_resources.items():
+            if k not in resources.custom_resources:
+                resources.custom_resources[k] = 0.0
+
+        super()._commit_resources(resources)
+
+    def _update_avail_resources(self, num_retries=5):
+        super()._update_avail_resources(num_retries)
+        self._resources_by_node = _get_resources_per_node()
+
+    def start_trial(self, trial, checkpoint=None):
+        # Reserve node before starting trial
+        resources = trial.resources
+
+        # Check for required GPUs first
+        required = resources.gpu_total()
+        if required > 0:
+            resource_attr = "gpu"
+        else:
+            # No GPU, just use CPU
+            resource_attr = "cpu"
+            required = resources.cpu_total()
+
+        # Compute nodes required to fulfill trial resources request
+        custom_resources = {}
+        for node_id, node_resource in self._resources_by_node.items():
+            # Compute resource remaining on each node
+            node_capacity = node_resource.get_res_total(node_id)
+            committed_capacity = self._committed_resources.get_res_total(node_id)
+            remaining_capacity = node_capacity - committed_capacity
+            node_procs = getattr(node_resource, resource_attr, 0)
+            available = node_procs * remaining_capacity
+
+            if available == 0:
+                continue
+
+            if required <= available:
+                custom_resources[node_id] = required / node_procs
+                required = 0
+                break
+            else:
+                custom_resources[node_id] = node_capacity
+                required -= available
+
+        if required > 0:
+            raise TuneError(f"Unable to start trial {trial.trial_id}. Not enough nodes")
+
+        # Update trial node affinity configuration and extra_custom_resources requirement
+        trial.config.update(__ray_node_affinity__=custom_resources)
+        trial.resources.extra_custom_resources.update(custom_resources)
+        super().start_trial(trial, checkpoint)
+
+    def has_resources(self, resources):
+        if not super().has_resources(resources):
+            return False
+
+        # Check for required GPUs first
+        required = resources.gpu_total()
+        if required > 0:
+            resource_attr = "gpu"
+        else:
+            # No GPU, just use CPU
+            resource_attr = "cpu"
+            required = resources.cpu_total()
+
+        # Compute nodes required to fulfill trial resources request
+        for node_id, node_resource in self._resources_by_node.items():
+            node_capacity = node_resource.get_res_total(node_id)
+            committed_capacity = self._committed_resources.get_res_total(node_id)
+            remaining_capacity = node_capacity - committed_capacity
+            node_procs = getattr(node_resource, resource_attr, 0)
+            available = node_procs * remaining_capacity
+            required -= available
+            if required <= 0:
+                return True
+
+        return False
 
 
 class ImagenetTrainable(Trainable):
@@ -58,21 +192,38 @@ class ImagenetTrainable(Trainable):
         # Determine the number of distributed processes based on the number
         # GPUs and CPUs
         if num_gpus > 0:
+            resource_attr = "gpu"
             world_size = num_gpus
             # Assign one GPU per remote process
             num_gpus = 1
             # Assign extra CPUs for dataloaders
             num_cpus = config.get("workers", 0)
         else:
+            resource_attr = "cpu"
             world_size = num_cpus
             # Assign one CPU per remote process
             num_cpus = 1
 
+        # Check for node affinity
+        resources_by_node = _get_resources_per_node()
+        ray_node_affinity = config.get("__ray_node_affinity__", {})
+        node_resource = 0.0
+        committed_resource = 0.0
+        resources = {}
+
         # Create one ray remote process for each experiment in the process group
-        experiment = ray.remote(num_cpus=num_cpus, num_gpus=num_gpus)(
-            ImagenetExperiment
-        )
-        self.procs = [experiment.remote() for _ in range(world_size)]
+        self.procs = []
+        for i in range(world_size):
+            if ray_node_affinity and node_resource <= 0:
+                node_id, node_resource = ray_node_affinity.popitem()
+                proc_per_node = getattr(resources_by_node[node_id], resource_attr, 0)
+                committed_resource = 1.0 / proc_per_node
+                resources = {node_id: committed_resource}
+
+            experiment = ray.remote(num_cpus=num_cpus, num_gpus=num_gpus,
+                                    resources=resources)(ImagenetExperiment)
+            self.procs.append(experiment.remote())
+            node_resource -= committed_resource
 
         # Use first process as head of the group
         ip = ray.get(self.procs[0].get_node_ip.remote())
@@ -142,6 +293,9 @@ def run(config):
 
     # Queue trials until the cluster scales up
     kwargs.update(queue_trials=True)
+
+    # Group trial into nodes as much as possible
+    kwargs.update(trial_executor=AffinityExecutor(queue_trials=True))
 
     pprint(kwargs)
     tune.run(**kwargs)


### PR DESCRIPTION
@subutai I've tested using the following command on a cluster with 4 x p3.8xlarge:
```
python run.py -g 8 -e super_sparse_100_seeds
```
I logged the `seed` passed to the `setup_experiment` to confirm the node affinity. 
Here is the printout:
```
(pid=22987, ip=10.0.5.53) 2020-02-07 06:20:21,840:INFO:super_sparse_100_seeds:seed:2134
(pid=26193, ip=10.0.5.53) 2020-02-07 06:20:23,318:INFO:super_sparse_100_seeds:seed:2134
(pid=26159, ip=10.0.5.53) 2020-02-07 06:20:22,361:INFO:super_sparse_100_seeds:seed:2134
(pid=26177, ip=10.0.5.53) 2020-02-07 06:20:22,830:INFO:super_sparse_100_seeds:seed:2134

(pid=22959, ip=10.0.5.154) 2020-02-07 06:20:21,884:INFO:super_sparse_100_seeds:seed:2134
(pid=22948, ip=10.0.5.154) 2020-02-07 06:20:21,926:INFO:super_sparse_100_seeds:seed:2134
(pid=22952, ip=10.0.5.154) 2020-02-07 06:20:21,975:INFO:super_sparse_100_seeds:seed:2134
(pid=22961, ip=10.0.5.154) 2020-02-07 06:20:22,014:INFO:super_sparse_100_seeds:seed:2134

(pid=22964, ip=10.0.5.164) 2020-02-07 06:20:22,240:INFO:super_sparse_100_seeds:seed:6851
(pid=22976, ip=10.0.5.164) 2020-02-07 06:20:22,239:INFO:super_sparse_100_seeds:seed:6851
(pid=22954, ip=10.0.5.164) 2020-02-07 06:20:22,247:INFO:super_sparse_100_seeds:seed:6851
(pid=22952, ip=10.0.5.164) 2020-02-07 06:20:22,239:INFO:super_sparse_100_seeds:seed:6851

(pid=26166, ip=10.0.5.66) 2020-02-07 06:20:22,230:INFO:super_sparse_100_seeds:seed:6851
(pid=26174, ip=10.0.5.66) 2020-02-07 06:20:22,749:INFO:super_sparse_100_seeds:seed:6851
(pid=26195, ip=10.0.5.66) 2020-02-07 06:20:23,257:INFO:super_sparse_100_seeds:seed:6851
(pid=26211, ip=10.0.5.66) 2020-02-07 06:20:23,722:INFO:super_sparse_100_seeds:seed:6851
```