### PR TITLE
Remove extra print statement

### DIFF
--- a/nupic/research/frameworks/vernon/run_with_raytune.py
+++ b/nupic/research/frameworks/vernon/run_with_raytune.py
@@ -56,7 +56,6 @@ def run(config):
 
     # Get ray.tune kwargs for the given config.
     kwargs = get_tune_kwargs(config)
-    pprint(kwargs)
 
     # Queue trials until the cluster scales up
     kwargs.update(queue_trials=True)


### PR DESCRIPTION
There are two print statements bracketing a single 'update' call.  Each one is very long, so just removing the first one.