### PR TITLE
Fix regression tests

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -37,7 +37,7 @@ pandas
 python-dateutil==2.8.0
 # fastai 2.1 requires pytorch 1.7, nupic.torch requires pytorch 1.6
 fastai<2.1
-pillow
+pillow~=6.0
 python-dotenv
 ray[tune]==0.8.3
 requests


### PR DESCRIPTION
Regression test checkpoints were created with pillow ver 6.0.0 and are not compatible with pillow 7 and above. This PR fixes pillow version to a version compatible with the regression tests