### PR TITLE
RES-1492: Add script to run distributed imagenet experiments on a single node multi GPU without ray tune

### DIFF
--- a/nupic/research/frameworks/pytorch/imagenet/__init__.py
+++ b/nupic/research/frameworks/pytorch/imagenet/__init__.py
@@ -20,5 +20,4 @@
 
 from .common_experiments import *
 from .imagenet_experiment import ImagenetExperiment
-from .imagenet_tune import ImagenetTrainable
 from .auto_augment import ImageNetPolicy

--- a/nupic/research/frameworks/pytorch/imagenet/experiment_utils.py
+++ b/nupic/research/frameworks/pytorch/imagenet/experiment_utils.py
@@ -271,3 +271,10 @@ def get_free_port():
         # removed socket.SO_REUSEADDR arg
         # TCP error due to two process with same rank in same port - maybe a fix
         return s.getsockname()[1]
+
+
+def get_node_ip_address():
+    """
+    Determine the IP address of the local node.
+    """
+    return socket.gethostbyname(socket.getfqdn())

--- a/nupic/research/frameworks/pytorch/imagenet/imagenet_experiment.py
+++ b/nupic/research/frameworks/pytorch/imagenet/imagenet_experiment.py
@@ -20,7 +20,6 @@
 import copy
 import io
 import logging
-from torch import multiprocessing
 import sys
 import time
 from collections import defaultdict
@@ -29,6 +28,7 @@ from pprint import pformat
 import numpy as np
 import torch
 import torch.distributed as dist
+from torch import multiprocessing
 from torch.backends import cudnn
 from torch.nn import DataParallel
 from torch.nn.parallel import DistributedDataParallel

--- a/nupic/research/frameworks/pytorch/imagenet/imagenet_experiment.py
+++ b/nupic/research/frameworks/pytorch/imagenet/imagenet_experiment.py
@@ -20,15 +20,13 @@
 import copy
 import io
 import logging
-import multiprocessing
+from torch import multiprocessing
 import sys
 import time
 from collections import defaultdict
 from pprint import pformat
 
 import numpy as np
-import ray.services
-import ray.util.sgd.utils as ray_utils
 import torch
 import torch.distributed as dist
 from torch.backends import cudnn
@@ -45,6 +43,8 @@ from nupic.research.frameworks.pytorch.imagenet.experiment_utils import (
     create_optimizer,
     create_train_dataset,
     create_validation_dataset,
+    get_free_port,
+    get_node_ip_address,
 )
 from nupic.research.frameworks.pytorch.imagenet.network_utils import create_model
 from nupic.research.frameworks.pytorch.lr_scheduler import ComposedLRScheduler
@@ -270,8 +270,7 @@ class ImagenetExperiment:
 
         # CUDA runtime does not support the fork start method.
         # See https://pytorch.org/docs/stable/notes/multiprocessing.html
-        if torch.cuda.is_available():
-            multiprocessing.set_start_method("spawn")
+        multiprocessing.set_start_method("spawn", force=True)
 
         # Configure data loaders
         self.train_loader = self.create_train_dataloader(config)
@@ -746,12 +745,12 @@ class ImagenetExperiment:
         return [p["weight_decay"] for p in self.optimizer.param_groups]
 
     def get_node_ip(self):
-        """Returns the IP address of the current ray node."""
-        return ray.services.get_node_ip_address()
+        """Returns the IP address of the current node."""
+        return get_node_ip_address()
 
     def get_free_port(self):
-        """Returns free TCP port in the current ray node"""
-        return ray_utils.find_free_port()
+        """Returns free TCP port in the current node"""
+        return get_free_port()
 
     @classmethod
     def get_execution_order(cls):

--- a/nupic/research/frameworks/pytorch/imagenet/imagenet_run.py
+++ b/nupic/research/frameworks/pytorch/imagenet/imagenet_run.py
@@ -30,7 +30,6 @@ import torch.multiprocessing as mp
 from nupic.research.frameworks.pytorch.imagenet import ImagenetExperiment
 from nupic.research.frameworks.pytorch.imagenet.experiment_utils import get_free_port
 
-
 # Disable HDF5 locking
 os.environ["HDF5_USE_FILE_LOCKING"] = "FALSE"
 

--- a/nupic/research/frameworks/pytorch/imagenet/imagenet_run.py
+++ b/nupic/research/frameworks/pytorch/imagenet/imagenet_run.py
@@ -1,0 +1,171 @@
+#  Numenta Platform for Intelligent Computing (NuPIC)
+#  Copyright (C) 2020, Numenta, Inc.  Unless you have an agreement
+#  with Numenta, Inc., for a separate license for this software code, the
+#  following terms and conditions apply:
+#
+#  This program is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU Affero Public License version 3 as
+#  published by the Free Software Foundation.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#  See the GNU Affero Public License for more details.
+#
+#  You should have received a copy of the GNU Affero Public License
+#  along with this program.  If not, see http://www.gnu.org/licenses.
+#
+#  http://numenta.org/licenses/
+#
+import collections
+import os
+import pickle
+import time
+import uuid
+from datetime import datetime
+
+import torch.distributed as dist
+import torch.multiprocessing as mp
+
+from nupic.research.frameworks.pytorch.imagenet import ImagenetExperiment
+from nupic.research.frameworks.pytorch.imagenet.experiment_utils import get_free_port
+
+
+# Disable HDF5 locking
+os.environ["HDF5_USE_FILE_LOCKING"] = "FALSE"
+
+
+def worker(rank, world_size, dist_url, config, queue):
+    """
+    Main distributed training worker process
+    """
+    # Limit this process to a single GPU deriving GPU ID from worker rank
+    os.environ["CUDA_VISIBLE_DEVICES"] = str(rank)
+
+    # Update config with distributed parameters
+    config["dist_url"] = dist_url
+    config["rank"] = rank
+    config["world_size"] = world_size
+    config["distributed"] = True
+
+    # Setup imagenet experiment for this process
+    experiment_class = config.get("experiment_class", ImagenetExperiment)
+    assert issubclass(experiment_class, ImagenetExperiment)
+    exp = experiment_class()
+    exp.setup_experiment(config)
+
+    # Wait until all processes have finished setting up
+    dist.barrier()
+
+    # Check if restoring experiment from checkpoint
+    checkpoint_file = config.get("checkpoint_file", None)
+    if checkpoint_file is not None:
+        with open(checkpoint_file, mode="rb") as f:
+            state = pickle.load(f)
+            exp.set_state(state)
+            # Wait until all processes have finished loading the checkpoint
+            dist.barrier()
+
+    checkpoint_at_end = config.get("checkpoint_at_end", False)
+    checkpoint_freq = config.get("checkpoint_freq", 0)
+
+    # Run experiment
+    while not exp.should_stop():
+        result = exp.run_epoch()
+        epoch = exp.get_current_epoch()
+        should_checkpoint = False
+        if rank == 0:
+            if checkpoint_at_end and exp.should_stop():
+                should_checkpoint = True
+            elif checkpoint_freq > 0 and (epoch % checkpoint_freq) == 0:
+                should_checkpoint = True
+
+        checkpoint = exp.get_state() if should_checkpoint else None
+        queue.put((epoch, result, checkpoint))
+
+    exp.stop_experiment()
+
+    # Signal this worker is done by returning None
+    queue.put(None)
+
+
+def run(config, logger=None, on_checkpoint=None):
+    """
+    Run ImagenetExperiment distributed training using torch.multiprocessing
+    given it's configuration
+    :param config: Experiment configuration
+    :param logger: Optional result logger callback reporting the results on
+                   each epoch. "function(result)"
+    :param on_checkpoint: Optional checkpoint callback called whenever a
+                          checkpoint is available. "function(epoch, checkpoint)"
+    :return: List with all results.
+    """
+    if logger is not None:
+        assert callable(logger)
+
+    num_gpus = config.get("num_gpus", 0)
+    num_cpus = config.get("num_cpus", 1)
+    experiment_class = config.get("experiment_class", ImagenetExperiment)
+    experiment_tag = config.pop("experiment_tag", None)
+    experiment_id = uuid.uuid4().hex
+
+    # Determine the number of distributed processes based on the number GPUs and CPUs
+    if num_gpus > 0:
+        world_size = num_gpus
+    else:
+        world_size = num_cpus
+
+    # Launch worker processes using a SimpleQueue to collect the results
+    dist_url = f"tcp://localhost:{get_free_port()}"
+    queue = mp.SimpleQueue()
+    ctx = mp.spawn(worker, args=(world_size, dist_url, config, queue),
+                   nprocs=world_size, join=False)  # non-blocking
+
+    # Collect worker results as they become available waiting until all worker
+    # processes are done.
+    worker_results = collections.defaultdict(list)
+    results = []
+    pending_workers = world_size
+    t1 = t0 = time.time()
+    while pending_workers > 0:
+        item = queue.get()
+        if item is None:
+            # The worker process returns None when it is done
+            pending_workers -= 1
+        else:
+            epoch, data, checkpoint = item
+            worker_results[epoch].append(data)
+            if on_checkpoint is not None and checkpoint is not None:
+                on_checkpoint(epoch, checkpoint)
+
+            # Aggregated worker results at the end of each epoch
+            epoch_result = worker_results[epoch]
+            if len(epoch_result) == world_size:
+                t2 = time.time()
+                epoch_result = experiment_class.aggregate_results(epoch_result)
+
+                # Update ray.tune fields
+                now = datetime.today()
+                epoch_result.update(training_iteration=epoch,
+                                    time_this_iter_s=t2 - t1,
+                                    time_total_s=t2 - t0,
+                                    date=now.strftime("%Y-%m-%d_%H-%M-%S"),
+                                    timestamp=int(time.mktime(now.timetuple())),
+                                    pid=os.getpid(),
+                                    hostname=os.uname()[1],
+                                    config=config,
+                                    experiment_tag=experiment_tag,
+                                    experiment_id=experiment_id,
+                                    neg_mean_loss=-epoch_result["mean_loss"],
+                                    timesteps_total=epoch_result.get("timestep", 0)
+                                    )
+                # Log epoch result
+                results.append(epoch_result)
+                if logger is not None:
+                    logger(epoch_result)
+                t1 = t2
+
+    # Wait until all worker processes terminate
+    ctx.join()
+
+    return results

--- a/nupic/research/support/ray_utils.py
+++ b/nupic/research/support/ray_utils.py
@@ -23,6 +23,9 @@ import os
 
 import ray
 import torch
+from ray.tune.suggest.variant_generator import (
+    generate_variants, format_vars
+)
 from ray.tune.trial_runner import _TuneFunctionDecoder
 
 
@@ -183,3 +186,26 @@ def register_torch_serializers():
         ray.register_custom_serializer(
             tensor_type, serializer=serializer, deserializer=deserializer
         )
+
+
+def generate_trial_variants(config):
+    """
+    Generate configuration for each trial variant evaluating 'ray.tune'
+    functions (grid_search, sample_from, ...) into its final values.
+
+    :param config: Ray tune configuration with 'ray.tune' functions
+    :return: list of dict for each trial configuration variant
+    """
+    trials = []
+    num_samples = config["num_samples"]
+    for i in range(num_samples):
+        for variables, variant in generate_variants(config):
+            # Update experiment tag with variant vars
+            if len(variables) > 0:
+                variant["experiment_tag"] = f"{i}_{format_vars(variables)}"
+            else:
+                variant["experiment_tag"] = str(i)
+
+            trials.append(variant)
+
+    return trials

--- a/nupic/research/support/ray_utils.py
+++ b/nupic/research/support/ray_utils.py
@@ -23,9 +23,7 @@ import os
 
 import ray
 import torch
-from ray.tune.suggest.variant_generator import (
-    generate_variants, format_vars
-)
+from ray.tune.suggest.variant_generator import format_vars, generate_variants
 from ray.tune.trial_runner import _TuneFunctionDecoder
 
 

--- a/projects/imagenet/local_run.py
+++ b/projects/imagenet/local_run.py
@@ -31,12 +31,12 @@ from functools import partial
 import torch
 import torch.multiprocessing as multiprocessing
 
-from nupic.research.frameworks.pytorch.imagenet import imagenet_run
 from nupic.research.frameworks.pytorch.imagenet import (
-    mixins, ImagenetExperiment
+    ImagenetExperiment,
+    imagenet_run,
+    mixins,
 )
 from nupic.research.frameworks.sigopt.sigopt_experiment import SigOptImagenetExperiment
-
 
 multiprocessing.set_start_method("spawn", force=True)
 
@@ -44,10 +44,8 @@ multiprocessing.set_start_method("spawn", force=True)
 def insert_experiment_mixin(config, mixin):
     experiment_class = config["experiment_class"]
 
-
     class Cls(mixin, experiment_class):
         pass
-
 
     Cls.__name__ = f"{mixin.__name__}{experiment_class.__name__}"
     config["experiment_class"] = Cls

--- a/projects/imagenet/local_run.py
+++ b/projects/imagenet/local_run.py
@@ -1,0 +1,190 @@
+#  Numenta Platform for Intelligent Computing (NuPIC)
+#  Copyright (C) 2020, Numenta, Inc.  Unless you have an agreement
+#  with Numenta, Inc., for a separate license for this software code, the
+#  following terms and conditions apply:
+#
+#  This program is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU Affero Public License version 3 as
+#  published by the Free Software Foundation.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#  See the GNU Affero Public License for more details.
+#
+#  You should have received a copy of the GNU Affero Public License
+#  along with this program.  If not, see http://www.gnu.org/licenses.
+#
+#  http://numenta.org/licenses/
+#
+"""
+Use this script to run Imagenet Experiments on a single node using Distributed
+Data Parallel (DDP) without ray
+"""
+import argparse
+import copy
+import os
+import tempfile
+from datetime import datetime
+from functools import partial
+
+import torch
+import torch.multiprocessing as multiprocessing
+
+from nupic.research.frameworks.pytorch.imagenet import imagenet_run
+from nupic.research.frameworks.pytorch.imagenet import (
+    mixins, ImagenetExperiment
+)
+from nupic.research.frameworks.sigopt.sigopt_experiment import SigOptImagenetExperiment
+
+
+multiprocessing.set_start_method("spawn", force=True)
+
+
+def insert_experiment_mixin(config, mixin):
+    experiment_class = config["experiment_class"]
+
+
+    class Cls(mixin, experiment_class):
+        pass
+
+
+    Cls.__name__ = f"{mixin.__name__}{experiment_class.__name__}"
+    config["experiment_class"] = Cls
+
+
+def create_trials(config):
+    """
+    Create trial configuration for each trial variant evaluating 'ray.tune'
+    functions (grid_search, sample_from, ...) into its final values and
+    creating the local and log dir for each trial
+
+    :param config: Ray tune configuration with 'ray.tune' functions
+    :return: list of dict for each trial configuration variant
+    """
+    from nupic.research.support.ray_utils import generate_trial_variants
+    trials = generate_trial_variants(config)
+    timestamp = datetime.today().strftime("%Y-%m-%d_%H-%M-%S")
+
+    for variant in trials:
+        # Create local dir
+        local_dir = os.path.join(
+            os.path.expanduser(variant["local_dir"]), variant["name"])
+        variant["local_dir"] = local_dir
+        os.makedirs(local_dir, exist_ok=True)
+
+        # Create logdir
+        experiment_class = variant.get("experiment_class", ImagenetExperiment)
+        experiment_tag = variant["experiment_tag"]
+        log_prefix = f"{experiment_class.__name__}_{experiment_tag}_{timestamp}"
+        logdir = tempfile.mkdtemp(dir=local_dir, prefix=log_prefix)
+        variant["logdir"] = logdir
+
+    return trials
+
+
+def save_checkpoint(config, epoch, checkpoint):
+    """
+    Callback responsible to save experiment checkpoint.
+    It will store the checkpoint in the same location as ray.tune
+    """
+    import pickle
+    logdir = config["logdir"]
+    checkpoint_dir = os.path.join(logdir, f"checkpoint_{epoch}")
+    os.makedirs(checkpoint_dir, exist_ok=True)
+    checkpoint_file = os.path.join(checkpoint_dir, "checkpoint")
+    with open(checkpoint_file, mode="wb") as f:
+        pickle.dump(checkpoint, f)
+
+
+def run_trial(trial_config):
+    """
+    Run a single trial configuration
+    """
+    # Configure ray.tune loggers
+    from ray.tune.logger import UnifiedLogger
+    logger = UnifiedLogger(config=trial_config,
+                           logdir=trial_config["logdir"],
+                           loggers=trial_config.get("loggers", None))
+
+    result = imagenet_run.run(config=trial_config,
+                              logger=logger.on_result,
+                              on_checkpoint=partial(save_checkpoint, trial_config))
+
+    logger.flush()
+    logger.close()
+    return result
+
+
+if __name__ == "__main__":
+    # The spawned 'imagenet_run.run' process does not import 'ray' however some
+    # configurations in the experiment package import 'ray' and 'ray.tune'. When
+    # 'ray' is imported after 'pickle' it throws an exception. We avoid this
+    # exception by loading the configurations in "main" local context instead of
+    # the global context
+    from experiments import CONFIGS
+
+    parser = argparse.ArgumentParser(
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+        argument_default=argparse.SUPPRESS,
+        description=__doc__
+    )
+    parser.add_argument("-e", "--experiment", dest="name",
+                        help="Experiment to run", choices=CONFIGS.keys())
+    parser.add_argument("-g", "--num-gpus", type=int,
+                        default=torch.cuda.device_count(),
+                        help="number of GPUs to use")
+    parser.add_argument("-n", "--num-cpus", type=int,
+                        default=torch.get_num_interop_threads(),
+                        help="number of CPUs to use when GPU is not available."),
+    parser.add_argument("-c", "--checkpoint-file", dest="restore_checkpoint_file",
+                        help="Resume experiment from specific checkpoint file")
+    parser.add_argument("-j", "--workers", type=int, default=6,
+                        help="Number of dataloaders workers")
+    parser.add_argument("-b", "--backend", choices=["nccl", "gloo"],
+                        help="Pytorch Distributed backend", default="nccl")
+    parser.add_argument("-p", "--progress", action="store_true",
+                        help="Show progress during training")
+    parser.add_argument("-l", "--log-level",
+                        choices=["critical", "error", "warning", "info", "debug"],
+                        help="Python Logging level")
+    parser.add_argument("-f", "--log-format",
+                        help="Python Logging Format")
+    parser.add_argument("-x", "--max-failures", type=int,
+                        help="How many times to try to recover before stopping")
+    parser.add_argument("--checkpoint-freq", type=int,
+                        help="How often to checkpoint (epochs)")
+    parser.add_argument("--profile", action="store_true",
+                        help="Enable torch.autograd.profiler.profile during training")
+    parser.add_argument("--profile-autograd", action="store_true",
+                        help="Enable torch.autograd.profiler.profile during training")
+    parser.add_argument("-t", "--create_sigopt", action="store_true",
+                        help="Create a new sigopt experiment using the config")
+
+    args = parser.parse_args()
+    if "name" not in args:
+        parser.print_help()
+        exit(1)
+
+    # Get configuration values
+    config = copy.deepcopy(CONFIGS[args.name])
+
+    # Merge configuration with command line arguments
+    config.update(vars(args))
+
+    if "profile" in args and args.profile:
+        insert_experiment_mixin(config, mixins.Profile)
+
+    if "profile_autograd" in args and args.profile_autograd:
+        insert_experiment_mixin(config, mixins.ProfileAutograd)
+
+    if "create_sigopt" in args:
+        s = SigOptImagenetExperiment()
+        s.create_experiment(config["sigopt_config"])
+        print(
+            "Created experiment: https://app.sigopt.com/experiment/"
+            + str(s.experiment_id))
+
+    results = []
+    for trial in create_trials(config):
+        results.append(run_trial(trial))

--- a/setup.cfg
+++ b/setup.cfg
@@ -66,6 +66,7 @@ include_trailing_comma = True
 force_grid_wrap = 0
 use_parentheses = True
 line_length = 88
+known_standard_library = posixpath
 known_first_party = nupic.research, nupic.torch, nupic.tensorflow
 known_third_party = tabulate, tqdm
 

--- a/setup.py
+++ b/setup.py
@@ -21,10 +21,9 @@
 # ------------------------------------------------------------------------------
 from os import path
 
-from setuptools import setup, find_namespace_packages
+from setuptools import find_namespace_packages, setup
 
 import nupic.research
-
 
 ROOT = path.abspath(path.dirname(__file__))
 


### PR DESCRIPTION
This PR removes ray dependencies from `imagenet_experiment.py` and adds a new script script to run distributed imagenet experiments on a single node using multi GPUs without ray tune.
The new script is called `local_run.py` and uses the same command line interface as the original ray tune version. For example:
```
python local_run.py -e default_sparse_1000
```
Will run the `default_sparse_1000` experiment on the local node using all available GPUs

