### PR TITLE
Re-enable loading CUDA checkpoints to CPU (again)

### DIFF
--- a/nupic/research/frameworks/pytorch/imagenet/network_utils.py
+++ b/nupic/research/frameworks/pytorch/imagenet/network_utils.py
@@ -98,13 +98,13 @@ def create_model(model_class, model_args, init_batch_norm, device=None,
         model.to(device)
 
     if checkpoint_file is not None:
-        restore_checkpoint(model, checkpoint_file, load_checkpoint_args)
+        restore_checkpoint(model, checkpoint_file, load_checkpoint_args, device)
 
     return model
 
 
-def restore_checkpoint(model, checkpoint_file, load_checkpoint_args):
+def restore_checkpoint(model, checkpoint_file, load_checkpoint_args, device=None):
     """Load model parameters from checkpoint"""
     load_ckpt_args = load_checkpoint_args or {}
     load_ckpt_args.setdefault("state_dict_transform", get_compatible_state_dict)
-    load_state_from_checkpoint(model, checkpoint_file, **load_ckpt_args)
+    load_state_from_checkpoint(model, checkpoint_file, device, **load_ckpt_args)


### PR DESCRIPTION
This broke in https://github.com/numenta/nupic.research/pull/331 (probably a merge conflict)

The restore code is currently in flux. This is a quick fix, some refactor / cleanup should happen later.