### PR TITLE
Enable using latest wandb (Remove dependency on WandbLogger)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -48,4 +48,4 @@ torchvision==0.7.0
 tqdm
 h5py
 pretrainedmodels==0.7.4
-wandb>=0.9.4,<=0.9.7
+wandb>=0.9.4


### PR DESCRIPTION
Trivial solution: inline the WandbLogger. I think it's better to implement our own logger anyway, rather than subclassing, so that we get direct control over how we use wandb's API.

Maybe in the future we'll want to fork/subclass `ray.tune.integration.wandb`, but in the meantime this change is an improvement. 