### PR TITLE
Re-enable loading CUDA checkpoints to CPU

### DIFF
--- a/nupic/research/frameworks/pytorch/imagenet/network_utils.py
+++ b/nupic/research/frameworks/pytorch/imagenet/network_utils.py
@@ -98,6 +98,6 @@ def create_model(model_class, model_args, init_batch_norm, device,
     if checkpoint_file is not None:
         load_ckpt_args = load_checkpoint_args or {}
         load_ckpt_args.setdefault("state_dict_transform", get_compatible_state_dict)
-        load_state_from_checkpoint(model, checkpoint_file, **load_ckpt_args)
+        load_state_from_checkpoint(model, checkpoint_file, device, **load_ckpt_args)
 
     return model

--- a/nupic/research/frameworks/pytorch/restore_utils.py
+++ b/nupic/research/frameworks/pytorch/restore_utils.py
@@ -37,7 +37,7 @@ from nupic.torch.modules.sparse_weights import SparseWeightsBase
 
 def load_state_from_checkpoint(
     model,
-    chekpoint_path,
+    checkpoint_path,
     device=None,
     strict=True,
     subset=None,
@@ -49,7 +49,7 @@ def load_state_from_checkpoint(
     A function for flexible loading of torch.nn.Module's.
 
     :param model: model to load state; instance of torch.nn.Module
-    :param chekpoint_path: path to checkpoint
+    :param checkpoint_path: path to checkpoint
     :param device: PyTorch device that the state dict will be mapped to
     :param strict: similar to `strict` of pytorch's `load_state_dict`
     :param subset: List of param names to accompany `strict=True`. This enables a user
@@ -72,12 +72,12 @@ def load_state_from_checkpoint(
                                  compatibility). The output should be new state_dict.
     """
 
-    assert os.path.isfile(chekpoint_path), (
+    assert os.path.isfile(checkpoint_path), (
         "Double check the checkpoint exists and is a file."
     )
 
     # Load the state dict from the checkpoint.
-    state_dict = get_state_dict(chekpoint_path, device)
+    state_dict = get_state_dict(checkpoint_path, device)
 
     assert state_dict is not None, (
         "Couldn't load the state_dict. "
@@ -94,7 +94,7 @@ def load_state_from_checkpoint(
         # Ensure subset is present in the checkpoint's state.
         assert set(subset) <= set(state_dict.keys()), "".join([
             "Found params in the subset which are not present in the checkpoint: ",
-            f"'{chekpoint_path}'"
+            f"'{checkpoint_path}'"
             "Params not present include:"
             f"\n {set(subset) - set(state_dict.keys())}"
         ])
@@ -103,7 +103,7 @@ def load_state_from_checkpoint(
         model_params = model.state_dict()
         assert set(subset) <= set(model_params.keys()), "".join([
             "Found params in the subset which are not present in the model: ",
-            f"'{chekpoint_path}'"
+            f"'{checkpoint_path}'"
             "Params not present include:"
             f"\n {set(subset) - set(model_params.keys())}"
         ])

--- a/nupic/research/frameworks/pytorch/restore_utils.py
+++ b/nupic/research/frameworks/pytorch/restore_utils.py
@@ -38,6 +38,7 @@ from nupic.torch.modules.sparse_weights import SparseWeightsBase
 def load_state_from_checkpoint(
     model,
     chekpoint_path,
+    device=None,
     strict=True,
     subset=None,
     resize_buffers=False,
@@ -49,6 +50,7 @@ def load_state_from_checkpoint(
 
     :param model: model to load state; instance of torch.nn.Module
     :param chekpoint_path: path to checkpoint
+    :param device: PyTorch device that the state dict will be mapped to
     :param strict: similar to `strict` of pytorch's `load_state_dict`
     :param subset: List of param names to accompany `strict=True`. This enables a user
                    define a set of params that will only be loaded and must be present
@@ -75,7 +77,7 @@ def load_state_from_checkpoint(
     )
 
     # Load the state dict from the checkpoint.
-    state_dict = get_state_dict(chekpoint_path)
+    state_dict = get_state_dict(chekpoint_path, device)
 
     assert state_dict is not None, (
         "Couldn't load the state_dict. "
@@ -220,7 +222,7 @@ def load_multi_state(
 # -------------------
 
 
-def get_state_dict(checkpoint_path):
+def get_state_dict(checkpoint_path, device=None):
 
     checkpoint_path = os.path.expanduser(checkpoint_path)
     with open(checkpoint_path, "rb") as loaded_state:
@@ -228,7 +230,7 @@ def get_state_dict(checkpoint_path):
 
     if "model" in checkpoint_dict:
         with io.BytesIO(checkpoint_dict["model"]) as buffer:
-            state_dict = deserialize_state_dict(buffer)
+            state_dict = deserialize_state_dict(buffer, device)
         return state_dict
     else:
         return None


### PR DESCRIPTION
The PR https://github.com/numenta/nupic.research/pull/329 removed the plumbing of the device down to `deserialize_state_dict`. This change re-plumbs it.