### PR TITLE
RES-1228: Modifications to `imagenet_experiment\tune.py` and `restore_utils.py`.

### DIFF
--- a/nupic/research/frameworks/pytorch/imagenet/imagenet_experiment.py
+++ b/nupic/research/frameworks/pytorch/imagenet/imagenet_experiment.py
@@ -140,6 +140,18 @@ class ImagenetExperiment:
             - mixed_precision: Whether or not to enable apex mixed precision
             - mixed_precision_args: apex mixed precision arguments.
                                     See "amp.initialize"
+            - create_train_dataloader: Optional user defined function to create
+                                       the training data loader. See below for
+                                       input params.
+            - create_validation_dataloader: Optional user defined function to create
+                                            the validation data loader. See below for
+                                            input params.
+            - train_model_func: Optional user defined function to train the model,
+                                expected to behave similarly to `train_model`
+                                in terms of input parameters and return values
+            - evaluate_model_func: Optional user defined function to validate the model
+                                   expected to behave similarly to `evaluate_model`
+                                   in terms of input parameters and return values
             - init_hooks: list of hooks (functions) to call on the model
                           just following its initialization
             - post_epoch_hooks: list of hooks (functions) to call on the model
@@ -147,6 +159,11 @@ class ImagenetExperiment:
             - checkpoint_file: if not None, will start from this model. The model
                                must have the same model_args and model_class as the
                                current experiment.
+            - checkpoint_at_init: boolean argument for whether to create a checkpoint
+                                  of the initialized model. this differs from
+                                  `checkpoint_at_start` for which the checkpoint occurs
+                                  after the first epoch of training as opposed to
+                                  before it
             - epochs_to_validate: list of epochs to run validate(). A -1 asks
                                   to run validate before any training occurs.
                                   Default: last three epochs.

--- a/nupic/research/frameworks/pytorch/imagenet/imagenet_experiment.py
+++ b/nupic/research/frameworks/pytorch/imagenet/imagenet_experiment.py
@@ -280,7 +280,7 @@ class ImagenetExperiment:
         val_batch_size = config.get("val_batch_size", self.batch_size)
         self.create_validation_dataloader = config.get(
             "create_validation_dataloader", create_validation_dataloader)
-        self.val_loader = create_validation_dataloader(
+        self.val_loader = self.create_validation_dataloader(
             data_dir=data_dir,
             val_dir=val_dir,
             batch_size=val_batch_size,

--- a/nupic/research/frameworks/pytorch/imagenet/imagenet_tune.py
+++ b/nupic/research/frameworks/pytorch/imagenet/imagenet_tune.py
@@ -284,11 +284,12 @@ class ImagenetTrainable(Trainable):
             worker_config["rank"] = i
             status.append(w.setup_experiment.remote(worker_config))
 
-        if config.get("checkpoint_at_init", False):
-            self.save()
-
         # Wait for remote functions to complete
         ray.get(status)
+
+        # Save initialized model.
+        if config.get("checkpoint_at_init", False):
+            self.save()
 
     def _train(self):
         status = []

--- a/nupic/research/frameworks/pytorch/imagenet/imagenet_tune.py
+++ b/nupic/research/frameworks/pytorch/imagenet/imagenet_tune.py
@@ -284,6 +284,9 @@ class ImagenetTrainable(Trainable):
             worker_config["rank"] = i
             status.append(w.setup_experiment.remote(worker_config))
 
+        if config.get("checkpoint_at_init", False):
+            self.save()
+
         # Wait for remote functions to complete
         ray.get(status)
 

--- a/nupic/research/frameworks/pytorch/restore_utils.py
+++ b/nupic/research/frameworks/pytorch/restore_utils.py
@@ -97,12 +97,30 @@ def get_nonlinear_param_names(
     return list(set(nonlinear_params))
 
 
+def remap_state_dict(state_dict, param_map):
+    """
+    Remaps the names of the params according to 'param_map'.
+    """
+
+    new_state_dict = {}
+    for param, state in state_dict.items():
+
+        if param in param_map:
+            new_param = param_map[param]
+            new_state_dict[new_param] = state
+        else:
+            new_state_dict[param] = state
+
+    return new_state_dict
+
+
 def load_multi_state(
     model,
     restore_full_model=None,
     restore_linear=None,
     restore_nonlinear=None,
     strict=True,
+    param_map=None,
 ):
     """
     Example 1:
@@ -137,6 +155,12 @@ def load_multi_state(
         state_dict = get_state_dict(restore_full_model)
 
         if state_dict:
+
+            # Remap param names in state_dict.
+            if param_map:
+                state_dict = remap_state_dict(state_dict, param_map)
+
+            # Load state.
             model.load_state_dict(state_dict, strict=True)
 
         return model
@@ -151,6 +175,10 @@ def load_multi_state(
         state_dict = get_state_dict(restore_linear)
 
         if state_dict:
+
+            # Remap param names in state_dict.
+            if param_map:
+                state_dict = remap_state_dict(state_dict, param_map)
 
             # Check all desired linear params are present.
             if strict:
@@ -167,6 +195,8 @@ def load_multi_state(
                 param_name: state_dict[param_name]
                 for param_name in linear_params
             }
+
+            # Load state.
             model.load_state_dict(linear_state, strict=False)
 
     # Case 2b:  Non-Linear param states
@@ -175,6 +205,10 @@ def load_multi_state(
         state_dict = get_state_dict(restore_nonlinear)
 
         if state_dict:
+
+            # Remap param names in state_dict.
+            if param_map:
+                state_dict = remap_state_dict(state_dict, param_map)
 
             # Check all desired nonlinear params are present.
             if strict:
@@ -191,6 +225,8 @@ def load_multi_state(
                 param_name: state_dict[param_name]
                 for param_name in nonlinear_params
             }
+
+            # Load state.
             model.load_state_dict(nonlinear_state, strict=False)
 
     # Validate results / quick sanity-check.

--- a/nupic/research/frameworks/pytorch/restore_utils.py
+++ b/nupic/research/frameworks/pytorch/restore_utils.py
@@ -19,13 +19,13 @@
 # http://numenta.org/licenses/
 # ----------------------------------------------------------------------
 import io
-import logging
 import os
 import pickle
 
 import torch
 
 from nupic.research.frameworks.pytorch.model_utils import deserialize_state_dict
+from nupic.torch.modules.sparse_weights import SparseWeightsBase
 
 
 def get_state_dict(checkpoint_path):
@@ -42,15 +42,59 @@ def get_state_dict(checkpoint_path):
         return None
 
 
-def get_linear_param_names(model):
+def get_linear_param_names(
+    model,
+    include_buffers=True,
+    include_sparse_weights_params=True,
+):
 
     linear_params = []
     for name_m, m in model.named_modules():
-        if isinstance(m, torch.nn.Linear):
+
+        # Identify whether to treat `SparseWeightsBase` as have linear params.
+        if include_sparse_weights_params and isinstance(m, SparseWeightsBase):
+            module = m.module  # -> may contain a linear layer
+        else:
+            module = m
+
+        # Check if the 'module' is linear then iterate over params/buffers of 'm'.
+        # Note: 'm' will either be a `torch.nn.Linear` or a `SparseWeightsBase`.
+        if isinstance(module, torch.nn.Linear):
+
+            # Iterate over all params of m.
             for name_p, _ in m.named_parameters():
                 full_name = name_m + ("." if name_m else "") + name_p
                 linear_params.append(full_name)
-    return linear_params
+
+            # Iterate over all buffers of m.
+            if include_buffers:
+
+                for name_b, _ in m.named_buffers():
+                    full_name = name_m + ("." if name_m else "") + name_b
+                    linear_params.append(full_name)
+
+    return list(set(linear_params))
+
+
+def get_nonlinear_param_names(
+    model,
+    include_buffers=True,
+    include_sparse_weights_params=True,
+):
+    linear_param_names = get_linear_param_names(
+        model, include_buffers, include_sparse_weights_params
+    )
+    nonlinear_params = []
+    for name_p, _ in model.named_parameters():
+        if name_p not in linear_param_names:
+            nonlinear_params.append(name_p)
+
+    if include_buffers:
+        for name_b, _ in model.named_buffers():
+            if name_b not in linear_param_names:
+                nonlinear_params.append(name_b)
+
+    return list(set(nonlinear_params))
 
 
 def load_multi_state(
@@ -58,6 +102,7 @@ def load_multi_state(
     restore_full_model=None,
     restore_linear=None,
     restore_nonlinear=None,
+    strict=True,
 ):
     """
     Example 1:
@@ -92,12 +137,13 @@ def load_multi_state(
         state_dict = get_state_dict(restore_full_model)
 
         if state_dict:
-            model.load_state_dict(state_dict, strict=False)
+            model.load_state_dict(state_dict, strict=True)
 
         return model
 
     # Case 2: Use separate sources for Linear and Non-Linear states.
     linear_params = get_linear_param_names(model)
+    nonlinear_params = get_nonlinear_param_names(model)
 
     # Case 2a:  Linear param states
     linear_state = dict()
@@ -106,10 +152,20 @@ def load_multi_state(
 
         if state_dict:
 
+            # Check all desired linear params are present.
+            if strict:
+                assert set(linear_params) <= set(state_dict.keys()), "".join([
+                    "Found linear params in the model ",
+                    "which are not present in the checkpoint '{}'.\n".format(
+                        restore_linear),
+                    "Params not present include:\n {}".format(
+                        set(linear_params) - set(state_dict.keys()))
+                ])
+
+            # Get and load desired linear params.
             linear_state = {
                 param_name: state_dict[param_name]
-                for param_name, param in state_dict.items()
-                if param_name in linear_params
+                for param_name in linear_params
             }
             model.load_state_dict(linear_state, strict=False)
 
@@ -120,21 +176,25 @@ def load_multi_state(
 
         if state_dict:
 
+            # Check all desired nonlinear params are present.
+            if strict:
+                assert set(nonlinear_params) <= set(state_dict.keys()), "".join([
+                    "Found nonlinear params in the model ",
+                    "which are not present in the checkpoint '{}'.\n".format(
+                        restore_nonlinear),
+                    "Params not present include:\n {}".format(
+                        set(nonlinear_params) - set(state_dict.keys()))
+                ])
+
+            # Get and load desired nonlinear params.
             nonlinear_state = {
                 param_name: state_dict[param_name]
-                for param_name, param in state_dict.items()
-                if param_name not in linear_params
+                for param_name in nonlinear_params
             }
             model.load_state_dict(nonlinear_state, strict=False)
 
     # Validate results / quick sanity-check.
     assert set(linear_state.keys()).isdisjoint(nonlinear_state.keys())
-    if linear_params and restore_linear:
-        if not set(linear_state.keys()) == set(linear_params):
-            logging.warning(
-                "Warning: Unable to load all linear params [{}] from {}".format(
-                    linear_params, restore_linear)
-            )
 
     return model
 

--- a/tests/unit/frameworks/pytorch/restore_utils_test.py
+++ b/tests/unit/frameworks/pytorch/restore_utils_test.py
@@ -1,0 +1,257 @@
+# ----------------------------------------------------------------------
+# Numenta Platform for Intelligent Computing (NuPIC)
+# Copyright (C) 2020, Numenta, Inc.  Unless you have an agreement
+# with Numenta, Inc., for a separate license for this software code, the
+# following terms and conditions apply:
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# See the GNU Affero Public License for more details.
+#
+# You should have received a copy of the GNU Affero Public License
+# along with this program.  If not, see http://www.gnu.org/licenses.
+#
+# http://numenta.org/licenses/
+# ----------------------------------------------------------------------
+
+import io
+import itertools
+import pickle
+import tempfile
+import unittest
+from pathlib import Path
+
+import numpy as np
+import torch
+
+from nupic.research.frameworks.pytorch.model_utils import (
+    serialize_state_dict,
+    set_random_seed,
+)
+from nupic.research.frameworks.pytorch.restore_utils import (
+    get_linear_param_names,
+    get_nonlinear_param_names,
+    load_multi_state,
+)
+from nupic.torch.models import MNISTSparseCNN
+
+
+def lower_forward(model, x):
+    y = model.cnn1(x)
+    y = model.cnn1_maxpool(y)
+    y = model.cnn1_kwinner(y)
+    y = model.cnn2(y)
+    y = model.cnn2_maxpool(y)
+    y = model.cnn2_kwinner(y)
+    y = model.flatten(y)
+    return y
+
+
+def upper_forward(model, x):
+    y = model.linear(x)
+    y = model.linear_kwinner(y)
+    y = model.output(y)
+    y = model.softmax(y)
+    return y
+
+
+def full_forward(model, x):
+    y = lower_forward(model, x)
+    y = upper_forward(model, y)
+    return y
+
+
+class RestoreUtilsTest(unittest.TestCase):
+
+    def setUp(self):
+
+        set_random_seed(20)
+        self.model = MNISTSparseCNN()
+        self.model.eval()
+
+        # Make all params twice as large to differentiate it from an init-ed model.
+        for name, param in self.model.named_parameters():
+            if ("cnn" in name or "linear" in name) and ("weight" in name):
+                param[:] = param.data * 2
+
+        # self.model.eval()
+        self.in_1 = torch.rand(2, 1, 28, 28)
+        self.in_2 = torch.rand(2, 1024)
+        self.out_full = full_forward(self.model, self.in_1)
+        self.out_lower = lower_forward(self.model, self.in_1)
+        self.out_upper = upper_forward(self.model, self.in_2)
+
+        # Create temporary results directory.
+        self.tempdir = tempfile.TemporaryDirectory()
+        self.results_dir = Path(self.tempdir.name) / Path("results")
+        self.results_dir.mkdir()
+
+        # Save model state.
+        state = {}
+        with io.BytesIO() as buffer:
+            serialize_state_dict(buffer, self.model.state_dict(), compresslevel=-1)
+            state["model"] = buffer.getvalue()
+
+        self.checkpoint_path = self.results_dir / Path("mymodel")
+        with open(self.checkpoint_path, "wb") as f:
+            pickle.dump(state, f)
+
+    def tearDown(self):
+        self.tempdir.cleanup()
+
+    def test_get_param_names(self):
+
+        linear_params = get_linear_param_names(self.model)
+        expected_linear_params = [
+            "output.weight",
+            "linear.module.bias",
+            "output.bias",
+            "linear.zero_weights",
+            "linear.module.weight"
+        ]
+        self.assertTrue(set(linear_params) == set(expected_linear_params))
+
+        nonlinear_params = get_nonlinear_param_names(self.model)
+        expected_nonlinear_params = []
+        for param, _ in itertools.chain(
+            self.model.named_parameters(), self.model.named_buffers()
+        ):
+            if param not in expected_linear_params:
+                expected_nonlinear_params.append(param)
+
+        self.assertTrue(set(nonlinear_params) == set(expected_nonlinear_params))
+
+    def test_load_full(self):
+
+        # Initialize model with new random seed.
+        set_random_seed(33)
+        model = MNISTSparseCNN()
+        model.eval()
+
+        # Check output through the full network.
+        for param1, param2 in zip(model.parameters(), self.model.parameters()):
+            tot_eq = (param1 == param2).sum().item()
+            self.assertNotEqual(tot_eq, np.prod(param1.shape))
+
+        # Check output through the full network.
+        out = full_forward(model, self.in_1)
+        num_matches = out.isclose(self.out_full, atol=1e-2).sum().item()
+        self.assertEqual(num_matches, 1)  # some correct
+
+        # Check output through the lower network.
+        out = lower_forward(model, self.in_1)
+        num_matches = out.isclose(self.out_lower, atol=1e-2).sum().item()
+        self.assertEqual(num_matches, 1337)  # some correct
+
+        # Check output through the lower network.
+        out = upper_forward(model, self.in_2)
+        num_matches = out.isclose(self.out_upper, atol=1e-2).sum().item()
+        self.assertEqual(num_matches, 1)  # some correct
+
+        # Restore full model.
+        model = load_multi_state(model, restore_full_model=self.checkpoint_path)
+        model.eval()
+
+        # Check output through the full network.
+        for param1, param2 in zip(model.parameters(), self.model.parameters()):
+            tot_eq = (param1 == param2).sum().item()
+            self.assertEqual(tot_eq, np.prod(param1.shape))
+
+        for buffer1, buffer2 in zip(model.buffers(), self.model.buffers()):
+            tot_eq = (buffer1 == buffer2).sum().item()
+            self.assertEqual(tot_eq, np.prod(buffer1.shape))
+
+        out = full_forward(model, self.in_1)
+        num_matches = out.isclose(self.out_full, atol=1e-2, rtol=0).sum().item()
+        self.assertEqual(num_matches, 20)  # all correct
+
+        # Check output through the lower network.
+        out = lower_forward(model, self.in_1)
+        num_matches = out.isclose(self.out_lower, atol=1e-2).sum().item()
+        self.assertEqual(num_matches, 2048)  # all correct
+
+        # Check output through the lower network.
+        out = upper_forward(model, self.in_2)
+        num_matches = out.isclose(self.out_upper, atol=1e-2).sum().item()
+        self.assertEqual(num_matches, 20)  # all correct
+
+    def test_load_nonlinear(self):
+
+        # Initialize model with new random seed.
+        set_random_seed(33)
+        model = MNISTSparseCNN()
+        model.eval()
+
+        # Check output through the full network.
+        for param1, param2 in zip(model.parameters(), self.model.parameters()):
+            tot_eq = (param1 == param2).sum().item()
+            self.assertNotEqual(tot_eq, np.prod(param1.shape))
+
+        # Check output through the lower network.
+        out = lower_forward(model, self.in_1)
+        num_matches = out.isclose(self.out_lower, atol=1e-2).sum().item()
+        self.assertEqual(num_matches, 1337)  # some correct
+
+        # Check output through the lower network.
+        out = upper_forward(model, self.in_2)
+        num_matches = out.isclose(self.out_upper, atol=1e-2).sum().item()
+        self.assertEqual(num_matches, 1)  # some correct
+
+        # Restore full model.
+        model = load_multi_state(model, restore_nonlinear=self.checkpoint_path)
+        model.eval()
+
+        # Check output through the lower network.
+        out = lower_forward(model, self.in_1)
+        num_matches = out.isclose(self.out_lower, atol=1e-2).sum().item()
+        self.assertEqual(num_matches, 2048)  # all correct
+
+        # Check output through the lower network.
+        out = upper_forward(model, self.in_2)
+        num_matches = out.isclose(self.out_upper, atol=1e-2).sum().item()
+        self.assertEqual(num_matches, 1)
+
+    def test_load_linear(self):
+
+        # Initialize model with new random seed.
+        set_random_seed(33)
+        model = MNISTSparseCNN()
+        model.eval()
+
+        # Check output through the full network.
+        for param1, param2 in zip(model.parameters(), self.model.parameters()):
+            tot_eq = (param1 == param2).sum().item()
+            self.assertNotEqual(tot_eq, np.prod(param1.shape))
+
+        # Check output through the lower network.
+        out = lower_forward(model, self.in_1)
+        num_matches = out.isclose(self.out_lower, atol=1e-2).sum().item()
+        self.assertEqual(num_matches, 1337)  # some correct
+
+        # Check output through the lower network.
+        out = upper_forward(model, self.in_2)
+        num_matches = out.isclose(self.out_upper, atol=1e-2).sum().item()
+        self.assertEqual(num_matches, 1)  # some correct
+
+        # Restore full model.
+        model = load_multi_state(model, restore_linear=self.checkpoint_path)
+        model.eval()
+
+        # Check output through the lower network.
+        out = lower_forward(model, self.in_1)
+        num_matches = out.isclose(self.out_lower, atol=1e-2).sum().item()
+        self.assertEqual(num_matches, 1337)  # some correct
+
+        # Check output through the lower network.
+        out = upper_forward(model, self.in_2)
+        num_matches = out.isclose(self.out_upper, atol=1e-2).sum().item()
+        self.assertEqual(num_matches, 20)  # all correct
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
Modifications to `imagenet_experiment\tune.py` and `restore_utils.py`:

* Enabled saving of a checkpoint of the initialized model (before this can, at its earliest, be done after 1 epoch of training)
* Added functionality for user defined `train_model` and `evaluate_model` to the `ImagenetExperiment` class. These are now specifiable through the config.
* Enabled param mapping in restore utils. For instance, if a network gets permuted (e.g. swapping the order of ReLU and KWinners), this functionality helps in specifying the mapping of the old names to their new ones. Thus, this enables loading a network from a checkpoint even if the parameters names have slightly changed.