### PR TITLE
Simplify `train_model` and `evaluate_model`

### DIFF
--- a/nupic/research/frameworks/pytorch/model_utils.py
+++ b/nupic/research/frameworks/pytorch/model_utils.py
@@ -142,6 +142,7 @@ def train_model(
                                                               t4 - t3, t5 - t4)
             post_batch_callback(model=model,
                                 error_loss=error_loss.detach(),
+                                complexity_loss=None,
                                 batch_idx=batch_idx,
                                 num_images=num_images,
                                 time_string=time_string)

--- a/nupic/research/frameworks/pytorch/model_utils.py
+++ b/nupic/research/frameworks/pytorch/model_utils.py
@@ -141,7 +141,7 @@ def train_model(
                            + "weight update: {:.3f}s").format(t1 - t0, t2 - t1, t3 - t2,
                                                               t4 - t3, t5 - t4)
             post_batch_callback(model=model,
-                                error_loss=error_loss.detach()
+                                error_loss=error_loss.detach(),
                                 batch_idx=batch_idx,
                                 num_images=num_images,
                                 time_string=time_string)

--- a/nupic/research/frameworks/pytorch/model_utils.py
+++ b/nupic/research/frameworks/pytorch/model_utils.py
@@ -90,7 +90,6 @@ def train_model(
     :return: mean loss for epoch
     :rtype: float
     """
-
     model.train()
     # Use asynchronous GPU copies when the memory is pinned
     # See https://pytorch.org/docs/master/notes/cuda.html

--- a/nupic/research/frameworks/vernon/experiments/supervised_experiment.py
+++ b/nupic/research/frameworks/vernon/experiments/supervised_experiment.py
@@ -369,7 +369,9 @@ class SupervisedExperiment(ExperimentBase):
             loader=loader,
             device=self.device,
             criterion=self.error_loss,
+            complexity_loss_fn=self.complexity_loss,
             batches_in_epoch=self.batches_in_epoch_val,
+            transform_to_device_fn=self.transform_data_to_device,
         )
 
     def train_epoch(self):
@@ -379,9 +381,11 @@ class SupervisedExperiment(ExperimentBase):
             optimizer=self.optimizer,
             device=self.device,
             criterion=self.error_loss,
+            complexity_loss_fn=self.complexity_loss,
             batches_in_epoch=self.batches_in_epoch,
             pre_batch_callback=self.pre_batch,
             post_batch_callback=self.post_batch_wrapper,
+            transform_to_device_fn=self.transform_data_to_device,
         )
 
     def run_epoch(self):

--- a/nupic/research/frameworks/vernon/experiments/supervised_experiment.py
+++ b/nupic/research/frameworks/vernon/experiments/supervised_experiment.py
@@ -369,9 +369,7 @@ class SupervisedExperiment(ExperimentBase):
             loader=loader,
             device=self.device,
             criterion=self.error_loss,
-            complexity_loss_fn=self.complexity_loss,
             batches_in_epoch=self.batches_in_epoch_val,
-            transform_to_device_fn=self.transform_data_to_device,
         )
 
     def train_epoch(self):
@@ -381,11 +379,9 @@ class SupervisedExperiment(ExperimentBase):
             optimizer=self.optimizer,
             device=self.device,
             criterion=self.error_loss,
-            complexity_loss_fn=self.complexity_loss,
             batches_in_epoch=self.batches_in_epoch,
             pre_batch_callback=self.pre_batch,
             post_batch_callback=self.post_batch_wrapper,
-            transform_to_device_fn=self.transform_data_to_device,
         )
 
     def run_epoch(self):


### PR DESCRIPTION
The parameter `freeze_params` has been removed as it was unused, and `active_classes` has been added. Overall, this simplifies both the train and evaluate functions since the removed parameter consumed much more lines of code than the newly-introduced parameter.

Note:
The implementation for `active classes` borrows from [here](https://github.com/numenta/nupic.research/blob/master/nupic/research/frameworks/continual_learning/multihead/multihead.py).