### PR TITLE
Record every training loss. Validate often. Use batch-based timesteps.

### DIFF
--- a/nupic/research/frameworks/pytorch/imagenet/imagenet_experiment.py
+++ b/nupic/research/frameworks/pytorch/imagenet/imagenet_experiment.py
@@ -23,8 +23,10 @@ import logging
 import multiprocessing
 import sys
 import time
+from collections import defaultdict
 from pprint import pformat
 
+import numpy as np
 import ray.services
 import ray.util.sgd.utils as ray_utils
 import torch
@@ -166,6 +168,10 @@ class ImagenetExperiment:
             - epochs_to_validate: list of epochs to run validate(). A -1 asks
                                   to run validate before any training occurs.
                                   Default: last three epochs.
+            - extra_validations_per_epoch: number of additional validations to
+                                           perform mid-epoch. Additional
+                                           validations are distributed evenly
+                                           across training batches.
             - launch_time: time the config was created (via time.time). Used to report
                            wall clock time until the first batch is done.
                            Default: time.time() in this setup_experiment().
@@ -255,8 +261,6 @@ class ImagenetExperiment:
         self.num_classes = config.get("num_classes", 1000)
         self.epochs = config.get("epochs", 1)
         self.batches_in_epoch = config.get("batches_in_epoch", sys.maxsize)
-        self.epochs_to_validate = config.get("epochs_to_validate",
-                                             range(self.epochs - 3, self.epochs + 1))
         self.current_epoch = 0
 
         # Get initial batch size
@@ -271,6 +275,35 @@ class ImagenetExperiment:
         self.train_loader = self.create_train_dataloader(config)
         self.val_loader = self.create_validation_dataloader(config)
         self.total_batches = len(self.train_loader)
+
+        self.epochs_to_validate = config.get("epochs_to_validate",
+                                             range(self.epochs - 3,
+                                                   self.epochs + 1))
+
+        extra_validations = config.get("extra_validations_per_epoch", 0)
+        batches_to_validate = np.linspace(
+            min(self.total_batches, self.batches_in_epoch),
+            0,
+            1 + extra_validations,
+            endpoint=False
+        )[::-1].round().astype("int").tolist()
+        self.additional_batches_to_validate = batches_to_validate[:-1]
+        if extra_validations > 0:
+            self.logger.info(
+                f"Extra validations per epoch: {extra_validations}, "
+                f"batch indices: {self.additional_batches_to_validate}")
+
+        # Used for logging. Conceptually, it is a version number for the model's
+        # parameters. By default, this is the elapsed number of batches that the
+        # model has been trained on. Experiments may also increment this on
+        # other events like model prunings. When validation is performed after a
+        # training batch, the validation results are assigned to the next
+        # timestep after that training batch, since it was performed on the
+        # subsequent version of the parameters.
+        self.current_timestep = 0
+
+        # A list of [(timestep, result), ...] for the current epoch.
+        self.extra_val_results = []
 
         # Configure learning rate scheduler
         lr_scheduler_class = config.get("lr_scheduler_class", None)
@@ -394,7 +427,7 @@ class ImagenetExperiment:
             complexity_loss_fn=self.complexity_loss,
             batches_in_epoch=self.batches_in_epoch,
             pre_batch_callback=self.pre_batch,
-            post_batch_callback=self.post_batch,
+            post_batch_callback=self.post_batch_wrapper,
             transform_to_device_fn=self.transform_data_to_device,
         )
 
@@ -415,7 +448,9 @@ class ImagenetExperiment:
             }
 
         ret.update(
+            timestep=self.current_timestep,
             learning_rate=self.get_lr()[0],
+            extra_val_results=self.extra_val_results,
         )
 
         if self.rank == 0:
@@ -423,6 +458,7 @@ class ImagenetExperiment:
             self.logger.debug("---------- End of run epoch ------------")
             self.logger.debug("")
 
+        self.extra_val_results = []
         self.current_epoch += 1
         return ret
 
@@ -454,6 +490,24 @@ class ImagenetExperiment:
                               self.rank, self.current_epoch, current_batch,
                               total_batches, loss, self.get_lr(), num_images)
             self.logger.debug("Timing: %s", time_string)
+
+    def post_batch_wrapper(self, model, loss, batch_idx, *args, **kwargs):
+        """
+        Perform the post_batch updates, then maybe validate.
+
+        This method exists because post_batch is designed to be overridden, and
+        validation needs to wait until after all post_batch overrides have run.
+        """
+        self.post_batch(model, loss, batch_idx, *args, **kwargs)
+        self.current_timestep += 1
+        validate = (batch_idx in self.additional_batches_to_validate
+                    and self.current_epoch in self.epochs_to_validate)
+        if validate:
+            result = self.validate()
+            self.extra_val_results.append(
+                (self.current_timestep, result)
+            )
+            self.model.train()
 
     def post_epoch(self):
         self.logger.debug("End of epoch %s LR/weight decay before step: %s/%s",
@@ -501,7 +555,19 @@ class ImagenetExperiment:
             A single result dict with results aggregated.
         :rtype: dict
         """
-        return cls.aggregate_validation_results(results)
+        ret = cls.aggregate_validation_results(results)
+
+        extra_val_aggregated = []
+        for i in range(len(ret["extra_val_results"])):
+            timestep = ret["extra_val_results"][i][0]
+            val_results = [process_result["extra_val_results"][i][1]
+                           for process_result in results]
+            extra_val_aggregated.append(
+                (timestep, aggregate_eval_results(val_results))
+            )
+        ret["extra_val_results"] = extra_val_aggregated
+
+        return ret
 
     @classmethod
     def aggregate_validation_results(cls, results):
@@ -526,13 +592,57 @@ class ImagenetExperiment:
         result.update(aggregate_eval_results(results))
         return result
 
+    @classmethod
+    def get_printable_result(cls, result):
+        """
+        Return a stripped down version of result that has its large data structures
+        removed so that the result can be printed to the console.
+        """
+        keys = ["total_correct", "total_tested", "mean_loss", "mean_accuracy",
+                "learning_rate", "timestep"]
+        return {key: result[key]
+                for key in keys
+                if key in result}
+
+    @classmethod
+    def expand_result_to_time_series(cls, result):
+        """
+        Given the result of a run_epoch call, returns a mapping from timesteps to
+        results. The mapping is stored as a dict so that subclasses and mixins
+        can easily add data to it.
+
+        Result keys are converted from Ray Tune requirements to better names,
+        and the keys are filtered to those that make useful charts.
+
+        :return: defaultdict mapping timesteps to result dicts
+        """
+        result_by_timestep = defaultdict(dict)
+
+        k_mapping = {
+            "mean_loss": "validation_loss",
+            "mean_accuracy": "validation_accuracy",
+            "learning_rate": "learning_rate",
+            "complexity_loss": "complexity_loss",
+        }
+        val_results = (result["extra_val_results"]
+                       + [(result["timestep"], result)])
+        for timestep, val_result in val_results:
+            result_by_timestep[timestep].update({
+                k2: val_result[k1]
+                for k1, k2 in k_mapping.items()
+                if k1 in val_result
+            })
+
+        return result_by_timestep
+
     def get_state(self):
         """
         Get experiment serialized state as a dictionary of  byte arrays
         :return: dictionary with "model", "optimizer" and "lr_scheduler" states
         """
         state = {
-            "current_epoch": self.current_epoch
+            "current_epoch": self.current_epoch,
+            "current_timestep": self.current_timestep,
         }
 
         # Save state into a byte array to avoid ray's GPU serialization issues
@@ -595,6 +705,9 @@ class ImagenetExperiment:
                 self.current_epoch = last_epoch // steps_per_epoch
             else:
                 self.current_epoch = last_epoch
+
+        if "current_timestep" in state:
+            self.current_timestep = state["current_timestep"]
 
     def stop_experiment(self):
         if self.distributed:
@@ -659,5 +772,9 @@ class ImagenetExperiment:
             aggregate_results=["ImagenetExperiment.aggregate_results"],
             aggregate_validation_results=[
                 "ImagenetExperiment.aggregate_validation_results"
+            ],
+            get_printable_result=["ImagenetExperiment.get_printable_result"],
+            expand_result_to_time_series=[
+                "ImagenetExperiment: validation results"
             ],
         )

--- a/nupic/research/frameworks/pytorch/imagenet/imagenet_experiment.py
+++ b/nupic/research/frameworks/pytorch/imagenet/imagenet_experiment.py
@@ -708,6 +708,8 @@ class ImagenetExperiment:
 
         if "current_timestep" in state:
             self.current_timestep = state["current_timestep"]
+        else:
+            self.current_timestep = self.total_batches * self.current_epoch
 
     def stop_experiment(self):
         if self.distributed:

--- a/nupic/research/frameworks/pytorch/imagenet/mixins/log_every_learning_rate.py
+++ b/nupic/research/frameworks/pytorch/imagenet/mixins/log_every_learning_rate.py
@@ -1,0 +1,79 @@
+# ----------------------------------------------------------------------
+# Numenta Platform for Intelligent Computing (NuPIC)
+# Copyright (C) 2020, Numenta, Inc.  Unless you have an agreement
+# with Numenta, Inc., for a separate license for this software code, the
+# following terms and conditions apply:
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# See the GNU Affero Public License for more details.
+#
+# You should have received a copy of the GNU Affero Public License
+# along with this program.  If not, see http://www.gnu.org/licenses.
+#
+# http://numenta.org/licenses/
+# ----------------------------------------------------------------------
+
+
+class LogEveryLearningRate:
+    """
+    Include the learning rate for every batch in the result dict.
+    """
+    def setup_experiment(self, config):
+        super().setup_experiment(config)
+        self.lr_history = []
+        self.momentum_history = []
+
+    def post_batch(self, *args, **kwargs):
+        super().post_batch(*args, **kwargs)
+
+        # Get the lr and momentum from the first param group.
+        for param_group in self.optimizer.param_groups:
+            lr = param_group["lr"]
+            momentum = param_group["momentum"]
+            break
+
+        self.lr_history.append(lr)
+        self.momentum_history.append(momentum)
+
+    def run_epoch(self):
+        result = super().run_epoch()
+
+        result["lr_history"] = self.lr_history
+        self.lr_history = []
+        result["momentum_history"] = self.momentum_history
+        self.momentum_history = []
+
+        return result
+
+    @classmethod
+    def expand_result_to_time_series(cls, result):
+        result_by_timestep = super().expand_result_to_time_series(result)
+
+        elapsed = result["timestep"]
+        for t, lr, momentum in zip(range(elapsed - len(result["lr_history"]),
+                                         elapsed),
+                                   result["lr_history"],
+                                   result["momentum_history"]):
+            result_by_timestep[t].update(
+                learning_rate=lr,
+                momentum=momentum,
+            )
+
+        return result_by_timestep
+
+    @classmethod
+    def get_execution_order(cls):
+        eo = super().get_execution_order()
+        eo["setup_experiment"].append("LogEveryLearningRate: initialize")
+        eo["post_batch"].append("LogEveryLearningRate: copy learning rate")
+        eo["run_epoch"].append("LogEveryLearningRate: to result dict")
+        eo["expand_result_to_time_series"].append(
+            "LogEveryLearningRate: learning_rate, momentum"
+        )
+        return eo

--- a/nupic/research/frameworks/pytorch/imagenet/mixins/log_every_loss.py
+++ b/nupic/research/frameworks/pytorch/imagenet/mixins/log_every_loss.py
@@ -1,0 +1,119 @@
+# ----------------------------------------------------------------------
+# Numenta Platform for Intelligent Computing (NuPIC)
+# Copyright (C) 2020, Numenta, Inc.  Unless you have an agreement
+# with Numenta, Inc., for a separate license for this software code, the
+# following terms and conditions apply:
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# See the GNU Affero Public License for more details.
+#
+# You should have received a copy of the GNU Affero Public License
+# along with this program.  If not, see http://www.gnu.org/licenses.
+#
+# http://numenta.org/licenses/
+# ----------------------------------------------------------------------
+
+import torch
+
+
+class LogEveryLoss:
+    """
+    Include the training loss for every batch in the result dict.
+
+    This class must be placed earlier in the mixin order than other mixins that
+    modify the loss.
+
+    class MyExperiment(mixins.LogEveryLoss,
+                       ...
+                       mixins.RegularizeLoss,
+                       ImagenetExperiment):
+        pass
+
+    """
+    def setup_experiment(self, config):
+        super().setup_experiment(config)
+        self.error_loss_history = []
+        self.complexity_loss_history = []
+
+    def error_loss(self, *args, **kwargs):
+        loss = super().error_loss(*args, **kwargs)
+        if self.model.training:
+            self.error_loss_history.append(loss.detach().clone())
+        return loss
+
+    def complexity_loss(self, *args, **kwargs):
+        loss = super().complexity_loss(*args, **kwargs)
+        if loss is not None:
+            if self.model.training:
+                self.complexity_loss_history.append(loss.detach().clone())
+        return loss
+
+    def run_epoch(self):
+        result = super().run_epoch()
+
+        log = torch.stack(self.error_loss_history)
+        result["error_loss_history"] = log.cpu().numpy().tolist()
+        self.error_loss_history = []
+
+        if len(self.complexity_loss_history) > 0:
+            log = torch.stack(self.complexity_loss_history)
+            result["complexity_loss_history"] = log.cpu().numpy().tolist()
+            self.complexity_loss_history = []
+
+        return result
+
+    @classmethod
+    def aggregate_results(cls, results):
+        aggregated = super().aggregate_results(results)
+
+        k = "error_loss_history"
+        loss_by_process_and_batch = torch.Tensor(len(results),
+                                                 len(results[0][k]))
+        for rank, result in enumerate(results):
+            loss_by_process_and_batch[rank, :] = torch.tensor(result[k])
+        aggregated[k] = loss_by_process_and_batch.mean(dim=0).tolist()
+
+        # "complexity_loss_history" doesn't need to be aggregated, since it's
+        # the same on every process.
+
+        return aggregated
+
+    @classmethod
+    def expand_result_to_time_series(cls, result):
+        result_by_timestep = super().expand_result_to_time_series(result)
+
+        end = result["timestep"]
+        start = end - len(result["error_loss_history"])
+        for t, loss in zip(range(start, end),
+                           result["error_loss_history"]):
+            result_by_timestep[t].update(
+                train_loss=loss,
+            )
+
+        if "complexity_loss_history" in result:
+            for t, loss in zip(range(start, end),
+                               result["complexity_loss_history"]):
+                result_by_timestep[t].update(
+                    complexity_loss=loss,
+                )
+
+        return result_by_timestep
+
+    @classmethod
+    def get_execution_order(cls):
+        eo = super().get_execution_order()
+        eo["setup_experiment"].append("LogEveryLoss: initialize")
+        eo["error_loss"].append("LogEveryLoss: copy loss")
+        eo["complexity_loss"].append("LogEveryLoss: copy loss")
+        eo["run_epoch"].append("LogEveryLoss: to result dict")
+        eo["aggregate_results"].append("LogEveryLoss: Aggregate")
+        eo["expand_result_to_time_series"].append(
+            "LogEveryLoss: error_loss, complexity_loss"
+        )
+        return eo

--- a/nupic/research/frameworks/pytorch/imagenet/mixins/log_every_loss.py
+++ b/nupic/research/frameworks/pytorch/imagenet/mixins/log_every_loss.py
@@ -35,6 +35,9 @@ class LogEveryLoss:
                        ImagenetExperiment):
         pass
 
+    These numbers are stored on the GPU until the end of the epoch. If every
+    kilobyte of GPU memory is being used by the experiment, this could result in
+    running out of memory.
     """
     def setup_experiment(self, config):
         super().setup_experiment(config)

--- a/nupic/research/frameworks/pytorch/imagenet/mixins/regularize_loss.py
+++ b/nupic/research/frameworks/pytorch/imagenet/mixins/regularize_loss.py
@@ -26,6 +26,11 @@ class RegularizeLoss(object):
     """
     Implement the complexity_loss as the sum all module.regularization()
     functions, times some specified scalar.
+
+    This mixin also records the model complexity (the regularization() sum) for
+    each batch. These numbers are stored on the GPU until the end of the epoch.
+    If every kilobyte of GPU memory is being used by the experiment, this could
+    result in running out of memory.
     """
     def setup_experiment(self, config):
         """

--- a/projects/imagenet/experiments/base.py
+++ b/projects/imagenet/experiments/base.py
@@ -128,6 +128,12 @@ DEFAULT = dict(
 
     # Python Logging Format
     log_format="%(asctime)s:%(levelname)s:%(name)s:%(message)s",
+
+    # Ray tune verbosity. When set to the default value of 2 it will log
+    # iteration result dicts. This dict can flood the console if it contains
+    # large data structures, so default to verbose=1. The ImagenetTrainable logs
+    # a succinct version of the result dict.
+    verbose=1,
 )
 
 DEBUG = copy.deepcopy(DEFAULT)


### PR DESCRIPTION
This change:

- Adds mixins that log every training loss to the result dict
  - There is very little performance overhead; they are copied from the GPU at the end of the epoch.
  - Similarly, I log the learning rate, momentum, and regularization info.
- Changes the `ImagenetExperiment` to support multiple validations per epoch.
- Adds logic for converting an epoch result dict to a time series, and adds support to our `WandbLogger`

With this change I am making it more common for us to put large data structures in the result dict, so I added logic to ensure those large data structures don't get printed to the console.