### PR TITLE
Changing parameter names for routing classes/functions

### DIFF
--- a/nupic/research/frameworks/dendrites/routing/hardcoded.py
+++ b/nupic/research/frameworks/dendrites/routing/hardcoded.py
@@ -33,10 +33,10 @@ from nupic.research.frameworks.dendrites.routing import (
 
 
 def run_hardcoded_routing_test(
-    d_in,
-    d_out,
+    dim_in,
+    dim_out,
     k,
-    d_context,
+    dim_context,
     dendrite_module,
     context_weights_fn=None,
     batch_size=100,
@@ -45,14 +45,14 @@ def run_hardcoded_routing_test(
     """
     Runs the hardcoded routing test for a specific type of dendritic network
 
-    :param d_in: the number of dimensions in the input to the routing function and test
-                 module
-    :param d_out: the number of dimensions in the sparse linear output of the routing
-                  function and test network
+    :param dim_in: the number of dimensions in the input to the routing function and
+                   test module
+    :param dim_out: the number of dimensions in the sparse linear output of the routing
+                    function and test network
     :param k: the number of unique random binary vectors in the routing function that
               can "route" the sparse linear output, and also the number of unique
               context vectors
-    :param d_context: the number of dimensions in the context vectors
+    :param dim_context: the number of dimensions in the context vectors
     :param dendrite_module: a torch.nn.Module subclass that implements a dendrite
                             module in addition to a linear feed-forward module
     :param context_weights_fn: a function that returns a 3D torch Tensor that gives the
@@ -65,13 +65,13 @@ def run_hardcoded_routing_test(
     """
 
     # Initialize routing function that this task will try to hardcode
-    r = RoutingFunction(d_in=d_in, d_out=d_out, k=k, sparsity=0.7)
+    r = RoutingFunction(dim_in=dim_in, dim_out=dim_out, k=k, sparsity=0.7)
 
     # Initialize context vectors, where each context vector corresponds to an output
     # mask in the routing function
     context_vectors = generate_context_vectors(
         num_contexts=k,
-        n_dim=d_context,
+        n_dim=dim_context,
         percent_on=0.2
     )
 
@@ -81,7 +81,7 @@ def run_hardcoded_routing_test(
     dendritic_network = dendrite_module(
         module=r.sparse_weights.module,
         num_segments=k,
-        dim_context=d_context,
+        dim_context=dim_context,
         module_sparsity=0.7,
         dendrite_sparsity=0.0
     )
@@ -101,7 +101,7 @@ def run_hardcoded_routing_test(
 
     # Sample a random batch of inputs and random batch of context vectors, and perform
     # hardcoded routing test
-    x_test = 4.0 * torch.rand((batch_size, d_in)) - 2.0  # sampled i.i.d. from U[-2, 2)
+    x_test = 4.0 * torch.rand((batch_size, dim_in)) - 2.0  # sampled from U(-2, 2)
     context_inds_test = randint(low=0, high=k, size=batch_size).tolist()
     context_test = torch.stack(
         [context_vectors[j, :] for j in context_inds_test],
@@ -137,17 +137,17 @@ if __name__ == "__main__":
     # Run the hardcoded routing test with a dendritic network that uses "dendrites as
     # gating"; this achieves near-zero mean absolute error, which strongly suggests
     # that dendritic networks can successfully route
-    d_in = 100
-    d_out = 100
+    dim_in = 100
+    dim_out = 100
     num_contexts = 10
-    d_context = 100
+    dim_context = 100
     batch_size = 100
 
     result = run_hardcoded_routing_test(
-        d_in=d_in,
-        d_out=d_out,
+        dim_in=dim_in,
+        dim_out=dim_out,
         k=num_contexts,
-        d_context=d_context,
+        dim_context=dim_context,
         dendrite_module=AbsoluteMaxGatingDendriticLayer,
         context_weights_fn=get_gating_context_weights,
         batch_size=batch_size,

--- a/nupic/research/frameworks/dendrites/routing/regular_network.py
+++ b/nupic/research/frameworks/dendrites/routing/regular_network.py
@@ -81,8 +81,8 @@ def test_regular_network(
     # Initialize routing function that this task will try to learn, and set
     # `requires_grad=False` since the routing function is static
     r = RoutingFunction(
-        d_in=dim_in,
-        d_out=dim_out,
+        dim_in=dim_in,
+        dim_out=dim_out,
         k=num_contexts,
         device=model.device,
         sparsity=0.7

--- a/nupic/research/frameworks/dendrites/routing/routing.py
+++ b/nupic/research/frameworks/dendrites/routing/routing.py
@@ -128,12 +128,12 @@ class RoutingFunction(torch.nn.Module):
     R(1, x) = [0.3, −0.4, 0.0, 0.0].
     """
 
-    def __init__(self, d_in, d_out, k, device=None, sparsity=0.7):
+    def __init__(self, dim_in, dim_out, k, device=None, sparsity=0.7):
         """
-        :param d_in: the number of dimensions in the input
-        :type d_in: int
-        :param d_out: the number of dimensions in the sparse linear output
-        :type d_out: int
+        :param dim_in: the number of dimensions in the input
+        :type dim_in: int
+        :param dim_out: the number of dimensions in the sparse linear output
+        :type dim_out: int
         :param k: the number of unique random binary vectors that can "route" the
                   sparse linear output
         :param device: device to use ('cpu' or 'cuda')
@@ -145,10 +145,10 @@ class RoutingFunction(torch.nn.Module):
         """
         super().__init__()
         self.sparse_weights = SparseWeights(
-            torch.nn.Linear(in_features=d_in, out_features=d_out, bias=False),
+            torch.nn.Linear(in_features=dim_in, out_features=dim_out, bias=False),
             sparsity=sparsity
         )
-        self.output_masks = generate_random_binary_vectors(k, d_out)
+        self.output_masks = generate_random_binary_vectors(k, dim_out)
         self.device = device if device is not None else torch.device("cpu")
 
     def forward(self, output_mask_inds, x):
@@ -202,7 +202,7 @@ if __name__ == "__main__":
 
     # Initialize RoutingFunction object with output_dim output dimensions and k output
     # masks
-    R = RoutingFunction(d_in=input_dim, d_out=output_dim, k=k)
+    R = RoutingFunction(dim_in=input_dim, dim_out=output_dim, k=k)
 
     # Print output masks
     for j in range(R.num_output_masks):

--- a/tests/unit/frameworks/dendrites/hardcoded_test.py
+++ b/tests/unit/frameworks/dendrites/hardcoded_test.py
@@ -49,17 +49,17 @@ class HardcodedErrorTest(unittest.TestCase):
         # function (and dendritic network), the number of dendritic weights, the size
         # of the context vector, and batch size over which the mean absolute error is
         # computed
-        d_in = 100
-        d_out = 100
+        dim_in = 100
+        dim_out = 100
         num_contexts = 10
-        d_context = 100
+        dim_context = 100
         batch_size = 100
 
         result = run_hardcoded_routing_test(
-            d_in=d_in,
-            d_out=d_out,
+            dim_in=dim_in,
+            dim_out=dim_out,
             k=num_contexts,
-            d_context=d_context,
+            dim_context=dim_context,
             dendrite_module=AbsoluteMaxGatingDendriticLayer,
             context_weights_fn=get_gating_context_weights,
             batch_size=batch_size

--- a/tests/unit/frameworks/dendrites/routing_test.py
+++ b/tests/unit/frameworks/dendrites/routing_test.py
@@ -44,8 +44,8 @@ class RoutingFunctionTest(unittest.TestCase):
         sparsity = 0.7
 
         r = RoutingFunction(
-            d_in=dim_in,
-            d_out=dim_out,
+            dim_in=dim_in,
+            dim_out=dim_out,
             k=num_output_masks,
             sparsity=sparsity
         )
@@ -70,8 +70,8 @@ class RoutingFunctionTest(unittest.TestCase):
         sparsity = 0.7
 
         r = RoutingFunction(
-            d_in=dim_in,
-            d_out=dim_out,
+            dim_in=dim_in,
+            dim_out=dim_out,
             k=num_output_masks,
             sparsity=sparsity
         )


### PR DESCRIPTION
Here, I make parameter names consistent across all routing- and dendrite-related classes & functions. Parameters that specify the number of dimensions are now `dim_*` (and no longer `d_*`). I feel this makes the parameter name for descriptive. I also modified unit test cases corresponding to these changes.