### PR TITLE
Initial Refactor for Experiment Trainables

### DIFF
--- a/nupic/research/frameworks/pytorch/imagenet/imagenet_experiment.py
+++ b/nupic/research/frameworks/pytorch/imagenet/imagenet_experiment.py
@@ -453,6 +453,12 @@ class ImagenetExperiment:
         else:
             return True
 
+    def pre_experiment(self):
+        """Run validation before training."""
+        if -1 in self.epochs_to_validate:
+            self.logger.debug("Validating before any training:")
+            return self.validate()
+
     def validate(self, loader=None):
         if loader is None:
             loader = self.val_loader
@@ -646,6 +652,10 @@ class ImagenetExperiment:
         result = copy.deepcopy(results[0])
         result.update(aggregate_eval_results(results))
         return result
+
+    @classmethod
+    def aggregate_pre_experiment_results(cls, results):
+        return cls.aggregate_validation_results(results)
 
     @classmethod
     def get_printable_result(cls, result):
@@ -854,6 +864,7 @@ class ImagenetExperiment:
                 "ImagenetExperiment.create_validation_dataloader"
             ],
             create_lr_scheduler=["ImagenetExperiment.create_lr_scheduler"],
+            pre_experiment=["ImagenetExperiment.pre_experiment"],
             validate=["ImagenetExperiment.validate"],
             train_epoch=["ImagenetExperiment.train_epoch"],
             run_epoch=["ImagenetExperiment.run_epoch"],
@@ -872,6 +883,9 @@ class ImagenetExperiment:
             aggregate_results=["ImagenetExperiment.aggregate_results"],
             aggregate_validation_results=[
                 "ImagenetExperiment.aggregate_validation_results"
+            ],
+            aggregate_pre_experiment_results=[
+                "ImagenetExperiment.aggregate_pre_experiment_results"
             ],
             get_printable_result=["ImagenetExperiment.get_printable_result"],
             expand_result_to_time_series=[

--- a/nupic/research/frameworks/pytorch/imagenet/imagenet_tune.py
+++ b/nupic/research/frameworks/pytorch/imagenet/imagenet_tune.py
@@ -47,7 +47,7 @@ from nupic.research.support.ray_utils import (
 os.environ["HDF5_USE_FILE_LOCKING"] = "FALSE"
 
 
-class ImagenetTrainable(Trainable):
+class SupervisedTrainable(Trainable):
     """
     Trainable class used to train resnet50 on Imagenet dataset using ray
     """
@@ -297,7 +297,7 @@ class ImagenetTrainable(Trainable):
         pass
 
 
-class SigOptImagenetTrainable(ImagenetTrainable):
+class SigOptImagenetTrainable(SupervisedTrainable):
     """
     This class updates the config using SigOpt before the models and workers are
     instantiated, and updates the result using SigOpt once training completes.
@@ -379,9 +379,9 @@ def run(config):
         kwargs = dict(zip(kwargs_names, [SigOptImagenetTrainable,
                                          *tune.run.__defaults__]))
     else:
-        imagenet_trainable = config.get("imagenet_trainable", ImagenetTrainable)
-        assert issubclass(imagenet_trainable, ImagenetTrainable)
-        kwargs = dict(zip(kwargs_names, [imagenet_trainable, *tune.run.__defaults__]))
+        supervised_trainable = config.get("supervised_trainable", SupervisedTrainable)
+        assert issubclass(supervised_trainable, SupervisedTrainable)
+        kwargs = dict(zip(kwargs_names, [supervised_trainable, *tune.run.__defaults__]))
 
     # Check if restoring experiment from last known checkpoint
     if config.pop("restore", False):
@@ -415,7 +415,7 @@ def run_single_instance(config):
 
     # Build kwargs for `tune.run` function using merged config and command line dict
     kwargs_names = tune.run.__code__.co_varnames[:tune.run.__code__.co_argcount]
-    kwargs = dict(zip(kwargs_names, [ImagenetTrainable, *tune.run.__defaults__]))
+    kwargs = dict(zip(kwargs_names, [SupervisedTrainable, *tune.run.__defaults__]))
     # Update`tune.run` kwargs with config
     kwargs.update(config)
     kwargs["config"] = config

--- a/nupic/research/frameworks/pytorch/imagenet/imagenet_tune.py
+++ b/nupic/research/frameworks/pytorch/imagenet/imagenet_tune.py
@@ -408,9 +408,9 @@ def run(config):
         kwargs = dict(zip(kwargs_names, [SigOptImagenetTrainable,
                                          *tune.run.__defaults__]))
     else:
-        supervised_trainable = config.get("supervised_trainable", SupervisedTrainable)
-        assert issubclass(supervised_trainable, SupervisedTrainable)
-        kwargs = dict(zip(kwargs_names, [supervised_trainable, *tune.run.__defaults__]))
+        ray_trainable = config.get("ray_trainable", SupervisedTrainable)
+        assert issubclass(ray_trainable, BaseTrainable)
+        kwargs = dict(zip(kwargs_names, [ray_trainable, *tune.run.__defaults__]))
 
     # Check if restoring experiment from last known checkpoint
     if config.pop("restore", False):

--- a/nupic/research/frameworks/pytorch/imagenet/imagenet_tune.py
+++ b/nupic/research/frameworks/pytorch/imagenet/imagenet_tune.py
@@ -17,6 +17,8 @@
 #
 #  http://numenta.org/licenses/
 #
+
+import abc
 import copy
 import logging
 import os
@@ -47,9 +49,11 @@ from nupic.research.support.ray_utils import (
 os.environ["HDF5_USE_FILE_LOCKING"] = "FALSE"
 
 
-class SupervisedTrainable(Trainable):
+class BaseTrainable(Trainable, metaclass=abc.ABCMeta):
     """
-    Trainable class used to train resnet50 on Imagenet dataset using ray
+    Trainable class used to train arbitrary experiments with ray. Whatever
+    the case, it's expected to proceed over well-defined iterations. Thus,
+    `_run_iteration` must be overridden.
     """
 
     @classmethod
@@ -284,6 +288,21 @@ class SupervisedTrainable(Trainable):
 
     def _process_config(self, config):
         pass
+
+    @abc.abstractmethod
+    def _run_iteration(self):
+        """Run one iteration of the experiment"""
+        raise NotImplementedError
+
+    def _process_result(self, result, pre_experiment_result=None):
+        pass
+
+
+class SupervisedTrainable(BaseTrainable):
+    """
+    Trainable class used to train supervised machine learning experiments
+    with ray.
+    """
 
     def _run_iteration(self):
         """Run one epoch of training on each process."""

--- a/nupic/research/frameworks/sigopt/sigopt_experiment.py
+++ b/nupic/research/frameworks/sigopt/sigopt_experiment.py
@@ -26,7 +26,7 @@ from sigopt import Connection
 class SigOptExperiment:
     """
     Class used to wrap around the SigOpt API and designed to be used in any experiment
-    runner. A particular experiment runner, such as ImagenetTrainable, will want to
+    runner. A particular experiment runner, such as SupervisedTrainable, will want to
     subclass and redefine update_config_with_suggestion() to be specific to their
     config.
     """

--- a/projects/imagenet/experiments/base.py
+++ b/projects/imagenet/experiments/base.py
@@ -131,7 +131,7 @@ DEFAULT = dict(
 
     # Ray tune verbosity. When set to the default value of 2 it will log
     # iteration result dicts. This dict can flood the console if it contains
-    # large data structures, so default to verbose=1. The ImagenetTrainable logs
+    # large data structures, so default to verbose=1. The SupervisedTrainable logs
     # a succinct version of the result dict.
     verbose=1,
 )


### PR DESCRIPTION
This PR gets the ball rolling on making our experiment classes more extensible. 

It starts with the Trainables:
* Refactoring the initial-validation functionality into a `pre_experiment` method.
* Introducing a `BaseTrainable` and `SupervisedTrainable`

@lscheinkman You'll notice that the notion of an iteration has been kept only with the Trainables and is not imposed on the ImagenetExperiment class.