### PR TITLE
Simplify VaryBatchSize mixin, remove unneeded self.batch_size

### DIFF
--- a/nupic/research/frameworks/vernon/experiments/meta_cl_experiment.py
+++ b/nupic/research/frameworks/vernon/experiments/meta_cl_experiment.py
@@ -112,10 +112,6 @@ class MetaContinualLearningExperiment(SupervisedExperiment):
 
         self.adaptation_lr = config.get("adaptation_lr", 0.03)
 
-        self.batch_size = config.get("batch_size", 5)
-        self.val_batch_size = config.get("val_batch_size", 15)
-        self.slow_batch_size = config.get("slow_batch_size", 64)
-        self.replay_batch_size = config.get("replay_batch_size", 64)
         self.num_fast_steps = config.get("num_fast_steps", 1)
 
         if self.num_fast_steps > len(self.train_fast_loader):

--- a/nupic/research/frameworks/vernon/experiments/supervised_experiment.py
+++ b/nupic/research/frameworks/vernon/experiments/supervised_experiment.py
@@ -75,7 +75,6 @@ class SupervisedExperiment(ExperimentBase):
         self.device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
         self.batches_in_epoch = sys.maxsize
         self.batches_in_epoch_val = sys.maxsize
-        self.batch_size = 1
         self.epochs = 1
         self.mixed_precision = False
         self.total_batches = 0
@@ -201,9 +200,6 @@ class SupervisedExperiment(ExperimentBase):
         self.batches_in_epoch = config.get("batches_in_epoch", sys.maxsize)
         self.batches_in_epoch_val = config.get("batches_in_epoch_val", sys.maxsize)
         self.current_epoch = 0
-
-        # Get initial batch size
-        self.batch_size = config.get("batch_size", 1)
 
         # Configure data loaders
         self.create_loaders(config)

--- a/nupic/research/frameworks/vernon/mixins/ewc.py
+++ b/nupic/research/frameworks/vernon/mixins/ewc.py
@@ -52,9 +52,10 @@ class ElasticWeightConsolidation:
         """
         super().setup_experiment(config)
         self.ewc_lambda = config.get("ewc_lambda", 40)
-        fischer_sampler_size = config.get("ewc_fisher_sample_size",
-                                          int(len(self.train_loader) * 0.1))
-        self.ewc_fisher_num_batches = fischer_sampler_size // self.batch_size
+        fisher_sampler_size = config.get("ewc_fisher_sample_size",
+                                         int(len(self.train_loader) * 0.1))
+        self.ewc_fisher_num_batches = (fisher_sampler_size
+                                       // self.train_loader.batch_size)
 
     def run_task(self):
         """Run outer loop over tasks"""
@@ -74,7 +75,9 @@ class ElasticWeightConsolidation:
         loglikelihoods = []
         for idx, (x, y) in enumerate(self.train_loader):
             loglikelihoods.append(
-                F.log_softmax(self.model(x))[range(self.batch_size), y.data]
+                F.log_softmax(self.model(x))[
+                    range(self.train_loader.batch_size), y.data
+                ]
             )
             # Can't use the full dataset, too expensive
             if idx >= self.ewc_fisher_num_batches:


### PR DESCRIPTION
I'm working on adding an interface that allows the VaryBatchSize mixin to adjust the `self.total_steps` property so that it is compatible with OneCycleLR. That change will be easier with this simplified VaryBatchSize code.

Note that it's better to do `isinstance(v, Sequence)` instead of `isinstance(v, list)`, because tuples should also be allowed.