### PR TITLE
RES-1400: Upgrade pytorch to 1.4

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -95,7 +95,7 @@ jobs:
             PYTEST_ADDOPTS: --junitxml=test_results/pytest/results.xml --verbose
           command: |
             mkdir -p test_results/pytest
-            python setup.py test
+            pytest
       - store_test_results:
           path: test_results
 

--- a/.gitignore
+++ b/.gitignore
@@ -102,16 +102,23 @@ venv.bak/
 
 # mypy
 .mypy_cache/
+
+# IDE
 .idea
-/projects/ray_tune_example/mnist/results
-/projects/whydense/cifar/data
+.vscode 
+
+# MacOS hidden files
 .DS_Store
-/projects/ray_tune_example/mnist/data
-/projects/whydense/cifar/results
+
+# Domino files
 .domino*
 domino*
-/projects/whydense/cifar/results1
 
 # local scripts
 cleancode.sh
 checkcode.sh
+/projects/ray_tune_example/mnist/results
+/projects/whydense/cifar/data
+/projects/ray_tune_example/mnist/data
+/projects/whydense/cifar/results
+/projects/whydense/cifar/results1

--- a/environment.yml
+++ b/environment.yml
@@ -3,17 +3,18 @@
 # platform: osx-64
 name: nupic.research
 channels:
-  - defaults
-  - conda-forge
   - pytorch
   - fastai
+  - intel
+  - defaults
+  - conda-forge
 
 dependencies:
   - python=3.7
   - pip
 
   # See nupic.torch requirements.txt
-  - pytorch=1.3.1
+  - pytorch=1.4
 
   # See requirements.txt
   - awscli
@@ -32,7 +33,7 @@ dependencies:
   - scikit-image
   - seaborn
   - tabulate
-  - torchvision=0.4.2
+  - torchvision=0.5.0
   - tqdm
   - h5py
 

--- a/nupic/research/frameworks/pytorch/lr_scheduler.py
+++ b/nupic/research/frameworks/pytorch/lr_scheduler.py
@@ -101,15 +101,13 @@ class ComposedLRScheduler(_LRScheduler):
 
         super().__init__(optimizer=optimizer, last_epoch=last_epoch)
 
-    def step(self, epoch=None):
+    def step(self):
         """
         Step should be called after every batch update if OneCycleLR is one of
         the mapped LR Schedulers. Make sure to specify "steps_per_epoch" when
         """
         # Get milestone for current step
-        current_step = epoch
-        if current_step is None:
-            current_step = self.last_epoch + 1
+        current_step = self.last_epoch + 1
         current_epoch = current_step // self.steps_per_epoch
         current_batch = current_step % self.steps_per_epoch
         current_milestone = self.milestones[bisect(self.milestones, current_epoch) - 1]
@@ -127,10 +125,13 @@ class ComposedLRScheduler(_LRScheduler):
             if self.lr_scheduler is not None:
                 self.lr_scheduler.step()
 
-        super().step(epoch)
+        self.last_epoch += 1
 
     def get_lr(self):
         return self.lr_scheduler.get_lr()
+
+    def get_last_lr(self):
+        return self.lr_scheduler.get_last_lr()
 
     def _update_optimizer(self):
         params = self.schedulers[self.active_milestone]

--- a/nupic/research/frameworks/pytorch/lr_scheduler.py
+++ b/nupic/research/frameworks/pytorch/lr_scheduler.py
@@ -23,29 +23,6 @@ from bisect import bisect
 from torch.optim.lr_scheduler import OneCycleLR, _LRScheduler
 
 
-class ScaledLR(_LRScheduler):
-    """
-    Multiply the learning rate of each parameter group  by a specific factor
-    assigned to the epoch. This LR scheduler could be chained together with
-    other schedulers. This is useful when scaling the LR to the batch size.
-
-    .. seealso:: See https://arxiv.org/pdf/1706.02677.pdf
-
-    :param optimizer: Wrapped optimizer
-    :param lr_scale: dict mapping initial epoch to LR scale
-    :param last_epoch: The index of last epoch. Default: -1.
-    """
-
-    def __init__(self, optimizer, lr_scale, last_epoch=-1):
-        self.lr_scale = lr_scale
-        self.epochs = sorted(self.lr_scale.keys())
-        super().__init__(optimizer=optimizer, last_epoch=last_epoch)
-
-    def get_lr(self):
-        scale = self.lr_scale[self.epochs[bisect(self.epochs, self.last_epoch) - 1]]
-        return map(lambda group: group["lr"] * scale, self.optimizer.param_groups)
-
-
 class ComposedLRScheduler(_LRScheduler):
     """
     Learning scheduler composed of different LR schedulers and optimizer

--- a/requirements.txt
+++ b/requirements.txt
@@ -42,6 +42,6 @@ scikit-image
 seaborn>=0.9.0
 sigopt
 tabulate
-torchvision==0.4.2
+torchvision==0.5.0
 tqdm
 h5py

--- a/tests/unit/frameworks/pytorch/lr_scheduler_test.py
+++ b/tests/unit/frameworks/pytorch/lr_scheduler_test.py
@@ -22,35 +22,9 @@ import unittest
 import numpy as np
 import torch
 import torch.optim
-from torch.optim.lr_scheduler import MultiStepLR, OneCycleLR, StepLR
+from torch.optim.lr_scheduler import OneCycleLR, StepLR
 
-from nupic.research.frameworks.pytorch.lr_scheduler import ComposedLRScheduler, ScaledLR
-
-
-class ScaledLRTest(unittest.TestCase):
-    def test_chaining_schedulers(self):
-        optimizer = torch.optim.SGD([torch.zeros(1)], lr=1.0)
-        lr_scheduler1 = MultiStepLR(optimizer=optimizer,
-                                    milestones=[5, 10, 15, 20],
-                                    gamma=0.1)
-        lr_scheduler2 = ScaledLR(optimizer=optimizer,
-                                 lr_scale={
-                                     0: 1.0,
-                                     5: 2.0,
-                                     10: 3.0,
-                                     15: 4.0,
-                                     20: 5.0,
-                                 })
-        expected = [1.] * 5 + [.2] * 5 + [.03] * 5 + [.004] * 5 + [.0005] * 5
-        actual = []
-        for _ in range(len(expected)):
-            lr = optimizer.param_groups[0]["lr"]
-            actual.append(round(lr, 8))
-            optimizer.step()
-            lr_scheduler1.step()
-            lr_scheduler2.step()
-
-        self.assertEqual(expected, actual)
+from nupic.research.frameworks.pytorch.lr_scheduler import ComposedLRScheduler
 
 
 class ComposedLRSchedulerTest(unittest.TestCase):


### PR DESCRIPTION
Upgrade pytorch to 1.4 and torchvision to 0.5.0
Depends on https://github.com/numenta/nupic.torch/pull/62

See https://github.com/pytorch/pytorch/releases/tag/v1.4.0 for all the changes
The main change to our code was the way LRSchedulers are chained together. See "Backwards Incompatible Changes" in the release notes.

I validated my changes by running the unit tests (lr_scheduler_test.py) and the `sparse_100_weight_decay` experiment. Got `80+%` accuracy. I am assuming it is similar to what we had before