### PR TITLE
RES-1774: Fix running ray`local-mode` option on MacOS

### DIFF
--- a/nupic/research/frameworks/vernon/run_with_raytune.py
+++ b/nupic/research/frameworks/vernon/run_with_raytune.py
@@ -51,7 +51,8 @@ def run(config):
     ray.init(address=address, local_mode=config.get("local_mode", False))
 
     # Register serializer and deserializer - needed when logging arrays and tensors.
-    register_torch_serializers()
+    if not  config.get("local_mode", False):
+        register_torch_serializers()
 
     # Get ray.tune kwargs for the given config.
     kwargs = get_tune_kwargs(config)

--- a/nupic/research/frameworks/vernon/run_with_raytune.py
+++ b/nupic/research/frameworks/vernon/run_with_raytune.py
@@ -51,7 +51,7 @@ def run(config):
     ray.init(address=address, local_mode=config.get("local_mode", False))
 
     # Register serializer and deserializer - needed when logging arrays and tensors.
-    if not  config.get("local_mode", False):
+    if not config.get("local_mode", False):
         register_torch_serializers()
 
     # Get ray.tune kwargs for the given config.

--- a/nupic/research/frameworks/vernon/trainables.py
+++ b/nupic/research/frameworks/vernon/trainables.py
@@ -45,7 +45,7 @@ os.environ["HDF5_USE_FILE_LOCKING"] = "FALSE"
 class RayActorHelperMethods:
     def get_node_ip(self):
         """Returns the IP address of the current node."""
-        return socket.gethostbyname(socket.getfqdn())
+        return socket.gethostbyname(socket.gethostname())
 
     def get_free_port(self):
         """Returns free TCP port in the current node"""
@@ -230,11 +230,11 @@ class BaseTrainable(Trainable, metaclass=abc.ABCMeta):
 
         self._process_config(config)
 
+        experiment = ray.remote(
+            num_cpus=num_cpus, num_gpus=num_gpus)(self.experiment_class)
         for i in range(1 + self.max_retries):
             self.procs = []
             for _ in range(world_size):
-                experiment = ray.remote(
-                    num_cpus=num_cpus, num_gpus=num_gpus)(self.experiment_class)
                 self.procs.append(experiment.remote())
 
             # Use first process as head of the group

--- a/projects/gsc/run.py
+++ b/projects/gsc/run.py
@@ -20,6 +20,8 @@
 import argparse
 import copy
 
+import ray
+
 from experiments import CONFIGS
 from nupic.research.frameworks.vernon.parser_utils import DEFAULT_PARSERS, process_args
 from nupic.research.frameworks.vernon.run_with_raytune import run

--- a/projects/gsc/run.py
+++ b/projects/gsc/run.py
@@ -20,7 +20,7 @@
 import argparse
 import copy
 
-import ray
+import ray  # noqa: F401
 
 from experiments import CONFIGS
 from nupic.research.frameworks.vernon.parser_utils import DEFAULT_PARSERS, process_args

--- a/projects/vernon_continual/run.py
+++ b/projects/vernon_continual/run.py
@@ -20,6 +20,8 @@
 import argparse
 import copy
 
+import ray
+
 from experiments import CONFIGS
 from nupic.research.frameworks.vernon.parser_utils import DEFAULT_PARSERS, process_args
 from nupic.research.frameworks.vernon.run_with_raytune import run

--- a/projects/vernon_continual/run.py
+++ b/projects/vernon_continual/run.py
@@ -20,7 +20,7 @@
 import argparse
 import copy
 
-import ray
+import ray  # noqa: F401
 
 from experiments import CONFIGS
 from nupic.research.frameworks.vernon.parser_utils import DEFAULT_PARSERS, process_args


### PR DESCRIPTION
Tested with `nupic.research/projects/gsc` and `nupic.research/projects/vernal_continual` with the following command line:
```
python run.py --local-mode -e default_sparse_cnn --backend gloo -n 1
```