### PR TITLE
Sampler bugfix: Don't mutate self.indices

### DIFF
--- a/nupic/research/frameworks/pytorch/dataset_utils/samplers.py
+++ b/nupic/research/frameworks/pytorch/dataset_utils/samplers.py
@@ -56,7 +56,7 @@ class TaskDistributedSampler(DistributedSampler):
         g = torch.Generator()
         g.manual_seed(self.epoch)
 
-        indices = self.indices
+        indices = list(self.indices)
         if self.shuffle:
             indices = [indices[i] for i in torch.randperm(len(indices), generator=g)]
 


### PR DESCRIPTION
When self.shuffle is False, this accidentaly mutates self.indices. (Bug found via code inspection)