### PR TITLE
Fixed `AbsoluteMaxGatingDendriticLayer`

### DIFF
--- a/nupic/research/frameworks/dendrites/dendritic_weights.py
+++ b/nupic/research/frameworks/dendrites/dendritic_weights.py
@@ -25,7 +25,6 @@ linear layer with the output from a set of dendritic segments.
 """
 
 import torch
-from torch.nn.functional import sigmoid
 
 from nupic.research.frameworks.dendrites import DendriteSegments
 from nupic.torch.modules.sparse_weights import SparseWeights
@@ -86,7 +85,7 @@ class GatingDendriticLayer(BiasingDendriticLayer):
     def apply_dendrites(self, y, dendrite_activations):
         """Apply dendrites as a gating mechanism."""
         # Multiple by the sigmoid of the max along each segment.
-        return y * sigmoid(dendrite_activations.max(dim=2).values)
+        return y * torch.sigmoid(dendrite_activations.max(dim=2).values)
 
 
 class AbsoluteMaxGatingDendriticLayer(BiasingDendriticLayer):
@@ -105,4 +104,6 @@ class AbsoluteMaxGatingDendriticLayer(BiasingDendriticLayer):
             torch.ones(output_max.shape),
             -1.0 * torch.ones(output_min.shape)
         )
-        return y * sigmoid(dendrite_activations.max(dim=2).values * sign_mask)
+        return y * torch.sigmoid(
+            torch.abs(dendrite_activations).max(dim=2).values * sign_mask
+        )

--- a/nupic/research/frameworks/dendrites/routing/hardcoded.py
+++ b/nupic/research/frameworks/dendrites/routing/hardcoded.py
@@ -119,10 +119,10 @@ def run_hardcoded_routing_test(
         print("")
         print(" {}{}".format("target".ljust(24), "actual".ljust(24)))
         for target_i, actual_i in zip(target[0, :15], actual[0, :15]):
-            
+
             target_i = str(target_i.item()).ljust(24)
             actual_i = str(actual_i.item()).ljust(24)
-            
+
             print(" {}{}".format(target_i, actual_i))
         print(" ...")
         print("")

--- a/nupic/research/frameworks/dendrites/routing/hardcoded.py
+++ b/nupic/research/frameworks/dendrites/routing/hardcoded.py
@@ -39,7 +39,8 @@ def run_hardcoded_routing_test(
     d_context,
     dendrite_module,
     context_weights_fn=None,
-    batch_size=100
+    batch_size=100,
+    verbose=False
 ):
     """
     Runs the hardcoded routing test for a specific type of dendritic network
@@ -59,6 +60,7 @@ def run_hardcoded_routing_test(
                                dendrite_module, and has parameters `output_masks`,
                                `context_vectors`, and `num_dendrites`
     :param batch_size: the number of test inputs
+    :param verbose: prints the 
     """
 
     # Initialize routing function that this task will try to hardcode
@@ -101,11 +103,28 @@ def run_hardcoded_routing_test(
     x_test = 4.0 * torch.rand((batch_size, d_in)) - 2.0  # sampled i.i.d. from U[-2, 2)
     context_inds_test = randint(low=0, high=k, size=batch_size).tolist()
     context_test = torch.stack(
-        [context_vectors[j, :] for j in context_inds_test], dim=0
+        [context_vectors[j, :] for j in context_inds_test],
+        dim=0
     )
 
     target = r(context_inds_test, x_test)
     actual = dendritic_network(x_test, context_test)
+
+    if verbose:
+
+        # Print targets and outputs on the first 15 dimensions
+        print("")
+        print(" Element-wise outputs along the first 15 dimensions:")
+        print("")
+        print(" {}{}".format("target".ljust(24), "actual".ljust(24)))
+        for target_i, actual_i in zip(target[0, :15], actual[0, :15]):
+            
+            target_i = str(target_i.item()).ljust(24)
+            actual_i = str(actual_i.item()).ljust(24)
+            
+            print(" {}{}".format(target_i, actual_i))
+        print(" ...")
+        print("")
 
     # Report mean absolute error
     mean_abs_error = torch.abs(target - actual).mean().item()
@@ -130,7 +149,8 @@ if __name__ == "__main__":
         d_context=d_context,
         dendrite_module=AbsoluteMaxGatingDendriticLayer,
         context_weights_fn=get_gating_context_weights,
-        batch_size=batch_size
+        batch_size=batch_size,
+        verbose=True
     )
 
     print(" Results over {} examples with {} random contexts".format(

--- a/nupic/research/frameworks/dendrites/routing/hardcoded.py
+++ b/nupic/research/frameworks/dendrites/routing/hardcoded.py
@@ -60,7 +60,8 @@ def run_hardcoded_routing_test(
                                dendrite_module, and has parameters `output_masks`,
                                `context_vectors`, and `num_dendrites`
     :param batch_size: the number of test inputs
-    :param verbose: prints the 
+    :param verbose: if True, prints target and output values on the first 15 dimensions
+                    of batch item 1
     """
 
     # Initialize routing function that this task will try to hardcode

--- a/tests/unit/frameworks/dendrites/dendrites_test.py
+++ b/tests/unit/frameworks/dendrites/dendrites_test.py
@@ -22,12 +22,12 @@
 import unittest
 
 import torch
-from torch.nn.functional import sigmoid
 
 from nupic.research.frameworks.dendrites import (
     BiasingDendriticLayer,
     DendriteSegments,
     GatingDendriticLayer,
+    AbsoluteMaxGatingDendriticLayer
 )
 
 
@@ -344,10 +344,116 @@ class BiasingDendriticLayerTests(unittest.TestCase):
         max_activation = torch.tensor([[-0.49, 0.87, -0.36], [-0.08, 0.08, 0.40]])
 
         # Expected output: dendrites applied as gate
-        expected_output = y * sigmoid(max_activation)
+        expected_output = y * torch.sigmoid(max_activation)
         actual_output = dendritic_layer.apply_dendrites(y, dendrite_activations)
 
         all_matches = (expected_output == actual_output).all()
+        self.assertTrue(all_matches)
+
+
+class AbsoluteMaxGatingDendriticLayerTests(unittest.TestCase):
+    def test_forward_output_shape(self):
+        """Validate shape of forward output."""
+
+        # Dendritic weights as a bias.
+        linear = torch.nn.Linear(10, 10)
+        dendritic_layer = AbsoluteMaxGatingDendriticLayer(
+            module=linear,
+            num_segments=20,
+            dim_context=15,
+            module_sparsity=0.7,
+            dendrite_sparsity=0.9
+        )
+        dendritic_layer.rezero_weights()
+
+        batch_size = 8
+        input_dim = dendritic_layer.module.weight.shape[1]
+        context_dim = dendritic_layer.segments.weights.shape[2]
+        x = torch.rand(batch_size, input_dim)
+        context = torch.rand(batch_size, context_dim)
+
+        out = dendritic_layer(x, context)
+        self.assertEqual(out.shape, (8, 10))
+
+    def test_apply_gating_dendrites(self):
+        """
+        Validate the outputs of the absolute max gating layer against hand-computed
+        outputs.
+        """
+        linear = torch.nn.Linear(10, 10)
+        dendritic_layer = AbsoluteMaxGatingDendriticLayer(
+            module=linear,
+            num_segments=20,
+            dim_context=15,
+            module_sparsity=0.7,
+            dendrite_sparsity=0.9,
+            dendrite_bias=False,
+        )
+
+        # pseudo output: batch_size=2, out_features=3
+        y = torch.tensor([[0.1, -0.1, 0.5], [0.2, 0.3, -0.2]])
+
+        # pseudo dendrite_activations: batch_size=2, num_units=3, num_segments=3
+        dendrite_activations = torch.tensor(
+            [
+                [[0.43, -1.64, 1.49], [-0.79, 0.53, 1.08], [0.02, 0.04, -0.57]],
+                [[1.79, -0.48, -0.38], [-0.15, 0.76, -1.13], [1.04, -0.58, -0.31]],
+            ]
+        )
+
+        # Expected absolute max activation per batch per unit
+        absolute_max_activations = torch.tensor([
+            [-1.64, 1.08, -0.57],
+            [1.79, -1.13, 1.04]
+        ])
+
+        # Expected output: dendrites applied as bias
+        expected_output = y * torch.sigmoid(absolute_max_activations)
+        actual_output = dendritic_layer.apply_dendrites(y, dendrite_activations)
+
+        all_matches = (expected_output == actual_output).all()
+        self.assertTrue(all_matches)
+
+    def test_gradients(self):
+        """
+        Validate gradient values to ensure they are flowing through the absolute max
+        operation. Note that this test doesn't actually consider the values of
+        gradients, apart from whether they are zero or non-zero.
+        """
+        linear = torch.nn.Linear(10, 10)
+        dendritic_layer = AbsoluteMaxGatingDendriticLayer(
+            module=linear,
+            num_segments=20,
+            dim_context=15,
+            module_sparsity=0.7,
+            dendrite_sparsity=0.9,
+            dendrite_bias=False,
+        )
+
+        # pseudo output: batch_size=2, out_features=3
+        y = torch.tensor([[0.1, -0.1, 0.5], [0.2, 0.3, -0.2]])
+
+        # pseudo dendrite_activations: batch_size=2, num_units=3, num_segments=3
+        dendrite_activations = torch.tensor(
+            [
+                [[0.43, -1.64, 1.49], [-0.79, 0.53, 1.08], [0.02, 0.04, -0.57]],
+                [[1.79, -0.48, -0.38], [-0.15, 0.76, -1.13], [1.04, -0.58, -0.31]],
+            ], requires_grad=True
+        )
+
+        output = dendritic_layer.apply_dendrites(y, dendrite_activations)
+        output.sum().backward()
+
+        # Expected gradient mask
+        expected_grad_mask = torch.tensor(
+            [
+                [[0.0, 1.0, 0.0], [0.0, 0.0, 1.0], [0.0, 0.0, 1.0]],
+                [[1.0, 0.0, 0.0], [0.0, 0.0, 1.0], [1.0, 0.0, 0.0]],
+            ]
+        )
+        actual_grad_mask = 1.0 * (dendrite_activations.grad != 0.0)
+
+        all_matches = (expected_grad_mask == actual_grad_mask).all()
         self.assertTrue(all_matches)
 
 

--- a/tests/unit/frameworks/dendrites/dendrites_test.py
+++ b/tests/unit/frameworks/dendrites/dendrites_test.py
@@ -24,10 +24,10 @@ import unittest
 import torch
 
 from nupic.research.frameworks.dendrites import (
+    AbsoluteMaxGatingDendriticLayer,
     BiasingDendriticLayer,
     DendriteSegments,
     GatingDendriticLayer,
-    AbsoluteMaxGatingDendriticLayer
 )
 
 


### PR DESCRIPTION
I made a few changes:

1. Included the `verbose` option to hardcoded test, which now prints target and output values during the routing test,

2. changed `torch.nn.functional.sigmoid` calls to `torch.sigmoid`, since the former is deprecated,

2. Fixed class `AbsoluteMaxGatingDendriticLayer` so that it's actually computing absolute max, and not just max (since I forgot to use `torch.abs` before),

3. Unit tests for `AbsoluteMaxGatingDendriticLayer`, which covers (a) correctness of output, and (b) that gradients are flowing through this layer (and especially through the max operator, while being zeroed out on all non-selected dendrites).