### PR TITLE
Test regular network on routing task

### DIFF
--- a/nupic/research/frameworks/dendrites/routing/__init__.py
+++ b/nupic/research/frameworks/dendrites/routing/__init__.py
@@ -19,5 +19,5 @@
 # http://numenta.org/licenses/
 # ----------------------------------------------------------------------
 
-from .routing import RoutingFunction
+from .routing import RoutingDataset, RoutingFunction
 from .utils import *

--- a/nupic/research/frameworks/dendrites/routing/regular_network.py
+++ b/nupic/research/frameworks/dendrites/routing/regular_network.py
@@ -26,9 +26,9 @@ from torch.utils.data import DataLoader
 from nupic.research.frameworks.dendrites.routing import (
     RoutingDataset,
     RoutingFunction,
-    evaluate_non_dendrite_model,
+    evaluate_dendrite_model,
     generate_context_vectors,
-    train_non_dendrite_model,
+    train_dendrite_model,
 )
 
 
@@ -115,32 +115,34 @@ def test_regular_network(
     model = model.to(model.device)
     r = r.to(r.device)
 
-    optimizer = torch.optim.Adam(model.parameters(), lr=1e-3)
+    optimizer = torch.optim.Adam(model.parameters(), lr=1e-4)
+    # optimizer = torch.optim.SGD(model.parameters(), lr=0.1)
 
     print("epoch,mean_loss")
     for epoch in range(1, num_training_epochs + 1):
 
-        train_non_dendrite_model(
+        train_dendrite_model(
             model=model,
             loader=routing_test_dataloader,
             optimizer=optimizer,
             device=model.device,
-            criterion=F.mse_loss
+            criterion=F.mse_loss,
+            concat=True
         )
 
         # Validate model - note that we use the same dataset/dataloader for validation
-        results = evaluate_non_dendrite_model(
+        results = evaluate_dendrite_model(
             model=model,
             loader=routing_test_dataloader,
             device=model.device,
-            criterion=F.mse_loss
+            criterion=F.mse_loss,
+            concat=True
         )
 
-        print("{},{},{},{}".format(
+        print("{},{},{}".format(
             epoch,
             results["loss"],
-            results["mean_abs_err_1s"],
-            results["mean_abs_err_0s"]
+            results["mean_abs_err"]
         ))
 
 

--- a/nupic/research/frameworks/dendrites/routing/regular_network.py
+++ b/nupic/research/frameworks/dendrites/routing/regular_network.py
@@ -116,7 +116,6 @@ def test_regular_network(
     r = r.to(r.device)
 
     optimizer = torch.optim.Adam(model.parameters(), lr=1e-4)
-    # optimizer = torch.optim.SGD(model.parameters(), lr=0.1)
 
     print("epoch,mean_loss")
     for epoch in range(1, num_training_epochs + 1):

--- a/nupic/research/frameworks/dendrites/routing/regular_network.py
+++ b/nupic/research/frameworks/dendrites/routing/regular_network.py
@@ -1,0 +1,154 @@
+# ----------------------------------------------------------------------
+# Numenta Platform for Intelligent Computing (NuPIC)
+# Copyright (C) 2020, Numenta, Inc.  Unless you have an agreement
+# with Numenta, Inc., for a separate license for this software code, the
+# following terms and conditions apply:
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# See the GNU Affero Public License for more details.
+#
+# You should have received a copy of the GNU Affero Public License
+# along with this program.  If not, see http://www.gnu.org/licenses.
+#
+# http://numenta.org/licenses/
+# ----------------------------------------------------------------------
+
+import torch
+import torch.nn.functional as F
+from torch.utils.data import DataLoader
+
+from nupic.research.frameworks.dendrites.routing import (
+    RoutingDataset,
+    RoutingFunction,
+    evaluate_non_dendrite_model,
+    generate_context_vectors,
+    train_non_dendrite_model,
+)
+
+
+class SingleLayerLinearNetwork(torch.nn.Module):
+    """
+    A feed-forward linear network with just a single layer and no non-linear activation
+    function
+    """
+
+    def __init__(self, input_size, output_size):
+        super().__init__()
+        self.layer = torch.nn.Linear(input_size, output_size)
+        self.device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+
+    def forward(self, x):
+        return self.layer(x)
+
+
+def test_regular_network(
+    dim_in,
+    dim_out,
+    num_contexts,
+    dim_context,
+    batch_size=64,
+    num_training_epochs=1000
+):
+    """
+    Trains and evalutes a feedforward network with no hidden layers to match an
+    arbitrary routing function
+
+    :param dim_in: the number of dimensions in the input to the routing function and
+                   test module
+    :param dim_out: the number of dimensions in the sparse linear output of the routing
+                    function and test network
+    :param num_contexts: the number of unique random binary vectors in the routing
+                         function that can "route" the sparse linear output, and also
+                         the number of unique context vectors
+    :param dim_context: the number of dimensions in the context vectors
+    :param dendrite_module: a torch.nn.Module subclass that implements a dendrite
+                            module in addition to a linear feed-forward module
+    :param batch_size: the batch size during training and evaluation
+    :param num_training_epochs: the number of epochs for which to train the dendritic
+                                network
+    """
+
+    # Input size to the model is 2 * dim_in since the context is concatenated with the
+    # regular input
+    model = SingleLayerLinearNetwork(input_size=2 * dim_in, output_size=dim_out)
+
+    # Initialize routing function that this task will try to learn, and set
+    # `requires_grad=False` since the routing function is static
+    r = RoutingFunction(
+        d_in=dim_in,
+        d_out=dim_out,
+        k=num_contexts,
+        device=model.device,
+        sparsity=0.7
+    )
+    r.sparse_weights.module.weight.requires_grad = False
+
+    # Initialize context vectors, where each context vector corresponds to an output
+    # mask in the routing function
+    context_vectors = generate_context_vectors(
+        num_contexts=num_contexts,
+        n_dim=dim_context,
+        percent_on=0.2
+    )
+
+    # Initialize dataset and dataloader
+    routing_test_dataset = RoutingDataset(
+        routing_function=r,
+        input_size=r.sparse_weights.module.in_features,
+        context_vectors=context_vectors,
+        device=model.device,
+        concat=True
+    )
+
+    routing_test_dataloader = DataLoader(
+        dataset=routing_test_dataset,
+        batch_size=batch_size
+    )
+
+    # Place objects that inherit from torch.nn.Module on device
+    model = model.to(model.device)
+    r = r.to(r.device)
+
+    optimizer = torch.optim.Adam(model.parameters(), lr=1e-3)
+
+    print("epoch,mean_loss")
+    for epoch in range(1, num_training_epochs + 1):
+
+        train_non_dendrite_model(
+            model=model,
+            loader=routing_test_dataloader,
+            optimizer=optimizer,
+            device=model.device,
+            criterion=F.mse_loss
+        )
+
+        # Validate model - note that we use the same dataset/dataloader for validation
+        results = evaluate_non_dendrite_model(
+            model=model,
+            loader=routing_test_dataloader,
+            device=model.device,
+            criterion=F.mse_loss
+        )
+
+        print("{},{},{},{}".format(
+            epoch,
+            results["loss"],
+            results["mean_abs_err_1s"],
+            results["mean_abs_err_0s"]
+        ))
+
+
+if __name__ == "__main__":
+
+    test_regular_network(
+        dim_in=100,
+        dim_out=100,
+        num_contexts=10,
+        dim_context=100
+    )

--- a/nupic/research/frameworks/dendrites/routing/routing.py
+++ b/nupic/research/frameworks/dendrites/routing/routing.py
@@ -87,7 +87,7 @@ class RoutingDataset(Dataset):
             raise IndexError("Index {} is out of range".format(idx))
         torch.manual_seed(idx)
 
-        x = self.alpha * torch.rand((self.input_size,)) - self.beta
+        x = self.alpha * torch.rand((self.input_size,)) + self.beta
         x = x.to(self.device)
 
         context_id = randint(0, self.num_output_masks - 1)


### PR DESCRIPTION
This introduces `regular_network.py` which trains a single-layer network on the routing task (in which the input and context vectors are concatenated as input to the network).

**Results:** The single-layer network's loss stops decreasing quite soon. Furthermore, there's no significant difference in mean abs. error on the dimensions that get masked (i.e., output multiplied by 0) vs. those that don't. The mean abs. error never goes below 0.05, whereas it does in the case of the learned dendrite module. This suggests the single-layer network doesn't learn the routing task.