### PR TITLE
Make aggregation of distributed results extensible

### DIFF
--- a/nupic/research/frameworks/pytorch/imagenet/imagenet_experiment.py
+++ b/nupic/research/frameworks/pytorch/imagenet/imagenet_experiment.py
@@ -17,6 +17,7 @@
 #
 #  http://numenta.org/licenses/
 #
+import copy
 import io
 import logging
 import multiprocessing
@@ -46,6 +47,7 @@ from nupic.research.frameworks.pytorch.imagenet.experiment_utils import (
 from nupic.research.frameworks.pytorch.imagenet.network_utils import create_model
 from nupic.research.frameworks.pytorch.lr_scheduler import ComposedLRScheduler
 from nupic.research.frameworks.pytorch.model_utils import (
+    aggregate_eval_results,
     deserialize_state_dict,
     evaluate_model,
     serialize_state_dict,
@@ -469,6 +471,23 @@ class ImagenetExperiment:
     def loss_function(self, output, target, **kwargs):
         return self._loss_function(output, target, **kwargs)
 
+    @classmethod
+    def aggregate_results(cls, results):
+        """
+        Aggregate multiple processes' "run_epoch" results into a single result.
+
+        :param results:
+            A list of return values from run_epoch from different processes.
+        :type results: list
+
+        :return:
+            A single result dict with results aggregated.
+        :rtype: dict
+        """
+        result = copy.deepcopy(results[0])
+        result.update(aggregate_eval_results(results))
+        return result
+
     def get_state(self):
         """
         Get experiment serialized state as a dictionary of  byte arrays
@@ -595,4 +614,5 @@ class ImagenetExperiment:
             pre_batch=["ImagenetExperiment.pre_batch"],
             post_batch=["ImagenetExperiment.post_batch"],
             loss_function=["ImagenetExperiment.loss_function"],
+            aggregate_results=["ImagenetExperiment.aggregate_results"],
         )

--- a/nupic/research/frameworks/pytorch/imagenet/imagenet_tune.py
+++ b/nupic/research/frameworks/pytorch/imagenet/imagenet_tune.py
@@ -66,6 +66,8 @@ class ImagenetTrainable(Trainable):
         return resource
 
     def _setup(self, config):
+        self.experiment_class = config["experiment_class"]
+
         config["logdir"] = self.logdir
 
         # Configure logging related stuff
@@ -191,8 +193,6 @@ class ImagenetTrainable(Trainable):
             num_cpus = 1
 
         self._process_config(config)
-
-        self.experiment_class = config["experiment_class"]
 
         for i in range(1 + self.max_retries):
             self.procs = []


### PR DESCRIPTION
Enables mixins to handle aggregation.

In a future PR I'm adding a mixin that saves the training loss for every batch and stores it as a list in the result dict. The current PR allows me to aggregate those lists.