### PR TITLE
botorch 0.2.2 is the last version supporting  pythorch 1.4

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -77,7 +77,7 @@ jobs:
   install_dependencies:
     working_directory: ~/nta/nupic.research
     docker:
-      - image: circleci/python:3.6
+      - image: circleci/python:3.7
     steps:
       - attach_workspace:
           at: ~/nta
@@ -105,7 +105,7 @@ jobs:
   check_style:
     working_directory: ~/nta/nupic.research
     docker:
-      - image: circleci/python:3.6
+      - image: circleci/python:3.7
     steps:
       - attach_workspace:
           at: ~/nta
@@ -122,7 +122,7 @@ jobs:
   test:
     working_directory: ~/nta/nupic.research
     docker:
-      - image: circleci/python:3.6
+      - image: circleci/python:3.7
     steps:
       - attach_workspace:
           at: ~/nta
@@ -141,7 +141,7 @@ jobs:
   build:
     working_directory: ~/nta/nupic.research
     docker:
-      - image: circleci/python:3.6
+      - image: circleci/python:3.7
     steps:
       - attach_workspace:
           at: ~/nta

--- a/requirements.txt
+++ b/requirements.txt
@@ -25,6 +25,7 @@ nupic.tensorflow @ git+https://github.com/numenta/nupic.tensorflow.git
 
 awscli
 ax-platform
+botorch==0.2.2
 gpytorch==1.1.0
 boto3
 elasticsearch

--- a/setup.py
+++ b/setup.py
@@ -55,7 +55,7 @@ setup(
     version=nupic.research.__version__,
     packages=find_namespace_packages(include=["nupic.*"]),
     install_requires=requirements,
-    python_requires=">=3.6, <4",
+    python_requires=">=3.7, <4",
     classifiers=[
         "Programming Language :: Python :: 3",
         "License :: OSI Approved :: GNU Affero General Public License v3 or later "


### PR DESCRIPTION
This dependency is installed by `ax` and botorch 0.2.2 is the last version supporting  pythorch 1.4