### PR TITLE
Improved dendrite activation plotting

### DIFF
--- a/nupic/research/frameworks/dendrites/utils.py
+++ b/nupic/research/frameworks/dendrites/utils.py
@@ -81,4 +81,5 @@ def plot_dendritic_activations(
         val = np.round(activations[i, j], 2)
         ax.text(j, i, val, ha="center", va="center", color="w")
 
-    return plt
+    figure = plt.gcf()
+    return figure

--- a/nupic/research/frameworks/dendrites/visualize_demo.py
+++ b/nupic/research/frameworks/dendrites/visualize_demo.py
@@ -75,7 +75,7 @@ def run_wandb_demo():
 
     # Plot heatmap of dendrite activations using wandb
     wandb.init(name="Output unit 0", project="Dendrites demo")
-    wandb.log({"Epoch 0": visual})
+    wandb.log({"Initial activations": visual})
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Modifications have been made to `plot_dendritic_activations` so that it plots a heatmap of activations where
- the more negative the value, the more red the cell, and
- the more positive the value, the more blue the cell, and

and looks similar to the bottom right plot in [this figure](https://matplotlib.org/3.1.1/_images/sphx_glr_image_annotated_heatmap_003.png).

NOTE: the major change I made is that `plot_dendritic_activations` now uses matplotlib to plot the value, and returns `matplotlib.pyplot` back (line 84) instead of the plot itself, because wandb needs the module in order to plot the image in a wandb run (done as `wandb.log({heatmap: plt})`). Yes, it's strage that we're passing the module back, so I'm curious if there are any better ways to get around this.