### PR TITLE
Refactor create_train_dataloader, move some of it into a classmethod

### DIFF
--- a/nupic/research/frameworks/pytorch/imagenet/imagenet_experiment.py
+++ b/nupic/research/frameworks/pytorch/imagenet/imagenet_experiment.py
@@ -91,19 +91,6 @@ class ImagenetExperiment:
         self.launch_time = 0
         self.epochs_to_validate = []
         self.current_epoch = 0
-        # Updated by mixins and subclasses.
-        self.execution_order = dict(
-            setup_experiment=["ImagenetExperiment.setup_experiment"],
-            create_model=["ImagenetExperiment.create_model"],
-            validate=["ImagenetExperiment.validate"],
-            train_epoch=["ImagenetExperiment.train_epoch"],
-            run_epoch=["ImagenetExperiment.run_epoch"],
-            pre_epoch=["ImagenetExperiment.pre_epoch"],
-            post_epoch=["ImagenetExperiment.post_epoch"],
-            pre_batch=["ImagenetExperiment.pre_batch"],
-            post_batch=["ImagenetExperiment.post_batch"],
-            loss_function=["ImagenetExperiment.loss_function"],
-        )
 
     def setup_experiment(self, config):
         """
@@ -201,7 +188,8 @@ class ImagenetExperiment:
         self.rank = config.get("rank", 0)
 
         if self.rank == 0:
-            self.logger.info(f"Execution order: {pformat(self.execution_order)}")
+            self.logger.info(
+                f"Execution order: {pformat(self.get_execution_order())}")
 
         if self.distributed:
             dist_url = config.get("dist_url", "tcp://127.0.0.1:54321")
@@ -560,3 +548,22 @@ class ImagenetExperiment:
     def get_free_port(self):
         """Returns free TCP port in the current ray node"""
         return ray_utils.find_free_port()
+
+    @classmethod
+    def get_execution_order(cls):
+        return dict(
+            setup_experiment=["ImagenetExperiment.setup_experiment"],
+            create_model=["ImagenetExperiment.create_model"],
+            create_train_dataloader=["ImagenetExperiment.create_train_dataloader"],
+            create_validation_dataloader=[
+                "ImagenetExperiment.create_validation_dataloader"
+            ],
+            validate=["ImagenetExperiment.validate"],
+            train_epoch=["ImagenetExperiment.train_epoch"],
+            run_epoch=["ImagenetExperiment.run_epoch"],
+            pre_epoch=["ImagenetExperiment.pre_epoch"],
+            post_epoch=["ImagenetExperiment.post_epoch"],
+            pre_batch=["ImagenetExperiment.pre_batch"],
+            post_batch=["ImagenetExperiment.post_batch"],
+            loss_function=["ImagenetExperiment.loss_function"],
+        )

--- a/nupic/research/frameworks/pytorch/imagenet/mixins/complex_loss.py
+++ b/nupic/research/frameworks/pytorch/imagenet/mixins/complex_loss.py
@@ -27,14 +27,6 @@ class ComplexLoss(object):
     Defines a new training loop that has direct access to Experiment attributes
     and can be customized for more complex loss functions
     """
-    def __init__(self):
-        super().__init__()
-        self.execution_order["train_epoch"] = ["ComplexLoss.train_epoch"]
-        self.execution_order["_train_model"] = ["ComplexLoss._train_model"]
-        self.execution_order["calculate_batch_loss"] = [
-            "ComplexLoss.calculate_batch_loss"
-        ]
-
     def train_epoch(self):
         """Overwrites train model to use private train_model method
         """
@@ -113,3 +105,11 @@ class ComplexLoss(object):
 
         del data, target
         return loss, output
+
+    @classmethod
+    def get_execution_order(cls):
+        eo = super().get_execution_order()
+        eo["train_epoch"] = ["ComplexLoss.train_epoch"]
+        eo["_train_model"] = ["ComplexLoss._train_model"]
+        eo["calculate_batch_loss"] = ["ComplexLoss.calculate_batch_loss"]
+        return eo

--- a/nupic/research/frameworks/pytorch/imagenet/mixins/constrain_parameters.py
+++ b/nupic/research/frameworks/pytorch/imagenet/mixins/constrain_parameters.py
@@ -24,12 +24,6 @@ class ConstrainParameters(object):
     """
     Calls modules' "constrain_parameters" method after every batch.
     """
-    def __init__(self):
-        super().__init__()
-        self.execution_order["setup_experiment"].append(
-            "ConstrainParameters initialization")
-        self.execution_order["post_batch"].append("ConstrainParameters")
-
     def setup_experiment(self, config):
         super().setup_experiment(config)
         self._constrain_parameters_modules = [
@@ -42,3 +36,10 @@ class ConstrainParameters(object):
         super().post_batch(*args, **kwargs)
         for module in self._constrain_parameters_modules:
             module.constrain_parameters()
+
+    @classmethod
+    def get_execution_order(cls):
+        eo = super().get_execution_order()
+        eo["setup_experiment"].append("ConstrainParameters initialization")
+        eo["post_batch"].append("ConstrainParameters")
+        return eo

--- a/nupic/research/frameworks/pytorch/imagenet/mixins/knowledge_distillation.py
+++ b/nupic/research/frameworks/pytorch/imagenet/mixins/knowledge_distillation.py
@@ -27,18 +27,6 @@ class KnowledgeDistillation(object):
     """
     Sets the network to learn from a teacher model
     """
-    def __init__(self):
-        super().__init__()
-
-        self.execution_order["setup_experiment"].append(
-            "Knowledge Distillation initialization")
-        self.execution_order["calculate_batch_loss"] = [
-            "KnowledgeDistillation.calculate_batch_loss"
-        ]
-        self.execution_order["_train_model"].insert(
-            0, "Update kd factor based on linear decay"
-        )
-
     def setup_experiment(self, config):
         """
         Add following variables to config
@@ -117,6 +105,16 @@ class KnowledgeDistillation(object):
 
         del softmax_output_teacher, combined_target
         return loss, output
+
+    @classmethod
+    def get_execution_order(cls):
+        eo = super().get_execution_order()
+        eo["setup_experiment"].append("Knowledge Distillation initialization")
+        eo["calculate_batch_loss"] = [
+            "KnowledgeDistillation.calculate_batch_loss"
+        ]
+        eo["_train_model"].insert(0, "Update kd factor based on linear decay")
+        return eo
 
 
 def soft_cross_entropy(output, target, size_average=True):

--- a/nupic/research/frameworks/pytorch/imagenet/mixins/log_backprop_structure.py
+++ b/nupic/research/frameworks/pytorch/imagenet/mixins/log_backprop_structure.py
@@ -26,12 +26,6 @@ class LogBackpropStructure(object):
     """
     Structure logging for the backprop_structure modules.
     """
-    def __init__(self):
-        super().__init__()
-        self.execution_order["setup_experiment"].append(
-            "LogBackpropStructure initialization")
-        self.execution_order["run_epoch"].append("LogBackpropStructure")
-
     def setup_experiment(self, config):
         super().setup_experiment(config)
         self.log_verbose_structure = config.get("log_verbose_structure", False)
@@ -40,6 +34,13 @@ class LogBackpropStructure(object):
         result = super().run_epoch(*args, **kwargs)
         result.update(nonzero_counts(self.model, self.log_verbose_structure))
         return result
+
+    @classmethod
+    def get_execution_order(cls):
+        eo = super().get_execution_order()
+        eo["setup_experiment"].append("LogBackpropStructure initialization")
+        eo["run_epoch"].append("LogBackpropStructure")
+        return eo
 
 
 def nonzero_counts(model, verbose):

--- a/nupic/research/frameworks/pytorch/imagenet/mixins/log_covariance.py
+++ b/nupic/research/frameworks/pytorch/imagenet/mixins/log_covariance.py
@@ -27,14 +27,6 @@ class LogCovariance(object):
     During testing, record the covariance of unit activations within each
     specified layer.
     """
-    def __init__(self):
-        super().__init__()
-        self.execution_order["setup_experiment"].append(
-            "LogCovariance initialization")
-        self.execution_order["validate"].insert(0, "LogCovariance add hooks")
-        self.execution_order["validate"].append(
-            "LogCovariance remove hooks, compute covariance")
-
     def setup_experiment(self, config):
         super().setup_experiment(config)
         self.log_covariance_layernames = config.get("log_covariance_layernames",
@@ -69,3 +61,11 @@ class LogCovariance(object):
             result["{}/variance_sum".format(layername)] = var.sum().item()
 
         return result
+
+    @classmethod
+    def get_execution_order(cls):
+        eo = super().get_execution_order()
+        eo["setup_experiment"].append("LogCovariance initialization")
+        eo["validate"].insert(0, "LogCovariance add hooks")
+        eo["validate"].append("LogCovariance remove hooks, compute covariance")
+        return eo

--- a/nupic/research/frameworks/pytorch/imagenet/mixins/maxup.py
+++ b/nupic/research/frameworks/pytorch/imagenet/mixins/maxup.py
@@ -34,13 +34,6 @@ class MaxupStandard(object):
 
     Requires ComplexLoss Mixin
     """
-    def __init__(self):
-        super().__init__()
-
-        self.execution_order["calculate_batch_loss"] = [
-            "MaxupStandard.calculate_batch_loss"
-        ]
-
     def calculate_batch_loss(self, data, target, async_gpu=True):
         """
         :param data: input to the training function, as specified by dataloader
@@ -74,6 +67,12 @@ class MaxupStandard(object):
         del data, data_variant, target, losses
         return loss, output
 
+    @classmethod
+    def get_execution_order(cls):
+        eo = super().get_execution_order()
+        eo["calculate_batch_loss"] = ["MaxupStandard.calculate_batch_loss"]
+        return eo
+
 
 class MaxupPerSample(object):
     """
@@ -86,13 +85,6 @@ class MaxupPerSample(object):
 
     Requires ComplexLoss Mixin
     """
-    def __init__(self):
-        super().__init__()
-
-        self.execution_order["calculate_batch_loss"] = [
-            "MaxupPerSample.calculate_batch_loss"
-        ]
-
     def calculate_batch_loss(self, data, target, async_gpu=True):
         """
         :param data: input to the training function, as specified by dataloader
@@ -131,6 +123,12 @@ class MaxupPerSample(object):
 
         del data, data_variant, target, one_hot_target, losses, max_indices
         return loss, output
+
+    @classmethod
+    def get_execution_order(cls):
+        eo = super().get_execution_order()
+        eo["calculate_batch_loss"] = ["MaxupPerSample.calculate_batch_loss"]
+        return eo
 
 
 def sample_cross_entropy(output, target):

--- a/nupic/research/frameworks/pytorch/imagenet/mixins/profile.py
+++ b/nupic/research/frameworks/pytorch/imagenet/mixins/profile.py
@@ -28,13 +28,6 @@ class Profile:
     """
     Save cProfile traces for initialization and each run_epoch.
     """
-    def __init__(self):
-        super().__init__()
-        self.execution_order["setup_experiment"].insert(0, "Profile begin")
-        self.execution_order["setup_experiment"].append("Profile end")
-        self.execution_order["run_epoch"].insert(0, "Profile begin")
-        self.execution_order["run_epoch"].append("Profile end")
-
     def setup_experiment(self, config):
         self.use_cProfile = (self.rank == 0)
         if self.use_cProfile:
@@ -65,3 +58,12 @@ class Profile:
             self.logger.info(f"Saved {filepath}")
 
         return result
+
+    @classmethod
+    def get_execution_order(cls):
+        eo = super().get_execution_order()
+        eo["setup_experiment"].insert(0, "Profile begin")
+        eo["setup_experiment"].append("Profile end")
+        eo["run_epoch"].insert(0, "Profile begin")
+        eo["run_epoch"].append("Profile end")
+        return eo

--- a/nupic/research/frameworks/pytorch/imagenet/mixins/profile_autograd.py
+++ b/nupic/research/frameworks/pytorch/imagenet/mixins/profile_autograd.py
@@ -26,13 +26,6 @@ class ProfileAutograd:
     """
     Use torch's autograd profiler during training.
     """
-    def __init__(self):
-        super().__init__()
-        self.execution_order["setup_experiment"].append(
-            "ProfileAutograd initialization")
-        self.execution_order["train_epoch"].insert(0, "ProfileAutograd begin")
-        self.execution_order["train_epoch"].append("ProfileAutograd end")
-
     def setup_experiment(self, config):
         super().setup_experiment(config)
         # Only profile from rank 0
@@ -47,3 +40,11 @@ class ProfileAutograd:
         if self.profile_autograd and prof is not None:
             self.logger.info(prof.key_averages().table(
                 sort_by="self_cpu_time_total"))
+
+    @classmethod
+    def get_execution_order(cls):
+        eo = super().get_execution_order()
+        eo["setup_experiment"].append("ProfileAutograd initialization")
+        eo["train_epoch"].insert(0, "ProfileAutograd begin")
+        eo["train_epoch"].append("ProfileAutograd end")
+        return eo

--- a/nupic/research/frameworks/pytorch/imagenet/mixins/regularize_loss.py
+++ b/nupic/research/frameworks/pytorch/imagenet/mixins/regularize_loss.py
@@ -24,14 +24,6 @@ class RegularizeLoss(object):
     """
     Add a regularization term to the loss function.
     """
-    def __init__(self):
-        super().__init__()
-        self.execution_order["setup_experiment"].append(
-            "RegularizeLoss initialization")
-        self.execution_order["loss_function"].append("RegularizeLoss")
-        self.execution_order["pre_epoch"].append(
-            "RegularizeLoss update regularization weight")
-
     def setup_experiment(self, config):
         """
         @param reg_schedule (list of tuples)
@@ -84,3 +76,11 @@ class RegularizeLoss(object):
         super().pre_epoch()
         if self.current_epoch in self.reg_schedule:
             self.reg_weight = self.reg_schedule[self.current_epoch]
+
+    @classmethod
+    def get_execution_order(cls):
+        eo = super().get_execution_order()
+        eo["setup_experiment"].append("RegularizeLoss initialization")
+        eo["loss_function"].append("RegularizeLoss")
+        eo["pre_epoch"].append("RegularizeLoss update regularization weight")
+        return eo

--- a/nupic/research/frameworks/pytorch/imagenet/mixins/rezero_weights.py
+++ b/nupic/research/frameworks/pytorch/imagenet/mixins/rezero_weights.py
@@ -33,12 +33,6 @@ class RezeroWeights:
     learning, so this mixin only needs to be applied on post_epoch rather than
     post_batch.
     """
-    def __init__(self):
-        super().__init__()
-        self.execution_order["setup_experiment"].append("RezeroWeights logging")
-        self.execution_order["create_model"].append("RezeroWeights")
-        self.execution_order["post_epoch"].append("RezeroWeights")
-
     def setup_experiment(self, config):
         super().setup_experiment(config)
 
@@ -74,3 +68,11 @@ class RezeroWeights:
                 params_sparse, nonzero_params_sparse1,
                 nonzero_params_sparse2,
                 float(nonzero_params_sparse2) / params_sparse)
+
+    @classmethod
+    def get_execution_order(cls):
+        eo = super().get_execution_order()
+        eo["setup_experiment"].append("RezeroWeights logging")
+        eo["create_model"].append("RezeroWeights")
+        eo["post_epoch"].append("RezeroWeights")
+        return eo

--- a/nupic/research/frameworks/pytorch/imagenet/mixins/update_boost_strength.py
+++ b/nupic/research/frameworks/pytorch/imagenet/mixins/update_boost_strength.py
@@ -26,10 +26,12 @@ class UpdateBoostStrength:
     """
     Update the KWinners boost strength before every epoch.
     """
-    def __init__(self):
-        super().__init__()
-        self.execution_order["pre_epoch"].append("UpdateBoostStrength")
-
     def pre_epoch(self):
         super().pre_epoch()
         self.model.apply(update_boost_strength)
+
+    @classmethod
+    def get_execution_order(cls):
+        eo = super().get_execution_order()
+        eo["pre_epoch"].append("UpdateBoostStrength")
+        return eo


### PR DESCRIPTION
This change factors a function `create_train_dataset` out of `create_train_dataloader`, and it puts `create_train_dataloader` functionality inside a method on the ImagenetExpreriment. The method is a classmethod so that it can be easily used by analysis tools while also being overrideable by experiment classes.

This change also does this for `create_validation_dataset`.