### PR TITLE
RES-1481: Refactor ImagenetExperiment to maintains the current epoch number internally

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -35,7 +35,6 @@ dependencies:
   - torchvision=0.5.0
   - tqdm
   - h5py
-  - grpcio>=1.24.3. # needed for tensorboard
 
   # ray[debug,dashboard]
   - aiohttp

--- a/nupic/research/frameworks/pytorch/imagenet/imagenet_experiment.py
+++ b/nupic/research/frameworks/pytorch/imagenet/imagenet_experiment.py
@@ -415,8 +415,8 @@ class ImagenetExperiment:
                 current_batch *= self.train_loader.sampler.num_replicas
             self.logger.debug("End of batch for rank: %s. Epoch: %s, Batch: %s/%s, "
                               "loss: %s, Learning rate: %s num_images: %s",
-                              self.rank, self.current_epoch, current_batch, total_batches, loss,
-                              self.get_lr(), num_images)
+                              self.rank, self.current_epoch, current_batch,
+                              total_batches, loss, self.get_lr(), num_images)
             self.logger.debug("Timing: %s", time_string)
 
     def post_epoch(self):

--- a/nupic/research/frameworks/pytorch/imagenet/imagenet_tune.py
+++ b/nupic/research/frameworks/pytorch/imagenet/imagenet_tune.py
@@ -120,9 +120,9 @@ class ImagenetTrainable(Trainable):
     def _restore(self, state):
         self.logger.debug(f"_restore: {self._trial_info.trial_name}({self.iteration})")
 
-        # Update epoch for old checkpoints
-        if "epoch" not in state:
-            state.update(epoch=self.iteration)
+        # Update current_epoch for old checkpoints
+        if "current_epoch" not in state:
+            state.update(current_epoch=self.iteration)
 
         # Restore the state to every process
         state_id = ray.put(state)

--- a/nupic/research/frameworks/pytorch/imagenet/imagenet_tune.py
+++ b/nupic/research/frameworks/pytorch/imagenet/imagenet_tune.py
@@ -93,7 +93,7 @@ class ImagenetTrainable(Trainable):
         try:
             status = []
             for w in self.procs:
-                status.append(w.run_epoch.remote(self.iteration))
+                status.append(w.run_epoch.remote())
 
             # Wait for remote functions and check for errors
             # Return the results from the first remote function
@@ -119,6 +119,11 @@ class ImagenetTrainable(Trainable):
 
     def _restore(self, state):
         self.logger.debug(f"_restore: {self._trial_info.trial_name}({self.iteration})")
+
+        # Update epoch for old checkpoints
+        if "epoch" not in state:
+            state.update(epoch=self.iteration)
+
         # Restore the state to every process
         state_id = ray.put(state)
         ray.get([w.set_state.remote(state_id) for w in self.procs])

--- a/nupic/research/frameworks/pytorch/imagenet/mixins/complex_loss.py
+++ b/nupic/research/frameworks/pytorch/imagenet/mixins/complex_loss.py
@@ -19,7 +19,6 @@
 # http://numenta.org/licenses/
 # ----------------------------------------------------------------------
 
-import functools
 import time
 
 

--- a/nupic/research/frameworks/pytorch/imagenet/mixins/complex_loss.py
+++ b/nupic/research/frameworks/pytorch/imagenet/mixins/complex_loss.py
@@ -36,20 +36,16 @@ class ComplexLoss(object):
             "ComplexLoss.calculate_batch_loss"
         ]
 
-    def train_epoch(self, epoch):
+    def train_epoch(self):
         """Overwrites train model to use private train_model method
-
-        :param epoch: Epoch number (provided by trainable)
         """
-        self._train_model(epoch)
+        self._train_model()
 
-    def _train_model(self, epoch):
+    def _train_model(self):
         """Private train model that has access to Experiment attributes
-
-        :param epoch: Epoch number
         """
-        pre_batch_callback = functools.partial(self.pre_batch, epoch=epoch)
-        post_batch_callback = functools.partial(self.post_batch, epoch=epoch)
+        pre_batch_callback = self.pre_batch
+        post_batch_callback = self.post_batch
 
         self.model.train()
         # Use asynchronous GPU copies when the memory is pinned

--- a/nupic/research/frameworks/pytorch/imagenet/mixins/knowledge_distillation.py
+++ b/nupic/research/frameworks/pytorch/imagenet/mixins/knowledge_distillation.py
@@ -79,19 +79,17 @@ class KnowledgeDistillation(object):
             self.kd_factor = self.kd_factor_init
         self.logger.info(f"KD factor: {self.kd_factor_init} {self.kd_factor_end}")
 
-    def _train_model(self, epoch):
+    def _train_model(self):
         """Private train model that has access to Experiment attributes
-
-        :param epoch: Epoch number
         """
         # calculates kd factor based on a linear decay
         if self.kd_factor_end is not None:
             self.kd_factor = linear_decay(first_epoch_value=self.kd_factor_init,
                                           last_epoch_value=self.kd_factor_end,
-                                          current_epoch=epoch,
+                                          current_epoch=self.current_epoch,
                                           total_epochs=self.epochs)
-            self.logger.debug(f"KD factor: {self.kd_factor:.3f} at epoch {epoch}")
-        super()._train_model(epoch)
+            self.logger.debug(f"KD factor: {self.kd_factor:.3f} at epoch {self.current_epoch}")
+        super()._train_model()
 
     def calculate_batch_loss(self, data, target, async_gpu=True):
         """

--- a/nupic/research/frameworks/pytorch/imagenet/mixins/knowledge_distillation.py
+++ b/nupic/research/frameworks/pytorch/imagenet/mixins/knowledge_distillation.py
@@ -88,7 +88,8 @@ class KnowledgeDistillation(object):
                                           last_epoch_value=self.kd_factor_end,
                                           current_epoch=self.current_epoch,
                                           total_epochs=self.epochs)
-            self.logger.debug(f"KD factor: {self.kd_factor:.3f} at epoch {self.current_epoch}")
+            self.logger.debug(
+                f"KD factor: {self.kd_factor:.3f} at epoch {self.current_epoch}")
         super()._train_model()
 
     def calculate_batch_loss(self, data, target, async_gpu=True):

--- a/nupic/research/frameworks/pytorch/imagenet/mixins/profile.py
+++ b/nupic/research/frameworks/pytorch/imagenet/mixins/profile.py
@@ -50,17 +50,17 @@ class Profile:
             pstats.Stats(pr).dump_stats(filepath)
             self.logger.info(f"Saved {filepath}")
 
-    def run_epoch(self, epoch):
+    def run_epoch(self):
         if self.use_cProfile:
             pr = cProfile.Profile()
             pr.enable()
 
-        result = super().run_epoch(epoch)
+        result = super().run_epoch()
 
         if self.use_cProfile:
             pr.disable()
             filepath = os.path.join(self.logdir,
-                                    f"profile-epoch{epoch}.profile")
+                                    f"profile-epoch{self.epoch}.profile")
             pstats.Stats(pr).dump_stats(filepath)
             self.logger.info(f"Saved {filepath}")
 

--- a/nupic/research/frameworks/pytorch/imagenet/mixins/profile.py
+++ b/nupic/research/frameworks/pytorch/imagenet/mixins/profile.py
@@ -60,7 +60,7 @@ class Profile:
         if self.use_cProfile:
             pr.disable()
             filepath = os.path.join(self.logdir,
-                                    f"profile-epoch{self.epoch}.profile")
+                                    f"profile-epoch{self.current_epoch}.profile")
             pstats.Stats(pr).dump_stats(filepath)
             self.logger.info(f"Saved {filepath}")
 

--- a/nupic/research/frameworks/pytorch/imagenet/mixins/profile_autograd.py
+++ b/nupic/research/frameworks/pytorch/imagenet/mixins/profile_autograd.py
@@ -38,11 +38,11 @@ class ProfileAutograd:
         # Only profile from rank 0
         self.profile_autograd = self.rank == 0
 
-    def train_epoch(self, epoch):
+    def train_epoch(self):
         with torch.autograd.profiler.profile(
                 use_cuda=torch.cuda.is_available(),
                 enabled=self.profile_autograd) as prof:
-            super().train_epoch(epoch)
+            super().train_epoch()
 
         if self.profile_autograd and prof is not None:
             self.logger.info(prof.key_averages().table(

--- a/nupic/research/frameworks/pytorch/imagenet/mixins/regularize_loss.py
+++ b/nupic/research/frameworks/pytorch/imagenet/mixins/regularize_loss.py
@@ -77,5 +77,5 @@ class RegularizeLoss(object):
 
     def pre_epoch(self):
         super().pre_epoch()
-        if self.epoch in self.reg_schedule:
-            self.reg_weight = self.reg_schedule[self.epoch]
+        if self.current_epoch in self.reg_schedule:
+            self.reg_weight = self.reg_schedule[self.current_epoch]

--- a/nupic/research/frameworks/pytorch/imagenet/mixins/regularize_loss.py
+++ b/nupic/research/frameworks/pytorch/imagenet/mixins/regularize_loss.py
@@ -75,7 +75,7 @@ class RegularizeLoss(object):
         loss += reg
         return loss
 
-    def pre_epoch(self, epoch):
-        super().pre_epoch(epoch)
-        if epoch in self.reg_schedule:
-            self.reg_weight = self.reg_schedule[epoch]
+    def pre_epoch(self):
+        super().pre_epoch()
+        if self.epoch in self.reg_schedule:
+            self.reg_weight = self.reg_schedule[self.epoch]

--- a/nupic/research/frameworks/pytorch/imagenet/mixins/rezero_weights.py
+++ b/nupic/research/frameworks/pytorch/imagenet/mixins/rezero_weights.py
@@ -56,8 +56,8 @@ class RezeroWeights:
         model.apply(rezero_weights)
         return model
 
-    def post_epoch(self, epoch):
-        super().post_epoch(epoch)
+    def post_epoch(self):
+        super().post_epoch()
 
         count_nnz = self.logger.isEnabledFor(logging.DEBUG) and self.rank == 0
         if count_nnz:

--- a/nupic/research/frameworks/pytorch/imagenet/mixins/update_boost_strength.py
+++ b/nupic/research/frameworks/pytorch/imagenet/mixins/update_boost_strength.py
@@ -30,6 +30,6 @@ class UpdateBoostStrength:
         super().__init__()
         self.execution_order["pre_epoch"].append("UpdateBoostStrength")
 
-    def pre_epoch(self, epoch):
-        super().pre_epoch(epoch)
+    def pre_epoch(self):
+        super().pre_epoch()
         self.model.apply(update_boost_strength)


### PR DESCRIPTION
In order to make the checkpoints self contained we need to keep the current epoch as part of the `ImagenetExperiment` instead of ray tune or any other external framework