### PR TITLE
Fix naming of ambiguous variables (pep E741)

### DIFF
--- a/nupic/research/frameworks/dendrites/dendrite_segments.py
+++ b/nupic/research/frameworks/dendrites/dendrite_segments.py
@@ -154,8 +154,8 @@ def random_mask(size, sparsity, dims=None, **kwargs):
 
         # Loop all combinations that index through dims.
         # The 1D case is equivalent to range.
-        dim_legths = [mask.shape[dim] for dim in dims]
-        dim_indices = product(*[range(l) for l in dim_legths])
+        dim_lengths = [mask.shape[dim] for dim in dims]
+        dim_indices = product(*[range(dl) for dl in dim_lengths])
 
         for idxs in dim_indices:
 

--- a/nupic/research/frameworks/dynamic_sparse/networks/hebbian.py
+++ b/nupic/research/frameworks/dynamic_sparse/networks/hebbian.py
@@ -189,7 +189,7 @@ class MLPHeb(HebbianNetwork):
         )
 
         # Create the classifier.
-        self.dynamic_sparse_modules = [l[0] for l in layers[1:]]
+        self.dynamic_sparse_modules = [layer[0] for layer in layers[1:]]
         self.classifier = nn.Sequential(*layers)
 
         # Initialize attr to decide whether to update coactivations during learning.

--- a/nupic/research/frameworks/pytorch/models/vgg_sparse_net.py
+++ b/nupic/research/frameworks/pytorch/models/vgg_sparse_net.py
@@ -76,22 +76,22 @@ class VGGSparseNet(nn.Sequential):
         in_channels, h, w = input_shape
         output_size = h * w
         output_units = output_size * in_channels
-        for l, block_size in enumerate(block_sizes):
+        for ly, block_size in enumerate(block_sizes):
             for b in range(block_size):
                 self._add_cnn_layer(
-                    index_str=str(l) + "_" + str(b),
+                    index_str=str(ly) + "_" + str(b),
                     in_channels=in_channels,
-                    out_channels=cnn_out_channels[l],
-                    kernel_size=cnn_kernel_sizes[l],
-                    percent_on=cnn_percent_on[l],
-                    weight_sparsity=cnn_weight_sparsity[l],
+                    out_channels=cnn_out_channels[ly],
+                    kernel_size=cnn_kernel_sizes[ly],
+                    percent_on=cnn_percent_on[ly],
+                    weight_sparsity=cnn_weight_sparsity[ly],
                     k_inference_factor=k_inference_factor,
                     boost_strength=boost_strength,
                     boost_strength_factor=boost_strength_factor,
                     add_pooling=b == block_size - 1,
                     use_max_pooling=use_max_pooling,
                 )
-                in_channels = cnn_out_channels[l]
+                in_channels = cnn_out_channels[ly]
             output_size = int(output_size / 4)
             output_units = output_size * in_channels
 
@@ -100,29 +100,29 @@ class VGGSparseNet(nn.Sequential):
 
         # Linear layer
         input_size = output_units
-        for l, linear_n in enumerate(linear_units):
+        for ly, linear_n in enumerate(linear_units):
             linear = nn.Linear(input_size, linear_n)
-            if linear_weight_sparsity[l] < 1.0:
+            if linear_weight_sparsity[ly] < 1.0:
                 self.add_module(
-                    "linear_" + str(l),
-                    SparseWeights(linear, linear_weight_sparsity[l]),
+                    "linear_" + str(ly),
+                    SparseWeights(linear, linear_weight_sparsity[ly]),
                 )
             else:
-                self.add_module("linear_" + str(l), linear)
+                self.add_module("linear_" + str(ly), linear)
 
-            if linear_percent_on[l] < 1.0:
+            if linear_percent_on[ly] < 1.0:
                 self.add_module(
-                    "kwinners_linear_" + str(l),
+                    "kwinners_linear_" + str(ly),
                     KWinners(
                         n=linear_n,
-                        percent_on=linear_percent_on[l],
+                        percent_on=linear_percent_on[ly],
                         k_inference_factor=k_inference_factor,
                         boost_strength=boost_strength,
                         boost_strength_factor=boost_strength_factor,
                     ),
                 )
             else:
-                self.add_module("Linear_ReLU_" + str(l), nn.ReLU())
+                self.add_module("Linear_ReLU_" + str(ly), nn.ReLU())
 
             input_size = linear_n
 

--- a/projects/rsm/rsm_experiment.py
+++ b/projects/rsm/rsm_experiment.py
@@ -396,7 +396,7 @@ class RSMExperiment(object):
                 visual_debug=self.visual_debug,
             )
             if self.n_layers > 1:
-                predictor_d_in = sum([l.total_cells for l in self.model.children()])
+                predictor_d_in = sum([ly.total_cells for ly in self.model.children()])
             else:
                 predictor_d_in = self.m_groups * self.n_cells_per_group
 
@@ -613,11 +613,11 @@ class RSMExperiment(object):
 
             if self.n_layers > 1 and self.loss_layers in ["above_first", "all_layers"]:
                 memory = self._repackage_hidden(targets[1])
-                for l in range(self.n_layers - 1):
+                for ly in range(self.n_layers - 1):
                     higher_targets = memory[
-                        l
+                        ly
                     ]  # Target memory states up to 2nd to last layer
-                    outputs = predicted_outputs[l + 1]  # Predictions from layer above
+                    outputs = predicted_outputs[ly + 1]  # Predictions from layer above
                     ls_loss = self.loss(outputs, higher_targets)
                     if loss is None:
                         loss = ls_loss
@@ -625,17 +625,17 @@ class RSMExperiment(object):
                         loss += ls_loss
 
             if self.l2_reg and self.lateral_conn:
-                for l in self.model.children():
+                for ly in self.model.children():
                     # Add L2 reg term for recurrent weights
-                    loss += self.l2_reg * l.linear_b.weight.norm(2) ** 2
-                    if hasattr(l.linear_b, "bias"):
-                        loss += self.l2_reg * l.linear_b.bias.norm(2) ** 2
+                    loss += self.l2_reg * ly.linear_b.weight.norm(2) ** 2
+                    if hasattr(ly.linear_b, "bias"):
+                        loss += self.l2_reg * ly.linear_b.bias.norm(2) ** 2
             if self.dec_l2_reg:
-                for l in self.model.children():
+                for ly in self.model.children():
                     # Add L2 reg term for decode weights
-                    loss += self.dec_l2_reg * l.linear_d.weight.norm(2) ** 2
-                    if hasattr(l.linear_d, "bias") and l.linear_d.bias is not None:
-                        loss += self.dec_l2_reg * l.linear_d.bias.norm(2) ** 2
+                    loss += self.dec_l2_reg * ly.linear_d.weight.norm(2) ** 2
+                    if hasattr(ly.linear_d, "bias") and ly.linear_d.bias is not None:
+                        loss += self.dec_l2_reg * ly.linear_d.bias.norm(2) ** 2
 
         return loss
 

--- a/projects/rsm/util.py
+++ b/projects/rsm/util.py
@@ -543,20 +543,20 @@ def plot_tensors(model, tuples, detailed=False, return_fig=False):
     n_tensors = len(tuples)
     fig, axs = plt.subplots(model.n_layers, n_tensors, dpi=144)
     for i, (label, val) in enumerate(tuples):
-        for l in range(model.n_layers):
-            layer_idx = model.n_layers - l - 1
+        for layer in range(model.n_layers):
+            layer_idx = model.n_layers - layer - 1
             ax = axs[layer_idx][i] if n_tensors > 1 else axs[layer_idx]
             # Get layer's values (from either list or tensor)
             # Outputs can't be stored in tensors since dimension heterogeneous
             if isinstance(val, list):
-                if val[l] is None:
+                if val[layer] is None:
                     ax.set_visible(False)
                     t = None
                 else:
-                    t = val[l].detach()[0]
+                    t = val[layer].detach()[0]
             else:
-                t = val.detach()[l, 0]
-            mod = list(model.children())[l]
+                t = val.detach()[layer, 0]
+            mod = list(model.children())[layer]
             if t is not None:
                 size = t.numel()
                 is_cell_level = t.numel() == mod.total_cells and mod.n > 1
@@ -571,7 +571,7 @@ def plot_tensors(model, tuples, detailed=False, return_fig=False):
                 tmin = t.min()
                 tmax = t.max()
                 tsum = t.sum()
-                title = "L%d %s" % (l + 1, label)
+                title = "L%d %s" % (layer + 1, label)
                 if detailed:
                     title += " (%s, rng: %.3f-%.3f, sum: %.3f)" % (
                         size,

--- a/projects/weight_init/weight_init_experiment.py
+++ b/projects/weight_init/weight_init_experiment.py
@@ -370,18 +370,18 @@ class TinyCIFARWeightInit(object):
         in_channels = 3
         output_size = 32 * 32
         output_units = output_size * in_channels
-        for l, block_size in enumerate(self.block_sizes):
+        for ly, block_size in enumerate(self.block_sizes):
             for b in range(block_size):
                 self._add_cnn_layer(
-                    index_str=str(l) + "_" + str(b),
+                    index_str=str(ly) + "_" + str(b),
                     in_channels=in_channels,
-                    out_channels=self.cnn_out_channels[l],
-                    kernel_size=self.cnn_kernel_sizes[l],
-                    percent_on=self.cnn_percent_on[l],
-                    weight_sparsity=self.cnn_weight_sparsity[l],
+                    out_channels=self.cnn_out_channels[ly],
+                    kernel_size=self.cnn_kernel_sizes[ly],
+                    percent_on=self.cnn_percent_on[ly],
+                    weight_sparsity=self.cnn_weight_sparsity[ly],
                     add_pooling=b == block_size - 1,
                 )
-                in_channels = self.cnn_out_channels[l]
+                in_channels = self.cnn_out_channels[ly]
             output_size = int(output_size / 4)
             output_units = output_size * in_channels
 
@@ -390,31 +390,31 @@ class TinyCIFARWeightInit(object):
 
         # Linear layer
         input_size = output_units
-        for l, linear_n in enumerate(self.linear_n):
+        for ly, linear_n in enumerate(self.linear_n):
             linear = nn.Linear(input_size, linear_n)
-            if self.linear_weight_sparsity[l] < 1.0:
+            if self.linear_weight_sparsity[ly] < 1.0:
                 self.model.add_module(
-                    "linear_" + str(l),
-                    SparseWeights(linear, self.linear_weight_sparsity[l]),
+                    "linear_" + str(ly),
+                    SparseWeights(linear, self.linear_weight_sparsity[ly]),
                 )
             else:
-                self.model.add_module("linear_" + str(l), linear)
+                self.model.add_module("linear_" + str(ly), linear)
 
-            if self.linear_percent_on[l] < 1.0:
+            if self.linear_percent_on[ly] < 1.0:
                 self.model.add_module(
-                    "kwinners_linear_" + str(l),
+                    "kwinners_linear_" + str(ly),
                     KWinners(
                         n=linear_n,
-                        percent_on=self.linear_percent_on[l],
+                        percent_on=self.linear_percent_on[ly],
                         k_inference_factor=self.k_inference_factor,
                         boost_strength=self.boost_strength,
                         boost_strength_factor=self.boost_strength_factor,
                     ),
                 )
             else:
-                self.model.add_module("Linear_ReLU_" + str(l), nn.ReLU())
+                self.model.add_module("Linear_ReLU_" + str(ly), nn.ReLU())
 
-            input_size = self.linear_n[l]
+            input_size = self.linear_n[ly]
 
         # Output layer
         self.model.add_module("output", nn.Linear(input_size, self.output_size))

--- a/projects/whydense/cifar-100/cifar_experiment.py
+++ b/projects/whydense/cifar-100/cifar_experiment.py
@@ -391,18 +391,18 @@ class TinyCIFAR(object):
         in_channels = 3
         output_size = 32 * 32
         output_units = output_size * in_channels
-        for l, block_size in enumerate(self.block_sizes):
+        for ly, block_size in enumerate(self.block_sizes):
             for b in range(block_size):
                 self._add_cnn_layer(
-                    index_str=str(l) + "_" + str(b),
+                    index_str=str(ly) + "_" + str(b),
                     in_channels=in_channels,
-                    out_channels=self.cnn_out_channels[l],
-                    kernel_size=self.cnn_kernel_sizes[l],
-                    percent_on=self.cnn_percent_on[l],
-                    weight_sparsity=self.cnn_weight_sparsity[l],
+                    out_channels=self.cnn_out_channels[ly],
+                    kernel_size=self.cnn_kernel_sizes[ly],
+                    percent_on=self.cnn_percent_on[ly],
+                    weight_sparsity=self.cnn_weight_sparsity[ly],
                     add_pooling=b == block_size - 1,
                 )
-                in_channels = self.cnn_out_channels[l]
+                in_channels = self.cnn_out_channels[ly]
             output_size = int(output_size / 4)
             output_units = output_size * in_channels
 
@@ -411,31 +411,31 @@ class TinyCIFAR(object):
 
         # Linear layer
         input_size = output_units
-        for l, linear_n in enumerate(self.linear_n):
+        for ly, linear_n in enumerate(self.linear_n):
             linear = nn.Linear(input_size, linear_n)
-            if self.linear_weight_sparsity[l] < 1.0:
+            if self.linear_weight_sparsity[ly] < 1.0:
                 self.model.add_module(
-                    "linear_" + str(l),
-                    SparseWeights(linear, self.linear_weight_sparsity[l]),
+                    "linear_" + str(ly),
+                    SparseWeights(linear, self.linear_weight_sparsity[ly]),
                 )
             else:
-                self.model.add_module("linear_" + str(l), linear)
+                self.model.add_module("linear_" + str(ly), linear)
 
-            if self.linear_percent_on[l] < 1.0:
+            if self.linear_percent_on[ly] < 1.0:
                 self.model.add_module(
-                    "kwinners_linear_" + str(l),
+                    "kwinners_linear_" + str(ly),
                     KWinners(
                         n=linear_n,
-                        percent_on=self.linear_percent_on[l],
+                        percent_on=self.linear_percent_on[ly],
                         k_inference_factor=self.k_inference_factor,
                         boost_strength=self.boost_strength,
                         boost_strength_factor=self.boost_strength_factor,
                     ),
                 )
             else:
-                self.model.add_module("Linear_ReLU_" + str(l), nn.ReLU())
+                self.model.add_module("Linear_ReLU_" + str(ly), nn.ReLU())
 
-            input_size = self.linear_n[l]
+            input_size = self.linear_n[ly]
 
         # Output layer
         self.model.add_module("output", nn.Linear(input_size, self.output_size))

--- a/projects/whydense/cifar/cifar_noise_test.py
+++ b/projects/whydense/cifar/cifar_noise_test.py
@@ -195,7 +195,7 @@ def test_model_sparsity(config, options, project_dir):
     loaders = create_test_loaders(
         noise_values, batch_size=1, data_dir=tiny_cifar.data_dir
     )
-    noise_datasets = [l.dataset for l in loaders]
+    noise_datasets = [loader.dataset for loader in loaders]
 
     # Test noise sensitivity for different layers
     model = tiny_cifar.model
@@ -253,7 +253,7 @@ def layer_noise_sensitivities(config, options, project_dir):
     loaders = create_test_loaders(
         noise_values, batch_size=1, data_dir=tiny_cifar.data_dir
     )
-    noise_datasets = [l.dataset for l in loaders]
+    noise_datasets = [loader.dataset for loader in loaders]
 
     # Test noise sensitivity for different layers
     model = tiny_cifar.model

--- a/requirements.txt
+++ b/requirements.txt
@@ -49,3 +49,4 @@ tqdm
 h5py
 pretrainedmodels==0.7.4
 wandb>=0.9.4
+colorama==0.4.3

--- a/tests/unit/frameworks/dynamic_sparse/dynamic_network_construction_test.py
+++ b/tests/unit/frameworks/dynamic_sparse/dynamic_network_construction_test.py
@@ -55,9 +55,9 @@ class NetworkConstructionTests(unittest.TestCase):
         make_dsnn(net, config)
 
         dynamic_layers = []
-        for l in net.modules():
-            if isinstance(l, (DSLinear, DSConv2d)):
-                dynamic_layers.append(l)
+        for layer in net.modules():
+            if isinstance(layer, (DSLinear, DSConv2d)):
+                dynamic_layers.append(layer)
 
         self.assertTrue(len(dynamic_layers) == 2)
         self.assertTrue(isinstance(dynamic_layers[0], DSConv2d))


### PR DESCRIPTION
Expanded to full name when possible (e.g. layer instead of l). When there was a line length restriction, I just added a another letter to avoid modifying the original code further (e.g. ly instead of l).