### PR TITLE
Anchor colorbar (in dendrite activation heatmap)

### DIFF
--- a/nupic/research/frameworks/dendrites/utils.py
+++ b/nupic/research/frameworks/dendrites/utils.py
@@ -62,9 +62,13 @@ def plot_dendritic_activations(
     ]
     y_labels = ["dendrite {}".format(j) for j in range(num_dendrites)]
 
+    # Find the range of activation values to anchor the colorbar
+    vmax = np.abs(activations).max()
+    vmin = -1.0 * vmax
+
     # Use matplotlib to plot the activation heatmap
     fig, ax = plt.subplots()
-    ax.imshow(activations, cmap="coolwarm_r")
+    ax.imshow(activations, cmap="coolwarm_r", vmin=vmin, vmax=vmax)
 
     ax.set_xticks(np.arange(num_contexts))
     ax.set_yticks(np.arange(num_dendrites))


### PR DESCRIPTION
Using matplotlib, the heatmap of dendrite activations is now anchored such that all negative values are red, and all positive values are blue (a value of zero will be colored white). This will help with visualizations.

[Here](https://drive.google.com/file/d/14F8GqMJZQXCyagM2oSa7u0T5T59eCFQd/view?usp=sharing) is a concrete example -- this follows the "negative=red" and "positive=blue" rule, and although +10 is the largest positive value, it's not dark blue since the largest negative value is -19.