### PR TITLE
Refactor building of kwargs into` get_tune_kwargs`

### DIFF
--- a/nupic/research/frameworks/vernon/run_experiment/run_with_raytune.py
+++ b/nupic/research/frameworks/vernon/run_experiment/run_with_raytune.py
@@ -138,12 +138,13 @@ def get_tune_kwargs(config):
 
     # Zip the kwargs along with the Ray trainable.
     if "sigopt_config" in config:
-        kwargs = dict(zip(kwargs_names, [SigOptImagenetTrainable,
-                                         *tune.run.__defaults__]))
+        default_trainable = SigOptImagenetTrainable
     else:
-        ray_trainable = config.get("ray_trainable", SupervisedTrainable)
-        assert issubclass(ray_trainable, Trainable)
-        kwargs = dict(zip(kwargs_names, [ray_trainable, *tune.run.__defaults__]))
+        default_trainable = SupervisedTrainable
+
+    ray_trainable = config.get("ray_trainable", default_trainable)
+    assert issubclass(ray_trainable, Trainable)
+    kwargs = dict(zip(kwargs_names, [ray_trainable, *tune.run.__defaults__]))
 
     # Check if restoring experiment from last known checkpoint
     if config.pop("restore", False):

--- a/nupic/research/frameworks/vernon/run_experiment/run_with_raytune.py
+++ b/nupic/research/frameworks/vernon/run_experiment/run_with_raytune.py
@@ -127,7 +127,7 @@ def get_tune_kwargs(config):
         - sigopt_config: (optional) used for running experiments with SigOpt and
                          the SigOptImagenetTrainable
         - restore: whether to restore from the latest checkpoint; defaults to False
-        - local_dir: needed with 'restore'; identifies to parent directory of
+        - local_dir: needed with 'restore'; identifies the parent directory of
                      experiment results.
         - name: needed with 'restore'; local_dir/name identifies the path to
                 the experiment checkpoints.
@@ -164,7 +164,7 @@ def get_tune_kwargs(config):
     # This may be `epochs` or `num_tasks`, for instance.
     stop_condition = getattr(ray_trainable, "stop_condition", "epochs")
     stop_iteration = config.get(stop_condition, None)
-    if stop_iteration:
+    if stop_iteration is not None:
         stop.update(training_iteration=stop_iteration)
 
     # Update the stop condition.

--- a/nupic/research/frameworks/vernon/run_experiment/run_with_raytune.py
+++ b/nupic/research/frameworks/vernon/run_experiment/run_with_raytune.py
@@ -101,14 +101,15 @@ def run_single_instance(config):
     # Update`tune.run` kwargs with config
     kwargs.update(config)
     kwargs["config"] = config
+
     # Update tune stop criteria with config epochs
     stop = kwargs.get("stop", {}) or dict()
-    epochs = config.get("epochs", 1)
-    num_tasks = config.get("num_tasks", None)
-    if num_tasks:
-        stop.update(training_iteration=num_tasks)
-    else:
-        stop.update(training_iteration=epochs)
+
+    stop_condition = getattr(ray_trainable, "stop_condition", "epochs")
+    stop_iteration = config.get(stop_condition, None)
+    if stop_iteration:
+        stop.update(training_iteration=stop_iteration)
+
     kwargs["stop"] = stop
     # Make sure to only select`tune.run` function arguments
     kwargs = dict(filter(lambda x: x[0] in kwargs_names, kwargs.items()))

--- a/nupic/research/frameworks/vernon/run_experiment/trainables.py
+++ b/nupic/research/frameworks/vernon/run_experiment/trainables.py
@@ -318,6 +318,8 @@ class ContinualLearningTrainable(SupervisedTrainable):
     with ray.
     """
 
+    stop_condition = "num_tasks"
+
     def _run_iteration(self):
         """Run one epoch of training on each process."""
         status = []


### PR DESCRIPTION
This cleans up the `run_with_raytune.py` file to reduce the amount of repeated functionality. 