### PR TITLE
Reference documents for Meta-Continual Learning

### DIFF
--- a/projects/meta_cl/references/meta_cl_pseudo_code.md
+++ b/projects/meta_cl/references/meta_cl_pseudo_code.md
@@ -1,0 +1,93 @@
+# OML vs ANML vs Ours
+
+# Meta-Training
+
+## In The ANML Paper
+```
+for e in epochs (20000 total)
+  sample 1 task
+
+  # inner loop
+  sample 20 images (if more then 1 task, done evenly across all of them)
+  for i in images
+    do one grad step; done w/ single image over fast params
+
+  # outer loop
+  sample 20 new images from the one task (these will be the same, since there are only 20 per class)
+  sample 64 new images across all tasks (replay set)
+  do one grad step; done w/ combined 128 images over fast and slow params
+```
+
+
+## In The OML Paper
+
+```
+for e in epoch (not sure how many)
+  sample 3 tasks
+  
+  # inner loop
+  sample 5 images from each task
+  for each task:
+    for i in images
+      do one grad step; done w/ single image over fast params
+
+  # outer loop
+  sample 5 new images for each task (15 total)
+  sample 15 replay images
+  do one grad step; done w/ the combined 30 images over fast and slow params
+```
+
+
+## In Our Previous Implementation
+This is prior to [PR #389](https://github.com/numenta/nupic.research/pull/389/commits/6e7bf3bb7728419da95b0766c1034b62a033d6c8)
+
+Note: Our implementation after that PR supports both OML and ANML meta-training.
+
+```
+for e in epochs (only 1000)
+  sample 10 tasks
+
+  # inner loop
+  for t in tasks
+    sample 5 images
+    do one grad step; done w/ all 5 images over fast params
+  
+  # outer loop
+  sample 64 new images across the 10 tasks
+  sample 64 new images across all tasks (remeber set)
+  do one grad step; done w/ combined 128 images over fast and slow params
+```
+
+# Meta-Testing
+
+## OML and ANML
+```
+for r in num_runs (anwhere from 15 to 50)
+  sample t tasks (either 10, 50, or 100, ect)
+  retrieve 15 images per task; hold-out 5 per task for testing
+
+  # meta-test training: uses 15 × t images
+  for each img; going sequentially, one task at a time
+    do one grad step; done w/ just the one image
+
+  # meta-test testing: using 5 × t images
+  evaluate model on held out images
+```
+
+## In Our Previous Implementation
+This is prior to [PR #389](https://github.com/numenta/nupic.research/pull/389/commits/6e7bf3bb7728419da95b0766c1034b62a033d6c8)
+
+Note: Our implementation after that PR supports both OML and ANML meta-testing.
+
+```
+for r in num_runs (we used 15)
+  sample t tasks (either 10, 50, or 100, ect)
+  retrieve 15 images per task; hold-out 5 each for testing
+
+  # meta-test training: uses 15 × t images
+  for each img; sampled iid over across all the t tasks
+    do one grad step; done w/ just the one image
+
+  # meta-test testing: using 5 × t images
+  evaluate model on held out images
+```

--- a/projects/meta_cl/references/oml_implementation_specifics.md
+++ b/projects/meta_cl/references/oml_implementation_specifics.md
@@ -1,0 +1,99 @@
+# OML Implementation Specifics
+
+Based off the repository https://github.com/khurramjaved96/mrcl
+
+This document describes the specifics of the Online-aware Meta-learning algorithm detailed in the paper:
+[Meta-Learning Representations for Continual Learning](https://arxiv.org/abs/1905.12588)
+
+Specifically, these specifics flesh out the details for
+  - meta-training: See [oml_omniglot.py](https://github.com/khurramjaved96/mrcl/blob/master/oml_omniglot.py)
+  - meta-testing: See [evaluate_omniglot.py](https://github.com/khurramjaved96/mrcl/blob/master/evaluate_omniglot.py)
+
+## Data
+
+Dataset: Omniglot
+  - 1663 character classes 
+  - 20 per class
+  - Split into "background" and "evaluation" sets
+  - "background" set: 964 classes; labeled 1 through 963
+  - "evaluation" set: 659 classes; labeled 1 through 658
+
+Transforms:
+  - Reshaped to size 84 x 84
+  - No normalization on the data
+
+One channel per image; shape will be `1 x 84 x 84` (C x W x H)
+
+## Meta-training
+
+Per meta-training iteration (inner loop + outer loop):
+  - Three tasks are sampled (1 task == 1 class)
+    - tasks sampled between `list(range(int(963/2), 963))` (that is `[481, ...,962]`)
+  - Reset the output weights corresponding to the sampled classes
+  - Both fast and slow data are taken over the same three sampled tasks
+  - Replay data is taken from the other half of the dataset, those among classes `[0, ...,480]`
+
+**Meta-train train (the inner loop)**
+  - 5 images per task
+
+**Meta-train test (the out loop)**
+  - 5 (different) images per task (taken from the same tasks as the inner loop)
+  - A remember set - 15 images sampled uniformly from the first 480 classes
+
+## Optim (Meta-training)
+  - inner_loop:
+    - update_lr=0.03 (used in inner loop)
+    - no explicit optimizer, but uses an SGD update rule
+  - outer loop
+    - meta_lr=1e-4 (used in outer loop)
+    - ADAM optimizer
+
+## The Model
+Pytorch printout:
+```
+OMLNetwork(
+  (representation): Sequential(
+    (0): Conv2d(1, 256, kernel_size=(3, 3), stride=(2, 2))
+    (1): ReLU()
+    (2): Conv2d(256, 256, kernel_size=(3, 3), stride=(1, 1))
+    (3): ReLU()
+    (4): Conv2d(256, 256, kernel_size=(3, 3), stride=(2, 2))
+    (5): ReLU()
+    (6): Conv2d(256, 256, kernel_size=(3, 3), stride=(1, 1))
+    (7): ReLU()
+    (8): Conv2d(256, 256, kernel_size=(3, 3), stride=(2, 2))
+    (9): ReLU()
+    (10): Conv2d(256, 256, kernel_size=(3, 3), stride=(2, 2))
+    (11): ReLU()
+    (12): Flatten()
+  )
+  (adaptation): Sequential(
+    (0): Linear(in_features=2304, out_features=1000, bias=True)
+  )
+)
+
+```
+^ Note, the output layer has 1000 output units, which is more than needed.
+
+  - Weight initialization:
+    - bias params are set to zero
+    - weights params for conv and linear layers use kaiming-normal initialization (fan-in)
+
+
+### What's tranined and when
+"Prediction Learning Network" == `adaption` network in above printout
+"Representation Learning Network" == `representatin` network in above printout
+
+Meta-train training:
+  - All layers of the Prediction Learning Network
+  - ~~Representation Learning Network (frozen)~~
+
+Meta-train testing:
+  - Both the PLN and RLN are updated
+
+Meta-test training:
+  - Prediction Learning Network
+  - ~~Representation Learning Network (frozen)~~
+
+Meta-test testing:
+  - NA (nothing should be updated at the point)


### PR DESCRIPTION
The OML algorithm is quite difficult to pin down in terms of specifics. I thought it would help to share my notes. In this PR, `oml_implementation_specifics.md` includes all the specifics of the OML algorithm I managed to flesh out.

As well, to get a high level overview of the meta-cl algorithms, there's `meta_cl_pseudo_code.md` which includes pseudo code of OML, ANML, and our previous implementation (included for comparison against the changes made in  [this](https://github.com/numenta/nupic.research/pull/389/commits/6e7bf3bb7728419da95b0766c1034b62a033d6c8) PR).

I didn't originally intend to make these super polished. These are mostly to serve as notes. However, feedback is welcome so please let me know if anything is not clear.