### PR TITLE
Adjusting our ANML Model for Accuracy

### DIFF
--- a/projects/meta_cl/experiments/anml_replicate.py
+++ b/projects/meta_cl/experiments/anml_replicate.py
@@ -111,7 +111,7 @@ meta_test_test_kwargs = dict(
     num_meta_testing_runs=10,
 
     # Run through meta-test testing 5 images at a time. No training occurs here.
-    test_test_batch_size=5,
+    test_test_batch_size=1,
 )
 
 

--- a/projects/meta_cl/networks/anml_networks.py
+++ b/projects/meta_cl/networks/anml_networks.py
@@ -77,7 +77,7 @@ class ANMLNetwork(nn.Module):
                 in_channels=in_channels, out_channels=out_channels,
                 kernel_size=kernel_size, stride=stride, padding=padding
             ),
-            nn.GroupNorm(num_groups=out_channels, num_channels=out_channels),
+            nn.InstanceNorm2d(num_features=out_channels, affine=True),
             nn.ReLU(),
         ]
 

--- a/projects/meta_cl/networks/anml_networks.py
+++ b/projects/meta_cl/networks/anml_networks.py
@@ -77,7 +77,7 @@ class ANMLNetwork(nn.Module):
                 in_channels=in_channels, out_channels=out_channels,
                 kernel_size=kernel_size, stride=stride, padding=padding
             ),
-            nn.BatchNorm2d(num_features=out_channels),
+            nn.GroupNorm(num_groups=out_channels, num_channels=out_channels),
             nn.ReLU(),
         ]
 


### PR DESCRIPTION
This PR makes two minor but important changes:
1. We now use a batch_size=1 during meta-testing
2. We now use GroupNorm instead of BatchNorm2d in our ANML network

The motivation of 2 is the observation of the following line:
https://github.com/uvm-neurobotics-lab/ANML/blob/cabaaf7f2336496cd51065847c524a705408d562/model/learner.py#L188

Here, we see that ANML always run it's forward pass on each image one at a time. Thus, to replicate their network, we cannot compute statistics over a whole mini-batch. In this PR, GroupNorm ensures we do just that, while still normalizing each channel and transforming by gamma and beta parameters.