### PR TITLE
added paragraph to README

### DIFF
--- a/projects/whydense/README.md
+++ b/projects/whydense/README.md
@@ -6,6 +6,6 @@ Link to paper: https://arxiv.org/abs/1903.11257.
 
 This repository contains code which was originally used in the paper "How Can We Be So Dense? The Benefits of Using Highly Sparse Representations" (https://arxiv.org/abs/1903.11257).
 
-The code relies on nupic.torch (link to: https://github.com/numenta/nupic.torch - Connect to preview ). nupic.torch contains easy to use pytorch implementations of the two types of sparsity used in the paper: the k-winner-take-all sparse activation function and sparse weights.
+The code relies on [nupic.torch](https://github.com/numenta/nupic.torch). nupic.torch contains easy to use pytorch implementations of the two types of sparsity used in the paper: the k-winner-take-all sparse activation function and sparse weights.
 
 **Note:** This is code has been modified since the release of the paper, and thus may not reproduce its results. For a reproducible version of the code, and for a full description of the code setup, structure, and hyperparameters, please see here: https://github.com/numenta/htmpapers/tree/master/arxiv/how_can_we_be_so_dense.

--- a/projects/whydense/README.md
+++ b/projects/whydense/README.md
@@ -6,4 +6,6 @@ Link to paper: https://arxiv.org/abs/1903.11257.
 
 This repository contains code which was originally used in the paper "How Can We Be So Dense? The Benefits of Using Highly Sparse Representations" (https://arxiv.org/abs/1903.11257).
 
+The code relies on nupic.torch (link to: https://github.com/numenta/nupic.torch - Connect to preview ). nupic.torch contains easy to use pytorch implementations of the two types of sparsity used in the paper: the k-winner-take-all sparse activation function and sparse weights.
+
 **Note:** This is code has been modified since the release of the paper, and thus may not reproduce its results. For a reproducible version of the code, and for a full description of the code setup, structure, and hyperparameters, please see here: https://github.com/numenta/htmpapers/tree/master/arxiv/how_can_we_be_so_dense.


### PR DESCRIPTION
RES-1924

Modify the README.md file in the directory:

https://github.com/numenta/nupic.research/tree/master/projects/whydense

Add this paragraph before the final paragraph:

“The code relies on nupic.torch (link to:  ). nupic.torch contains easy to use pytorch implementations of the two types of sparsity used in the paper: the k-winner-take-all sparse activation function and sparse weights.”