### PR TITLE
Fix to sparsity level in routing utils

### DIFF
--- a/nupic/research/frameworks/dendrites/routing/utils.py
+++ b/nupic/research/frameworks/dendrites/routing/utils.py
@@ -67,7 +67,6 @@ def generate_random_binary_vectors(k, n_dim, sparsity_level=0.5):
         binary_vectors > sparsity_level,
         torch.ones((k, n_dim)),
         torch.zeros((k, n_dim))
-        
     )
     return binary_vectors
 

--- a/nupic/research/frameworks/dendrites/routing/utils.py
+++ b/nupic/research/frameworks/dendrites/routing/utils.py
@@ -65,8 +65,9 @@ def generate_random_binary_vectors(k, n_dim, sparsity_level=0.5):
     binary_vectors = torch.rand((k, n_dim))
     binary_vectors = torch.where(
         binary_vectors > sparsity_level,
-        torch.zeros((k, n_dim)),
-        torch.ones((k, n_dim))
+        torch.ones((k, n_dim)),
+        torch.zeros((k, n_dim))
+        
     )
     return binary_vectors
 


### PR DESCRIPTION
In the function `generate_random_binary_vectors` (in routing utils), the parameter `sparsity_level` controls how sparse the binary vectors are. Due to a minor bug, this function was actually returning binary vectors with sparsity 1 - `sparsity_level`. This is a quick single-line fix.