### PR TITLE
Remove assumption that all epochs have same number of batches

### DIFF
--- a/nupic/research/frameworks/vernon/distributed/experiments/cl_experiment.py
+++ b/nupic/research/frameworks/vernon/distributed/experiments/cl_experiment.py
@@ -50,10 +50,10 @@ class ContinualLearningExperiment(DistributedBase,
         else:
             self.model = DataParallel(self.model)
 
-    def pre_epoch(self):
-        super().pre_epoch()
+    def prepare_loaders_for_epoch(self, epoch):
+        super().prepare_loaders_for_epoch(epoch)
         if self.distributed:
-            self.train_loader.sampler.set_epoch(self.current_epoch)
+            self.train_loader.sampler.set_epoch(epoch)
 
     @classmethod
     def create_train_sampler(cls, config, dataset):
@@ -73,7 +73,8 @@ class ContinualLearningExperiment(DistributedBase,
 
         # Extended methods
         eo["setup_experiment"].append(exp + ": DistributedDataParallel")
-        eo["pre_epoch"].append(exp + ": Update distributed sampler")
+        eo["prepare_loaders_for_epoch"].append(
+            exp + ": Update distributed sampler")
         eo["create_train_sampler"].insert(0,
                                           ("If distributed { "
                                            "create distribited sampler "

--- a/nupic/research/frameworks/vernon/distributed/experiments/supervised_experiment.py
+++ b/nupic/research/frameworks/vernon/distributed/experiments/supervised_experiment.py
@@ -53,10 +53,10 @@ class SupervisedExperiment(DistributedBase,
         else:
             self.model = DataParallel(self.model)
 
-    def pre_epoch(self):
-        super().pre_epoch()
+    def prepare_loaders_for_epoch(self, epoch):
+        super().prepare_loaders_for_epoch(epoch)
         if self.distributed:
-            self.train_loader.sampler.set_epoch(self.current_epoch)
+            self.train_loader.sampler.set_epoch(epoch)
 
     @classmethod
     def create_train_sampler(cls, config, dataset):
@@ -98,7 +98,8 @@ class SupervisedExperiment(DistributedBase,
 
         # Extended methods
         eo["setup_experiment"].append(exp + ": DistributedDataParallel")
-        eo["pre_epoch"].append(exp + ": Update distributed sampler")
+        eo["prepare_loaders_for_epoch"].append(
+            exp + ": Update distributed sampler")
 
         eo.update(
             # Overwritten methods

--- a/nupic/research/frameworks/vernon/distributed/experiments/supervised_experiment.py
+++ b/nupic/research/frameworks/vernon/distributed/experiments/supervised_experiment.py
@@ -53,15 +53,11 @@ class SupervisedExperiment(DistributedBase,
         else:
             self.model = DataParallel(self.model)
 
-    def prepare_loaders_for_epoch(self, epoch):
-        super().prepare_loaders_for_epoch(epoch)
-        if self.distributed:
-            self.train_loader.sampler.set_epoch(epoch)
-
     @classmethod
-    def create_train_sampler(cls, config, dataset):
+    def create_train_sampler(cls, config, dataset, epoch):
         if config.get("distributed", False):
             sampler = DistributedSampler(dataset)
+            sampler.set_epoch(epoch)
         else:
             sampler = None
         return sampler
@@ -98,8 +94,6 @@ class SupervisedExperiment(DistributedBase,
 
         # Extended methods
         eo["setup_experiment"].append(exp + ": DistributedDataParallel")
-        eo["prepare_loaders_for_epoch"].append(
-            exp + ": Update distributed sampler")
 
         eo.update(
             # Overwritten methods

--- a/nupic/research/frameworks/vernon/experiment_utils.py
+++ b/nupic/research/frameworks/vernon/experiment_utils.py
@@ -17,53 +17,8 @@
 #
 #  http://numenta.org/licenses/
 #
-import copy
 import socket
 from contextlib import closing
-
-from torch.optim.lr_scheduler import OneCycleLR
-
-from nupic.research.frameworks.pytorch.lr_scheduler import ComposedLRScheduler
-
-
-def create_lr_scheduler(optimizer, lr_scheduler_class, lr_scheduler_args,
-                        steps_per_epoch):
-    """
-    Configure learning rate scheduler
-
-    :param optimizer:
-        Wrapped optimizer
-    :param lr_scheduler_class:
-        LR scheduler class to use. Must inherit from _LRScheduler
-    :param lr_scheduler_args:
-        LR scheduler class constructor arguments
-    :param steps_per_epoch:
-        The total number of batches in the epoch.
-        Only used if lr_scheduler_class is :class:`ComposedLRScheduler` or
-        :class:`OneCycleLR`
-    """
-    if issubclass(lr_scheduler_class, OneCycleLR):
-        # Update OneCycleLR parameters
-        lr_scheduler_args = copy.deepcopy(lr_scheduler_args)
-        lr_scheduler_args.update(steps_per_epoch=steps_per_epoch)
-    elif issubclass(lr_scheduler_class, ComposedLRScheduler):
-        # Update ComposedLRScheduler parameters
-        lr_scheduler_args = copy.deepcopy(lr_scheduler_args)
-        schedulers = lr_scheduler_args.get("schedulers", None)
-        if schedulers is not None:
-            # Convert dict from ray/json {str:dict} style to {int:dict}
-            schedulers = {int(k): v for k, v in schedulers.items()}
-
-            # Update OneCycleLR "steps_per_epoch" parameter
-            for _, item in schedulers.items():
-                lr_class = item.get("lr_scheduler_class", None)
-                if lr_class is not None and issubclass(lr_class, OneCycleLR):
-                    lr_args = item.get("lr_scheduler_args", {})
-                    lr_args.update(steps_per_epoch=steps_per_epoch)
-            lr_scheduler_args["schedulers"] = schedulers
-        lr_scheduler_args["steps_per_epoch"] = steps_per_epoch
-
-    return lr_scheduler_class(optimizer, **lr_scheduler_args)
 
 
 def get_free_port():

--- a/nupic/research/frameworks/vernon/experiments/cl_experiment.py
+++ b/nupic/research/frameworks/vernon/experiments/cl_experiment.py
@@ -90,7 +90,6 @@ class ContinualLearningExperiment(
         """Run outer loop over tasks"""
         # configure the sampler to load only samples from current task
         self.logger.info("Training...")
-        self.train_loader.sampler.set_active_tasks(self.current_task)
 
         # Run epochs, inner loop
         # TODO: return the results from run_epoch
@@ -111,6 +110,11 @@ class ContinualLearningExperiment(
 
         self.current_task += 1
         return ret
+
+    def prepare_loaders_for_epoch(self, epoch):
+        super().prepare_loaders_for_epoch(epoch)
+        task = epoch // self.epochs
+        self.train_loader.sampler.set_active_tasks(task)
 
     @classmethod
     def create_train_sampler(cls, config, dataset):
@@ -148,6 +152,7 @@ class ContinualLearningExperiment(
 
         # Extended methods
         eo["setup_experiment"].append(exp + ".setup_experiment")
+        eo["prepare_loaders_for_epoch"].append(exp + ": Set current task")
 
         eo.update(
             # Overwritten methods

--- a/nupic/research/frameworks/vernon/experiments/components/evaluation_metrics.py
+++ b/nupic/research/frameworks/vernon/experiments/components/evaluation_metrics.py
@@ -31,29 +31,25 @@ class ContinualLearningMetrics(object):
         """
         Evaluates accuracy at current task only. Used for debugging.
         """
-        self.val_loader.sampler.set_active_tasks(self.current_task)
-        return self.validate()
+        return self.validate(self.current_task)
 
     def eval_first_task(self):
         """
         Evaluates accuracy at first task only. Used for debugging.
         """
-        self.val_loader.sampler.set_active_tasks(0)
-        return self.validate()
+        return self.validate(tasks=0)
 
     def eval_all_visited_tasks(self):
         """
         Evaluates all tasks seen so far jointly. Equivalent to average accuracy
         """
-        self.val_loader.sampler.set_active_tasks(range(0, self.current_task + 1))
-        return self.validate()
+        return self.validate(tasks=range(self.current_task + 1))
 
     def eval_all_tasks(self):
         """
         Evaluates all tasks, including visited and not visited tasks.
         """
-        self.val_loader.sampler.set_active_tasks(range(0, self.num_tasks))
-        return self.validate()
+        return self.validate(tasks=range(self.num_tasks))
 
     def eval_individual_tasks(self):
         """
@@ -61,8 +57,7 @@ class ContinualLearningMetrics(object):
         Evaluates all tasks seen so far, and report accuracy individually.
         """
         task_results = {}
-        for task_id in range(0, self.current_task + 1):
-            self.val_loader.sampler.set_active_tasks(task_id)
-            for k, v in self.validate().items():
+        for task_id in range(self.current_task + 1):
+            for k, v in self.validate(tasks=task_id).items():
                 task_results[f"task{task_id}__{k}"] = v
         return task_results

--- a/nupic/research/frameworks/vernon/mixins/extra_validations_per_epoch.py
+++ b/nupic/research/frameworks/vernon/mixins/extra_validations_per_epoch.py
@@ -48,7 +48,7 @@ class ExtraValidationsPerEpoch(StepBasedLogging):
 
         extra_validations = config.get("extra_validations_per_epoch", 0)
         batches_to_validate = np.linspace(
-            min(self.total_batches, self.batches_in_epoch),
+            min(len(self.train_loader), self.batches_in_epoch),
             0,
             1 + extra_validations,
             endpoint=False

--- a/nupic/research/frameworks/vernon/mixins/quantization_aware.py
+++ b/nupic/research/frameworks/vernon/mixins/quantization_aware.py
@@ -106,7 +106,8 @@ class QuantizationAware(object):
         # freeze observer parameters for the last 500 batches of last epoch
         if (not self.observer_disabled
            and self.current_epoch == self.epochs
-           and self.batch_idx > (self.when_disable_observers * self.total_batches)):
+           and self.batch_idx > (self.when_disable_observers
+                                 * len(self.train_loader))):
             self.logger.info(f"Freezing observer at epoch {self.current_epoch} "
                              "and batch {self.batch_idx}")
             self.model.apply(disable_observer)
@@ -115,7 +116,8 @@ class QuantizationAware(object):
         # freeze BN parameters for the last 200 batches of last epoch
         if (not self.batch_norm_frozen
            and self.current_epoch == self.epochs
-           and self.batch_idx > (self.when_freeze_batch_norm * self.total_batches)):
+           and self.batch_idx > (self.when_freeze_batch_norm
+                                 * len(self.train_loader))):
             self.logger.info(f"Freezing BN parameters at epoch {self.current_epoch}"
                              "and batch {self.batch_idx}")
             self.model.apply(nni.qat.freeze_bn_stats)

--- a/nupic/research/frameworks/vernon/mixins/regularize_loss.py
+++ b/nupic/research/frameworks/vernon/mixins/regularize_loss.py
@@ -68,7 +68,7 @@ class RegularizeLoss(object):
         reg_scalar = self.reg_scalar
         if callable(reg_scalar):
             reg_scalar = reg_scalar(self.current_epoch, batch_idx,
-                                    self.total_batches)
+                                    len(self.train_loader))
 
         self.reg_scalar_value = reg_scalar
 

--- a/nupic/research/frameworks/vernon/mixins/step_based_logging.py
+++ b/nupic/research/frameworks/vernon/mixins/step_based_logging.py
@@ -73,7 +73,7 @@ class StepBasedLogging(
         self.current_timestep += 1
 
     def should_log_batch(self, train_batch_idx):
-        return (train_batch_idx == self.total_batches - 1) or (
+        return (train_batch_idx == len(self.train_loader) - 1) or (
             self.log_timestep_freq > 0
             and (self.current_timestep % self.log_timestep_freq) == 0)
 

--- a/projects/imagenet/experiments/snr_pruning.py
+++ b/projects/imagenet/experiments/snr_pruning.py
@@ -65,8 +65,8 @@ def conv_target_density(in_channels, out_channels, kernel_size):
 
 def make_reg_schedule(epochs, pct_ramp_start, pct_ramp_end, peak_value,
                       pct_drop, final_value):
-    def reg_schedule(epoch, batch_idx, steps_per_epoch):
-        pct = (epoch + batch_idx / steps_per_epoch) / epochs
+    def reg_schedule(epoch, epoch_pct):
+        pct = (epoch + epoch_pct) / epochs
 
         if pct < pct_ramp_start:
             return 0.0

--- a/tests/unit/frameworks/pytorch/imagenet_experiment_test.py
+++ b/tests/unit/frameworks/pytorch/imagenet_experiment_test.py
@@ -113,7 +113,7 @@ class ImagenetExperimentTest(unittest.TestCase):
             exp.setup_experiment(self.config)
 
             i = 0
-            for image, _ in exp.train_loader:
+            for image, _ in exp.create_train_dataloader(self.config):
                 batch_size = image.shape[0]
                 self.assertEqual(batch_size, 4)
                 i += 1


### PR DESCRIPTION
Mixins and experiments that vary the batch size (e.g. VaryBatchSize mixin) or the samplers (e.g. ContinualLearningExperiment) will now be compatible with code that relies on step counts:(e.g. OneCycleLR).