### PR TITLE
Fix to `ray_custom_loggers.py`

### DIFF
--- a/nupic/research/frameworks/dynamic_sparse/common/ray_custom_loggers.py
+++ b/nupic/research/frameworks/dynamic_sparse/common/ray_custom_loggers.py
@@ -38,8 +38,6 @@ from ray.tune.util import flatten_dict
 
 logger = logging.getLogger(__name__)
 
-# import tensorflow as tf  # noqa: @ remove
-
 
 def to_tf_values(result, path, histo_bins=1000):
     """Adapted from [1], generate a list of tf.Summary.Value() objects that

--- a/nupic/research/frameworks/dynamic_sparse/common/ray_custom_loggers.py
+++ b/nupic/research/frameworks/dynamic_sparse/common/ray_custom_loggers.py
@@ -34,9 +34,11 @@ import PIL.Image
 import seaborn as sns
 from ray.tune.logger import CSVLogger, JsonLogger, Logger
 from ray.tune.result import TIME_TOTAL_S, TIMESTEPS_TOTAL, TRAINING_ITERATION
-from ray.tune.utils import flatten_dict
+from ray.tune.util import flatten_dict
 
 logger = logging.getLogger(__name__)
+
+# import tensorflow as tf  # noqa: @ remove
 
 
 def to_tf_values(result, path, histo_bins=1000):

--- a/nupic/research/frameworks/dynamic_sparse/common/ray_custom_loggers.py
+++ b/nupic/research/frameworks/dynamic_sparse/common/ray_custom_loggers.py
@@ -189,7 +189,7 @@ class TFLoggerPlus(Logger):
 
                 tf = tensorflow
                 use_tf150_api = distutils.version.LooseVersion(
-                    tf.VERSION
+                    tf.__version__
                 ) >= distutils.version.LooseVersion("1.5.0")
         except ImportError:
             logger.warning(


### PR DESCRIPTION
Small fix to `ray_custom_loggers.py` which is helpful for expressive plots to tensorboard. 

Note: One may use these loggers by
```
import ray
from nupic.research.frameworks.dynamic_sparse.common.ray_custom_loggers import (
     DEFAULT_LOGGERS
 )

# Define trainable
class MyTrainable(ray.tune.Trainable)
...

# Define config and run.
config = {
   ...
   loggers=DEFAULT_LOGGERS
}

ray.tune.run(**config)
```
