### PR TITLE
Introduce the Omniglot dataset via git-lfs (just the zip files)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,2 @@
 *.pt filter=lfs diff=lfs merge=lfs -text
+tests/unit/frameworks/pytorch/data/** filter=lfs diff=lfs merge=lfs -text

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,2 @@
 *.pt filter=lfs diff=lfs merge=lfs -text
-tests/unit/frameworks/pytorch/data/** filter=lfs diff=lfs merge=lfs -text
+*.zip filter=lfs diff=lfs merge=lfs -text

--- a/.gitignore
+++ b/.gitignore
@@ -122,3 +122,8 @@ checkcode.sh
 /projects/ray_tune_example/mnist/data
 /projects/whydense/cifar/results
 /projects/whydense/cifar/results1
+
+
+# local test data
+/tests/unit/frameworks/pytorch/data/omniglot-py/images_background
+/tests/unit/frameworks/pytorch/data/omniglot-py/images_evaluation

--- a/environment.yml
+++ b/environment.yml
@@ -8,6 +8,7 @@ channels:
 dependencies:
   - python=3.7
   - pip
+  - git-lfs
 
   # Dependencies not available in conda
   - pip:

--- a/nupic/research/frameworks/pytorch/test_utils/__init__.py
+++ b/nupic/research/frameworks/pytorch/test_utils/__init__.py
@@ -20,3 +20,4 @@
 
 from .fake_data import *
 from .temp_fake_data import *
+from .omniglot_from_zip import *

--- a/nupic/research/frameworks/pytorch/test_utils/omniglot_from_zip.py
+++ b/nupic/research/frameworks/pytorch/test_utils/omniglot_from_zip.py
@@ -1,0 +1,55 @@
+# ----------------------------------------------------------------------
+# Numenta Platform for Intelligent Computing (NuPIC)
+# Copyright (C) 2020, Numenta, Inc.  Unless you have an agreement
+# with Numenta, Inc., for a separate license for this software code, the
+# following terms and conditions apply:
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# See the GNU Affero Public License for more details.
+#
+# You should have received a copy of the GNU Affero Public License
+# along with this program.  If not, see http://www.gnu.org/licenses.
+#
+# http://numenta.org/licenses/
+# ----------------------------------------------------------------------
+
+from os.path import isdir, isfile, join
+
+from torchvision.datasets import Omniglot
+from torchvision.datasets.utils import extract_archive
+
+__all__ = ["OmniglotFromZip"]
+
+
+class OmniglotFromZip(Omniglot):
+
+    def download(self):
+        """
+        Try and extract Omniglot from a zipfile before downloading the dataset. If the
+        dataset is already downloaded and extracted, this function will do nothing.
+
+        Make sure `download=True` to enable extraction.
+        """
+
+        # Target folder is either "images_background" or "images_evaluation"
+        target_folder = self._get_target_folder()
+        zip_filename = target_folder + ".zip"
+        zip_path = join(self.root, zip_filename)
+        extract_folder = join(self.root, target_folder)
+
+        # Extract zip file if it exists and hasn't already been extracted.
+        if isfile(zip_path) and not isdir(extract_folder):
+            print("Extracting {} to {}".format(zip_path, self.root))
+            extract_archive(
+                from_path=zip_path,
+                to_path=self.root,
+                remove_finished=False,  # don't delete the zip file
+            )
+
+        super().download()

--- a/tests/unit/frameworks/pytorch/data/omniglot-py/images_background.zip
+++ b/tests/unit/frameworks/pytorch/data/omniglot-py/images_background.zip
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ad41ab679c8b5d90b271ef46be6987cc81211774a695c29dcc5367b2b26ee640
+size 9464212

--- a/tests/unit/frameworks/pytorch/data/omniglot-py/images_evaluation.zip
+++ b/tests/unit/frameworks/pytorch/data/omniglot-py/images_evaluation.zip
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1f61a8f3366785b057fc117d9228e78a16e3d976c8953b2a10fcc74cf0609cee
+size 6462886

--- a/tests/unit/frameworks/pytorch/omniglot_test.py
+++ b/tests/unit/frameworks/pytorch/omniglot_test.py
@@ -1,0 +1,52 @@
+# ----------------------------------------------------------------------
+# Numenta Platform for Intelligent Computing (NuPIC)
+# Copyright (C) 2020, Numenta, Inc.  Unless you have an agreement
+# with Numenta, Inc., for a separate license for this software code, the
+# following terms and conditions apply:
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# See the GNU Affero Public License for more details.
+#
+# You should have received a copy of the GNU Affero Public License
+# along with this program.  If not, see http://www.gnu.org/licenses.
+#
+# http://numenta.org/licenses/
+# ----------------------------------------------------------------------
+
+import pathlib
+import unittest
+
+from nupic.research.frameworks.pytorch.test_utils import OmniglotFromZip
+
+ROOT = pathlib.Path(__file__).parent / "data"
+
+
+class OmniglotTest(unittest.TestCase):
+
+    def test_load_dataset(self):
+        """Load the background and evaluation set."""
+        background_dataset = OmniglotFromZip(
+            root=ROOT,
+            background=True,
+            download=True,
+            transform=None
+        )
+        self.assertEqual(len(background_dataset), 19280)
+
+        evaluation_dataset = OmniglotFromZip(
+            root=ROOT,
+            background=False,
+            download=True,
+            transform=None
+        )
+        self.assertEqual(len(evaluation_dataset), 13180)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
This PR adds the downloaded Omniglot dataset to our testing directory. This will be helpful for more extensive testing of our experiment framework Vernon such as end-to-end tests of the experiment classes.

Supersedes https://github.com/numenta/nupic.research/pull/391
