### PR TITLE
Control batch logging with config["log_timestep_freq"]

### DIFF
--- a/nupic/research/frameworks/pytorch/imagenet/imagenet_experiment.py
+++ b/nupic/research/frameworks/pytorch/imagenet/imagenet_experiment.py
@@ -20,6 +20,7 @@
 import copy
 import io
 import logging
+import math
 import sys
 import time
 from collections import defaultdict
@@ -139,6 +140,10 @@ class ImagenetExperiment:
             - epochs: Number of epochs to train
             - batches_in_epoch: Number of batches per epoch.
                                 Useful for debugging
+            - log_timestep_freq: Configures mixins and subclasses that log every
+                                 timestep to only log every nth timestep (in
+                                 addition to the final timestep of each epoch).
+                                 Set to 0 to log only at the end of each epoch.
             - progress: Show progress during training
             - name: Experiment name. Used as logger name
             - log_level: Python Logging level
@@ -302,6 +307,7 @@ class ImagenetExperiment:
         # timestep after that training batch, since it was performed on the
         # subsequent version of the parameters.
         self.current_timestep = 0
+        self.log_timestep_freq = config.get("log_timestep_freq", 1)
 
         # A list of [(timestep, result), ...] for the current epoch.
         self.extra_val_results = []
@@ -434,6 +440,7 @@ class ImagenetExperiment:
         )
 
     def run_epoch(self):
+        timestep_begin = self.current_timestep
         self.pre_epoch()
         self.train_epoch()
         self.post_epoch()
@@ -450,7 +457,8 @@ class ImagenetExperiment:
             }
 
         ret.update(
-            timestep=self.current_timestep,
+            timestep_begin=timestep_begin,
+            timestep_end=self.current_timestep,
             learning_rate=self.get_lr()[0],
             extra_val_results=self.extra_val_results,
         )
@@ -471,7 +479,8 @@ class ImagenetExperiment:
     def pre_batch(self, model, batch_idx):
         pass
 
-    def post_batch(self, model, loss, batch_idx, num_images, time_string):
+    def post_batch(self, model, error_loss, complexity_loss, batch_idx,
+                   num_images, time_string):
         # Update 1cycle learning rate after every batch
         if isinstance(self.lr_scheduler, (OneCycleLR, ComposedLRScheduler)):
             self.lr_scheduler.step()
@@ -490,17 +499,20 @@ class ImagenetExperiment:
             self.logger.debug("End of batch for rank: %s. Epoch: %s, Batch: %s/%s, "
                               "loss: %s, Learning rate: %s num_images: %s",
                               self.rank, self.current_epoch, current_batch,
-                              total_batches, loss, self.get_lr(), num_images)
+                              total_batches, error_loss, self.get_lr(),
+                              num_images)
             self.logger.debug("Timing: %s", time_string)
 
-    def post_batch_wrapper(self, model, loss, batch_idx, *args, **kwargs):
+    def post_batch_wrapper(self, model, error_loss, complexity_loss, batch_idx,
+                           *args, **kwargs):
         """
         Perform the post_batch updates, then maybe validate.
 
         This method exists because post_batch is designed to be overridden, and
         validation needs to wait until after all post_batch overrides have run.
         """
-        self.post_batch(model, loss, batch_idx, *args, **kwargs)
+        self.post_batch(model, error_loss, complexity_loss, batch_idx,
+                        *args, **kwargs)
         self.current_timestep += 1
         validate = (batch_idx in self.additional_batches_to_validate
                     and self.current_epoch in self.epochs_to_validate)
@@ -601,13 +613,13 @@ class ImagenetExperiment:
         removed so that the result can be printed to the console.
         """
         keys = ["total_correct", "total_tested", "mean_loss", "mean_accuracy",
-                "learning_rate", "timestep"]
+                "learning_rate"]
         return {key: result[key]
                 for key in keys
                 if key in result}
 
     @classmethod
-    def expand_result_to_time_series(cls, result):
+    def expand_result_to_time_series(cls, result, config):
         """
         Given the result of a run_epoch call, returns a mapping from timesteps to
         results. The mapping is stored as a dict so that subclasses and mixins
@@ -627,7 +639,7 @@ class ImagenetExperiment:
             "complexity_loss": "complexity_loss",
         }
         val_results = (result["extra_val_results"]
-                       + [(result["timestep"], result)])
+                       + [(result["timestep_end"], result)])
         for timestep, val_result in val_results:
             result_by_timestep[timestep].update({
                 k2: val_result[k1]
@@ -723,6 +735,39 @@ class ImagenetExperiment:
         number of epochs but customizable to any other stopping criteria
         """
         return self.current_epoch >= self.epochs
+
+    def should_log_batch(self, train_batch_idx):
+        """
+        Returns true if the current timestep should be logged, either because it's a
+        logged timestep or the final training batch of an epoch.
+        """
+        return (train_batch_idx == self.total_batches - 1
+                or (self.log_timestep_freq > 0
+                    and (self.current_timestep % self.log_timestep_freq) == 0))
+
+    @classmethod
+    def get_recorded_timesteps(cls, result, config):
+        """
+        Given an epoch result dict and config, returns a list of timestep numbers
+        that are supposed to be logged for that epoch.
+        """
+        log_timestep_freq = config.get("log_timestep_freq", 1)
+        timestep_end = result["timestep_end"]
+        if log_timestep_freq == 0:
+            ret = [timestep_end - 1]
+        else:
+            # Find first logged timestep in range
+            logged_begin = int(math.ceil(result["timestep_begin"]
+                                         / log_timestep_freq)
+                               * log_timestep_freq)
+
+            ret = list(range(logged_begin, timestep_end, log_timestep_freq))
+
+            last_batch_timestep = timestep_end - 1
+            if last_batch_timestep % log_timestep_freq != 0:
+                ret.append(last_batch_timestep)
+
+        return ret
 
     def get_lr(self):
         """

--- a/nupic/research/frameworks/wandb/ray_wandb.py
+++ b/nupic/research/frameworks/wandb/ray_wandb.py
@@ -129,10 +129,10 @@ class WandbLogger(wandb.ray.WandbLogger):
     )
     ```
 
-    The "result_to_time_series_fn" is a function that takes a result and returns
-    a dictionary of {timestep: result}. If you provide this function, you
-    convert from an epoch-based time series to your own timestep-based time
-    series, logging a multiple timesteps for each epoch.
+    The "result_to_time_series_fn" is a function that takes a result and config
+    and returns a dictionary of {timestep: result}. If you provide this
+    function, you convert from an epoch-based time series to your own
+    timestep-based time series, logging multiple timesteps for each epoch.
 
     Note, as a `ray.tune.logger.Logger` this class will process all results returned
     from training. However, as of now, only numbers get synced to wandb (e.g. {acc: 1}).
@@ -197,7 +197,8 @@ class WandbLogger(wandb.ray.WandbLogger):
                 del tmp[k]
 
         if self.result_to_time_series_fn is not None:
-            time_series_dict = self.result_to_time_series_fn(tmp)
+            assert self._config is not None
+            time_series_dict = self.result_to_time_series_fn(tmp, self._config)
             for t, d in sorted(time_series_dict.items(), key=lambda x: x[0]):
                 metrics = {}
                 for key, value in flatten_dict(d, delimiter="/").items():


### PR DESCRIPTION
This requires passing the complexity_loss into the post_batch. With this change, the LogEveryLoss mixin can now be anywhere in the mixin order -- we don't have to be careful with it.