### PR TITLE
Fix __repr__ placement of Quant and Dequant in resnet

### DIFF
--- a/nupic/research/frameworks/pytorch/models/resnets.py
+++ b/nupic/research/frameworks/pytorch/models/resnets.py
@@ -291,6 +291,8 @@ class ResNet(nn.Module):
             # by default.
             act_layer = discard_kernel_size(act_layer)
 
+        self.quant = QuantStub()
+
         features = [
             # stem
             ("stem", conv_layer(3, 64, kernel_size=7, stride=2,
@@ -336,7 +338,7 @@ class ResNet(nn.Module):
             num_classes,
             **linear_args
         )
-        self.quant = QuantStub()
+
         self.dequant = DeQuantStub()
 
     def _make_group(self, block, planes, num_blocks, stride, conv_layer,


### PR DESCRIPTION
Change the resnet `__repr__` so that it indicates where quantization and dequantization occur.

Example printed view:

```python
ResNet(
  (quant): QuantStub()
  (features): Sequential(
    (stem): Conv2d(3, 64, kernel_size=(7, 7), stride=(2, 2), padding=(3, 3), bias=False)
    (bn_stem): BatchNorm2d(64, eps=1e-05, momentum=0.1, affine=True, track_running_stats=True)
  ...
    (avg_pool): AdaptiveAvgPool2d(output_size=1)
    (flatten): Flatten()
  )
  (classifier): Linear(in_features=2048, out_features=1000, bias=True)
  (dequant): DeQuantStub()
)
```

These modules don't have parameters or buffers, so we don't have to worry about values in the `state_dict` being shifted.