### PR TITLE
Hardcoded routing test (for sigmoid gating dendritic network)

### DIFF
--- a/nupic/research/frameworks/dendrites/__init__.py
+++ b/nupic/research/frameworks/dendrites/__init__.py
@@ -20,4 +20,7 @@
 # ----------------------------------------------------------------------
 
 from .dendrite_segments import DendriteSegments
-from .dendritic_weights import BiasingDendriticLayer, GatingDendriticLayer
+from .dendritic_weights import (
+	AbsoluateMaxGatingDendriticLayer, BiasingDendriticLayer,
+	GatingDendriticLayer
+)

--- a/nupic/research/frameworks/dendrites/__init__.py
+++ b/nupic/research/frameworks/dendrites/__init__.py
@@ -21,6 +21,6 @@
 
 from .dendrite_segments import DendriteSegments
 from .dendritic_weights import (
-	AbsoluateMaxGatingDendriticLayer, BiasingDendriticLayer,
+	AbsoluteMaxGatingDendriticLayer, BiasingDendriticLayer,
 	GatingDendriticLayer
 )

--- a/nupic/research/frameworks/dendrites/dendritic_weights.py
+++ b/nupic/research/frameworks/dendrites/dendritic_weights.py
@@ -89,7 +89,7 @@ class GatingDendriticLayer(BiasingDendriticLayer):
         return y * sigmoid(dendrite_activations.max(dim=2).values)
 
 
-class AbsoluateMaxGatingDendriticLayer(BiasingDendriticLayer):
+class AbsoluteMaxGatingDendriticLayer(BiasingDendriticLayer):
     """
     This layer is similar to `GatingDendriticLayer`, but selects dendrite activations
     based on absolute max activation values instead of just max activation values. For

--- a/nupic/research/frameworks/dendrites/dendritic_weights.py
+++ b/nupic/research/frameworks/dendrites/dendritic_weights.py
@@ -24,6 +24,7 @@ A simple implementation of dendrite weights. This combines the output from a (sp
 linear layer with the output from a set of dendritic segments.
 """
 
+import torch
 from torch.nn.functional import sigmoid
 
 from nupic.research.frameworks.dendrites import DendriteSegments
@@ -86,3 +87,22 @@ class GatingDendriticLayer(BiasingDendriticLayer):
         """Apply dendrites as a gating mechanism."""
         # Multiple by the sigmoid of the max along each segment.
         return y * sigmoid(dendrite_activations.max(dim=2).values)
+
+
+class AbsoluateMaxGatingDendriticLayer(BiasingDendriticLayer):
+    """
+    This layer is similar to `GatingDendriticLayer`, but selects dendrite activations
+    based on absolute max activation values instead of just max activation values. For
+    example, if choosing between activations -7.4, and 6.5 for a particular unit, -7.4
+    will be chosen, and its sign will be kept.
+    """
+
+    def apply_dendrites(self, y, dendrite_activations):
+        output_max = dendrite_activations.max(dim=2).values
+        output_min = dendrite_activations.min(dim=2).values
+        sign_mask = torch.where(
+            (output_max ** 2) > (output_min ** 2),
+            torch.ones(output_max.shape),
+            -1.0 * torch.ones(output_min.shape)
+        )
+        return y * sigmoid(dendrite_activations.max(dim=2).values * sign_mask)

--- a/nupic/research/frameworks/dendrites/routing/hardcoded.py
+++ b/nupic/research/frameworks/dendrites/routing/hardcoded.py
@@ -24,7 +24,7 @@ import copy
 import torch
 from numpy.random import randint
 
-from nupic.research.frameworks.dendrites import AbsoluateMaxGatingDendriticLayer
+from nupic.research.frameworks.dendrites import AbsoluteMaxGatingDendriticLayer
 from nupic.research.frameworks.dendrites.routing import (
     RoutingFunction,
     generate_context_vectors,
@@ -128,7 +128,7 @@ if __name__ == "__main__":
         d_out=d_out,
         k=num_contexts,
         d_context=d_context,
-        dendrite_module=AbsoluateMaxGatingDendriticLayer,
+        dendrite_module=AbsoluteMaxGatingDendriticLayer,
         context_weights_fn=get_gating_context_weights,
         batch_size=batch_size
     )
@@ -143,4 +143,4 @@ if __name__ == "__main__":
 
     # Results over 100 examples with 10 random contexts
     # > Mean absolute error between R(j, x) and output from dendritic network:
-    # >      1.5237264228140646e-10
+    # >      0.0006185245583765209

--- a/nupic/research/frameworks/dendrites/routing/hardcoded.py
+++ b/nupic/research/frameworks/dendrites/routing/hardcoded.py
@@ -1,0 +1,140 @@
+# ----------------------------------------------------------------------
+# Numenta Platform for Intelligent Computing (NuPIC)
+# Copyright (C) 2020, Numenta, Inc.  Unless you have an agreement
+# with Numenta, Inc., for a separate license for this software code, the
+# following terms and conditions apply:
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# See the GNU Affero Public License for more details.
+#
+# You should have received a copy of the GNU Affero Public License
+# along with this program.  If not, see http://www.gnu.org/licenses.
+#
+# http://numenta.org/licenses/
+# ----------------------------------------------------------------------
+
+import copy
+
+import torch
+from numpy.random import randint
+
+from nupic.research.frameworks.dendrites import GatingDendriticLayer
+from nupic.research.frameworks.dendrites.routing import (
+    RoutingFunction,
+    generate_context_vectors,
+    get_gating_context_weights,
+)
+
+
+def run_hardcoded_routing_test(
+        d_in,
+        d_out,
+        k,
+        d_context,
+        dendrite_module,
+        context_weights_fn=None,
+        batch_size=100
+):
+    """
+    Runs the hardcoded routing test for a specific type of dendritic network
+
+    :param d_in: the number of dimensions in the input to the routing function and test
+                 module
+    :param d_out: the number of dimensions in the sparse linear output of the routing
+                  function and test network
+    :param k: the number of unique random binary vectors in the routing function that
+              can "route" the sparse linear output, and also the number of unique
+              context vectors
+    :param d_context: the number of dimensions in the context vectors
+    :param dendrite_module: a torch.nn.Module subclass that implements a dendrite
+                            module in addition to a linear feed-forward module
+    :param context_weights_fn: a function that returns a 3D torch Tensor that gives the
+                               near-optimal dendrite values for the specified
+                               dendrite_module, and has parameters `output_masks`,
+                               `context_vectors`, and `num_dendrites`
+    :param batch_size: the number of test inputs
+    """
+
+    # Initialize routing function that this task will try to hardcode
+    r = RoutingFunction(d_in=d_in, d_out=d_out, k=k, sparsity=0.7)
+
+    # Initialize context vectors, where each context vector corresponds to an output
+    # mask in the routing function
+    context_vectors = generate_context_vectors(
+        num_contexts=k,
+        n_dim=d_context,
+        percent_on=0.2
+    )
+
+    # Initialize dendrite module using the same feed-forward sparse weights as the
+    # routing function; also note that the value passed to `dendrite_sparsity` is
+    # irrelevant since the context weights are subsequently overwritten
+    dendritic_network = dendrite_module(
+        module=r.sparse_weights.module,
+        num_segments=k,
+        dim_context=d_context,
+        module_sparsity=0.7,
+        dendrite_sparsity=0.0
+    )
+
+    dendritic_network.register_buffer(
+        "zero_mask",
+        copy.deepcopy(r.sparse_weights.zero_mask.half())
+    )
+
+    # Choose the context weights specifically so that they can gate the outputs of the
+    # forward module
+    if context_weights_fn is not None:
+        dendritic_network.segments.weights.data = context_weights_fn(
+            output_masks=r.output_masks, context_vectors=context_vectors,
+            num_dendrites=k
+        )
+
+    # Sample a random batch of inputs and random batch of context vectors, and perform
+    # hardcoded routing test
+    x_test = 4.0 * torch.rand((batch_size, d_in)) - 2.0  # sampled i.i.d. from U[-2, 2)
+    context_inds_test = randint(low=0, high=k, size=batch_size).tolist()
+    context_test = torch.stack(
+        [context_vectors[j, :] for j in context_inds_test], dim=0
+    )
+
+    target = r(context_inds_test, x_test)
+    actual = dendritic_network(x_test, context_test)
+
+    # Report mean absolute error
+    mean_abs_error = torch.abs(target - actual).mean().item()
+    print(" Results over {} examples with {} random contexts".format(batch_size, k))
+    print(" > Mean absolute error between R(j, x) and output from dendritic network:")
+    print(" > \t{}".format(mean_abs_error))
+
+
+if __name__ == "__main__":
+
+    # Run the hardcoded routing test with a dendritic network that uses "dendrites as
+    # gating"; this achieves near-zero mean absolute error, which strongly suggests
+    # that dendritic networks can successfully route
+    d_in = 100
+    d_out = 100
+    num_contexts = 10
+    d_context = 100
+
+    run_hardcoded_routing_test(
+        d_in=d_in,
+        d_out=d_out,
+        k=num_contexts,
+        d_context=d_context,
+        dendrite_module=GatingDendriticLayer,
+        context_weights_fn=get_gating_context_weights
+    )
+
+    # Sample output below
+
+    # Results over 100 examples with 10 random contexts
+    # > Mean absolute error between R(j, x) and output from dendritic network:
+    # >      1.5237264228140646e-10

--- a/nupic/research/frameworks/dendrites/routing/hardcoded.py
+++ b/nupic/research/frameworks/dendrites/routing/hardcoded.py
@@ -24,7 +24,7 @@ import copy
 import torch
 from numpy.random import randint
 
-from nupic.research.frameworks.dendrites import GatingDendriticLayer
+from nupic.research.frameworks.dendrites import AbsoluateMaxGatingDendriticLayer
 from nupic.research.frameworks.dendrites.routing import (
     RoutingFunction,
     generate_context_vectors,
@@ -33,13 +33,13 @@ from nupic.research.frameworks.dendrites.routing import (
 
 
 def run_hardcoded_routing_test(
-        d_in,
-        d_out,
-        k,
-        d_context,
-        dendrite_module,
-        context_weights_fn=None,
-        batch_size=100
+    d_in,
+    d_out,
+    k,
+    d_context,
+    dendrite_module,
+    context_weights_fn=None,
+    batch_size=100
 ):
     """
     Runs the hardcoded routing test for a specific type of dendritic network
@@ -109,9 +109,7 @@ def run_hardcoded_routing_test(
 
     # Report mean absolute error
     mean_abs_error = torch.abs(target - actual).mean().item()
-    print(" Results over {} examples with {} random contexts".format(batch_size, k))
-    print(" > Mean absolute error between R(j, x) and output from dendritic network:")
-    print(" > \t{}".format(mean_abs_error))
+    return {"mean_abs_error": mean_abs_error}
 
 
 if __name__ == "__main__":
@@ -123,15 +121,23 @@ if __name__ == "__main__":
     d_out = 100
     num_contexts = 10
     d_context = 100
+    batch_size = 100
 
-    run_hardcoded_routing_test(
+    result = run_hardcoded_routing_test(
         d_in=d_in,
         d_out=d_out,
         k=num_contexts,
         d_context=d_context,
-        dendrite_module=GatingDendriticLayer,
-        context_weights_fn=get_gating_context_weights
+        dendrite_module=AbsoluateMaxGatingDendriticLayer,
+        context_weights_fn=get_gating_context_weights,
+        batch_size=batch_size
     )
+
+    print(" Results over {} examples with {} random contexts".format(
+        batch_size, num_contexts
+    ))
+    print(" > Mean absolute error between R(j, x) and output from dendritic network:")
+    print(" > \t{}".format(result["mean_abs_error"]))
 
     # Sample output below
 

--- a/nupic/research/frameworks/dendrites/routing/utils.py
+++ b/nupic/research/frameworks/dendrites/routing/utils.py
@@ -85,7 +85,7 @@ def get_gating_context_weights(output_masks, context_vectors, num_dendrites):
     dim_context = context_vectors.size(1)
 
     # Context weights
-    context_weights = -99.0 * torch.ones((num_units, num_dendrites, dim_context))
+    context_weights = torch.zeros((num_units, num_dendrites, dim_context))
 
     for m in range(num_units):
         for j in range(num_dendrites):

--- a/nupic/research/frameworks/dendrites/routing/utils.py
+++ b/nupic/research/frameworks/dendrites/routing/utils.py
@@ -22,6 +22,32 @@
 import torch
 
 
+def generate_context_vectors(num_contexts, n_dim, percent_on=0.2):
+    """
+    Returns a binary Torch tensor of shape (num_vectors, n_dim) where each row
+    represents a context vector with n_dim * percent_on non-zero values
+    :param num_contexts: the number of context vectors
+    :type num_contexts: int
+    :param n_dim: the size of each binary vector
+    :type n_dim: int
+    :param percent_on: the fraction of non-zero
+    :type percent_on: float
+    """
+    num_ones = int(percent_on * n_dim)
+    num_zeros = n_dim - num_ones
+
+    context_vectors = torch.cat((
+        torch.zeros((num_contexts, num_zeros)),
+        torch.ones((num_contexts, num_ones))
+    ), dim=1)
+
+    # All rows in context_vectors are currently the same; they need to be shuffled
+    for i in range(num_contexts):
+        context_vectors[i, :] = context_vectors[i, torch.randperm(n_dim)]
+
+    return context_vectors
+
+
 def generate_random_binary_vectors(k, n_dim, sparsity_level=0.5):
     """
     Returns a Torch tensor of shape (k, n_dim) where each each entry is 1
@@ -41,3 +67,39 @@ def generate_random_binary_vectors(k, n_dim, sparsity_level=0.5):
         torch.ones((k, n_dim))
     )
     return binary_vectors
+
+
+def get_gating_context_weights(output_masks, context_vectors, num_dendrites):
+    """
+    Returns a torch Tensor of shape (num_units, num_dendrites, dim_context) that gives
+    a near-optimal choice of context/dendrite weights to a sigmoid gating verion of
+    routing given any routing function specified by output_masks and arbitrary choice
+    of context vectors context_vectors (num_units: number of output units in feed-
+    forward module, dim_context: the number of dimensions in each context vector)
+
+    :param output_masks: 2D torch Tensor of binary output masks
+    :param context_vectors: 2D torch Tensor of binary context vectors
+    :param num_dendrites: the number of dendrite/context weights per unit
+    """
+    num_units = output_masks.size(1)
+    dim_context = context_vectors.size(1)
+
+    # Context weights
+    context_weights = -99.0 * torch.ones((num_units, num_dendrites, dim_context))
+
+    for m in range(num_units):
+        for j in range(num_dendrites):
+            for c in range(dim_context):
+                if context_vectors[j, c] > 0.0:
+
+                    # if output mask j is on for output unit m, then set context weight
+                    # to +1
+                    if output_masks[j, m] > 0.0:
+                        context_weights[m, j, c] = 1.0
+
+                    # otherwise, if output mask j is off for output unit m, then set
+                    # context weight to -1
+                    else:
+                        context_weights[m, j, c] = -1.0
+
+    return context_weights

--- a/tests/unit/frameworks/dendrites/hardcoded_test.py
+++ b/tests/unit/frameworks/dendrites/hardcoded_test.py
@@ -21,7 +21,7 @@
 
 import unittest
 
-from nupic.research.frameworks.dendrites import AbsoluateMaxGatingDendriticLayer
+from nupic.research.frameworks.dendrites import AbsoluteMaxGatingDendriticLayer
 from nupic.research.frameworks.dendrites.routing import get_gating_context_weights
 from nupic.research.frameworks.dendrites.routing.hardcoded import (
     run_hardcoded_routing_test,
@@ -60,7 +60,7 @@ class HardcodedErrorTest(unittest.TestCase):
             d_out=d_out,
             k=num_contexts,
             d_context=d_context,
-            dendrite_module=AbsoluateMaxGatingDendriticLayer,
+            dendrite_module=AbsoluteMaxGatingDendriticLayer,
             context_weights_fn=get_gating_context_weights,
             batch_size=batch_size
         )

--- a/tests/unit/frameworks/dendrites/hardcoded_test.py
+++ b/tests/unit/frameworks/dendrites/hardcoded_test.py
@@ -1,0 +1,73 @@
+# ----------------------------------------------------------------------
+# Numenta Platform for Intelligent Computing (NuPIC)
+# Copyright (C) 2020, Numenta, Inc.  Unless you have an agreement
+# with Numenta, Inc., for a separate license for this software code, the
+# following terms and conditions apply:
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# See the GNU Affero Public License for more details.
+#
+# You should have received a copy of the GNU Affero Public License
+# along with this program.  If not, see http://www.gnu.org/licenses.
+#
+# http://numenta.org/licenses/
+# ----------------------------------------------------------------------
+
+import unittest
+
+from nupic.research.frameworks.dendrites import AbsoluateMaxGatingDendriticLayer
+from nupic.research.frameworks.dendrites.routing import get_gating_context_weights
+from nupic.research.frameworks.dendrites.routing.hardcoded import (
+    run_hardcoded_routing_test,
+)
+
+
+class HardcodedErrorTest(unittest.TestCase):
+    """
+    Tests the hand-picked context weights for performance on the hardcoded routing test
+    in a dendritic network that uses dendrites for gating
+    """
+
+    def test_mean_abs_error(self):
+        """
+        Ensure mean absolute error retrieved by the hardcoded test is no larger than a
+        chosen epsilon
+        """
+
+        # Set `epsilon` to a value that the mean absolute error between the routing
+        # output and dendritic network (with hardcoded dendritic weights) output should
+        # never exceed
+        epsilon = 0.01
+
+        # These hyperparameters control the size of the input and output to the routing
+        # function (and dendritic network), the number of dendritic weights, the size
+        # of the context vector, and batch size over which the mean absolute error is
+        # computed
+        d_in = 100
+        d_out = 100
+        num_contexts = 10
+        d_context = 100
+        batch_size = 100
+
+        result = run_hardcoded_routing_test(
+            d_in=d_in,
+            d_out=d_out,
+            k=num_contexts,
+            d_context=d_context,
+            dendrite_module=AbsoluateMaxGatingDendriticLayer,
+            context_weights_fn=get_gating_context_weights,
+            batch_size=batch_size
+        )
+
+        mean_abs_error = result["mean_abs_error"]
+        self.assertLess(mean_abs_error, epsilon)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Here's an implementation of the hardcoded routing test where the dendritic network uses the `GatingDendriticLayer`. The context weights are hardcoded, and set using the function `get_gating_context_weights` in `frameworks/dendrites/routing/utils`.