### PR TITLE
Refactor `create_model` to be more general

### DIFF
--- a/nupic/research/frameworks/pytorch/imagenet/network_utils.py
+++ b/nupic/research/frameworks/pytorch/imagenet/network_utils.py
@@ -69,7 +69,7 @@ def get_compatible_state_dict(state_dict, model):
     return state_dict
 
 
-def create_model(model_class, model_args, init_batch_norm, device=None,
+def create_model(model_class, model_args, init_model_fn=None, device=None,
                  checkpoint_file=None, load_checkpoint_args=None):
     """
     Create imagenet experiment model with option to load state from checkpoint
@@ -78,8 +78,8 @@ def create_model(model_class, model_args, init_batch_norm, device=None,
             The model class. Must inherit from torch.nn.Module
     :param model_args:
         The model constructor arguments
-    :param init_batch_norm:
-        Whether or not to initialize batch norm modules
+    :param init_model_fn:
+        Initialization function to apply to the modules
     :param device:
         Model device
     :param checkpoint_file:
@@ -90,8 +90,8 @@ def create_model(model_class, model_args, init_batch_norm, device=None,
     :return: Configured model
     """
     model = model_class(**model_args)
-    if init_batch_norm:
-        model.apply(init_resnet50_batch_norm)
+    if init_model_fn is not None:
+        model.apply(init_model_fn)
 
     if device is not None:
         model.to(device)

--- a/tests/unit/frameworks/pytorch/imagenet_util_test.py
+++ b/tests/unit/frameworks/pytorch/imagenet_util_test.py
@@ -92,7 +92,7 @@ class ImagenetExperimentUtilsTest(unittest.TestCase):
     def setUp(self):
         set_random_seed(42)
 
-    def test_creaate_model_from_checkpoint(self):
+    def test_create_model_from_checkpoint(self):
         model1 = _create_test_model()
 
         # Save model checkpoint only, ignoring optimizer and other imagenet

--- a/tests/unit/frameworks/pytorch/imagenet_util_test.py
+++ b/tests/unit/frameworks/pytorch/imagenet_util_test.py
@@ -50,7 +50,7 @@ def _create_test_model(checkpoint_file=None):
     Create standard resnet50 model to be used in tests.
     """
     model = create_model(model_class=resnet50, model_args=TEST_MODEL_ARGS,
-                         init_batch_norm=False, checkpoint_file=checkpoint_file,
+                         init_model_fn=None, checkpoint_file=checkpoint_file,
                          device="cpu")
 
     # Simulate imagenet experiment by changing the weights
@@ -110,7 +110,7 @@ class ImagenetExperimentUtilsTest(unittest.TestCase):
             # Load model from checkpoint
             model2 = create_model(
                 model_class=resnet50, model_args=TEST_MODEL_ARGS,
-                init_batch_norm=False, device="cpu",
+                init_model_fn=None, device="cpu",
                 checkpoint_file=checkpoint_file.name)
 
         self.assertTrue(compare_models(model1, model2, (3, 32, 32)))

--- a/tests/unit/frameworks/pytorch/resnet_quantization_test.py
+++ b/tests/unit/frameworks/pytorch/resnet_quantization_test.py
@@ -38,7 +38,7 @@ def _create_test_model(model_class):
     model = create_model(
         model_class=model_class,
         model_args=model_args,
-        init_batch_norm=False,
+        init_model_fn=None,
         device=device,
     )
     return model

--- a/tests/unit/frameworks/pytorch/resnet_serialize_test.py
+++ b/tests/unit/frameworks/pytorch/resnet_serialize_test.py
@@ -44,7 +44,7 @@ class ResNetSerialization(unittest.TestCase):
         model = create_model(
             model_class=model_class,
             model_args=model_args,
-            init_batch_norm=False,
+            init_model_fn=None,
             device=device,
         )
 
@@ -60,7 +60,7 @@ class ResNetSerialization(unittest.TestCase):
             model2 = create_model(
                 model_class=model_class,
                 model_args=model_args,
-                init_batch_norm=False,
+                init_model_fn=None,
                 device=device,
                 checkpoint_file=checkpoint_file.name
             )
@@ -77,7 +77,7 @@ class ResNetSerialization(unittest.TestCase):
         model = create_model(
             model_class=model_class,
             model_args=model_args,
-            init_batch_norm=False,
+            init_model_fn=None,
             device=device,
         )
 
@@ -93,7 +93,7 @@ class ResNetSerialization(unittest.TestCase):
             model2 = create_model(
                 model_class=model_class,
                 model_args=model_args,
-                init_batch_norm=False,
+                init_model_fn=None,
                 device=device,
                 checkpoint_file=checkpoint_file.name
             )


### PR DESCRIPTION
As we refactor the experiment class, it’s important to have a general `create_model` function. Previously, it called `init_resnet50_batch_norm` which reinitialized the resent batchnorm layers and any linear layers as well. This PR generalizes this functionality by
* Passing an `init_model_fn` to `create_model`; applied via model.apply
* Refactoring `init_resnet50_batch_norm` to work via model.apply
* Modify `create_model` classmethod of `ImagementExperiment` to set `init_model_fn=init_resnet50_batch_norm` when `init_batch_norm=True`