### PR TITLE
Sigopt search with the MetaCL Experiment

### DIFF
--- a/projects/meta_cl/experiments/__init__.py
+++ b/projects/meta_cl/experiments/__init__.py
@@ -20,6 +20,7 @@
 # ----------------------------------------------------------------------
 
 from .metacl import CONFIGS as METACL
+from .metacl_sigopt import CONFIGS as METACL_SIGOPT
 from .anml_replicate import CONFIGS as ANML_REPLICATE
 from .anml_variants import CONFIGS as ANML_VARIANTS
 from .dendrites import CONFIGS as DENDRITES
@@ -35,6 +36,7 @@ __all__ = ["CONFIGS"]
 # Collect all configurations
 CONFIGS = dict()
 CONFIGS.update(METACL)
+CONFIGS.update(METACL_SIGOPT)
 CONFIGS.update(ANML_REPLICATE)
 CONFIGS.update(ANML_VARIANTS)
 CONFIGS.update(DENDRITES)

--- a/projects/meta_cl/experiments/metacl_sigopt.py
+++ b/projects/meta_cl/experiments/metacl_sigopt.py
@@ -1,0 +1,76 @@
+# ----------------------------------------------------------------------
+# Numenta Platform for Intelligent Computing (NuPIC)
+# Copyright (C) 2020, Numenta, Inc.  Unless you have an agreement
+# with Numenta, Inc., for a separate license for this software code, the
+# following terms and conditions apply:
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# See the GNU Affero Public License for more details.
+#
+# You should have received a copy of the GNU Affero Public License
+# along with this program.  If not, see http://www.gnu.org/licenses.
+#
+# http://numenta.org/licenses/
+# ----------------------------------------------------------------------
+
+from copy import deepcopy
+
+from sigopt_utils import MetaCLSigOptExperiment, MetaCLSigOptRemoteProcessTrainable
+
+from .oml_variants import oml_trained_like_anml
+
+oml_trained_like_anml_lr_search = deepcopy(oml_trained_like_anml)
+oml_trained_like_anml_lr_search.update(
+    ray_trainable=MetaCLSigOptRemoteProcessTrainable,
+    sigopt_experiment=MetaCLSigOptExperiment,
+    epochs=20000,
+    num_meta_test_classes=[100],
+    stop=dict(early_stop=1.0),
+    sigopt_config=dict(
+        name="oml_trained_like_anml_lr_search",
+        parameters=[
+            dict(name="log10_inner_lr", type="double", bounds=dict(min=-5, max=-1)),
+            dict(name="log10_outer_lr", type="double", bounds=dict(min=-5, max=-1)),
+        ],
+        metrics=[dict(name="mean_test_test_acc", objective="maximize")],
+        parallel_bandwidth=1,
+        observation_budget=61,
+        project="mcaporale-metacl",
+    ),
+    sigopt_experiment_id=368294,
+)
+
+# |--------------------------------------------------------------|
+# |   Num Classes | Meta-test test   | Meta-test train   |    LR |
+# |--------------:|:-----------------|:------------------|------:|
+# |            10 | 0.91 ± 0.05      | 0.97 ± 0.02       | 0.001 |
+# |            50 | 0.88 ± 0.01      | 0.98 ± 0.01       | 0.001 |
+# |           100 | 0.83 ± 0.02      | 0.98 ± 0.01       | 0.001 |
+# |           200 | 0.77 ± 0.01      | 0.96 ± 0.01       | 0.001 |
+# |           600 | 0.63 ± 0.01      | 0.93 ± 0.00       | 0.001 |
+# |--------------------------------------------------------------|
+#
+oml_trained_like_anml_best_lr = deepcopy(oml_trained_like_anml)
+oml_trained_like_anml_best_lr.update(
+    # Using best lr's found in sigopt search.
+    adaptation_lr=0.07041400155996859,  # OML originally used 0.03
+    optimizer_args=dict(lr=0.0002724584690422078),  # OML originally used 0.0001
+
+    # Log results to wandb.
+    wandb_args=dict(
+        name="oml_trained_like_anml_best_lr",
+        project="metacl",
+    ),
+)
+
+
+CONFIGS = dict(
+    oml_trained_like_anml_lr_search=oml_trained_like_anml_lr_search,
+    oml_trained_like_anml_best_lr=oml_trained_like_anml_best_lr,
+)

--- a/projects/meta_cl/sigopt_utils.py
+++ b/projects/meta_cl/sigopt_utils.py
@@ -1,0 +1,148 @@
+# ----------------------------------------------------------------------
+# Numenta Platform for Intelligent Computing (NuPIC)
+# Copyright (C) 2020, Numenta, Inc.  Unless you have an agreement
+# with Numenta, Inc., for a separate license for this software code, the
+# following terms and conditions apply:
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# See the GNU Affero Public License for more details.
+#
+# You should have received a copy of the GNU Affero Public License
+# along with this program.  If not, see http://www.gnu.org/licenses.
+#
+# http://numenta.org/licenses/
+# ----------------------------------------------------------------------
+
+from pprint import pformat, pprint
+
+from nupic.research.frameworks.sigopt import SigOptExperiment
+from nupic.research.frameworks.vernon.trainables import RemoteProcessTrainable
+
+
+class MetaCLSigOptRemoteProcessTrainable(RemoteProcessTrainable):
+    """
+    This class updates the config using SigOpt before the models and workers are
+    instantiated, and updates the result using SigOpt once training completes.
+    """
+
+    def _process_config(self, config):
+        """
+        :param config:
+            Dictionary configuration of the trainable
+
+            - sigopt_experiment_id: id of experiment
+            - sigopt_config: dict to specify configuration of sigopt experiment
+            - sigopt_experiment_class: class inherited from `SigoptExperiment` which
+                                       characterizes how the trainable will get and
+                                       utilize suggestions
+
+        """
+        # Update the config through SigOpt.
+        self.sigopt = None
+        if "sigopt_config" in config:
+            assert config.get("sigopt_experiment_id", None) is not None
+
+            # Check for user specified sigopt-experiment class.
+            experiment_class = config.get(
+                "sigopt_experiment_class", MetaCLSigOptExperiment)
+            assert issubclass(experiment_class, SigOptExperiment)
+
+            # Instantiate experiment.
+            self.sigopt = experiment_class(
+                experiment_id=config["sigopt_experiment_id"],
+                sigopt_config=config["sigopt_config"])
+
+            self.logger.info(
+                f"Sigopt execution order: {pformat(self.sigopt.get_execution_order())}")
+
+            # Get suggestion and update config.
+            self.suggestion = self.sigopt.get_next_suggestion()
+            self.sigopt.update_config_with_suggestion(config, self.suggestion)
+            print("SigOpt suggestion: ", self.suggestion)
+            print("Config after Sigopt:")
+            pprint(config)
+            self.epochs = config["epochs"]
+
+            # Get names of performance metrics.
+            assert "metrics" in config["sigopt_config"]
+            self.metric_names = [
+                metric["name"] for metric in config["sigopt_config"]["metrics"]
+            ]
+
+    def _process_result(self, result):
+        """
+        This overwrites the _process_result of the parent mixin.
+
+        Update sigopt with the new result once we're at the end of training.
+        """
+
+        super()._process_result(result)
+
+        if self.sigopt is not None:
+            # Default value for ealy stop: 0.0 (i.e. don't stop)
+            result["early_stop"] = result.get("early_stop", 0.0)
+
+            # Identify if the experiment should be stopped early.
+            # If so, update with result.
+            if self.iteration >= self.epochs - 1:
+                result["early_stop"] = 1.0
+
+                # Calculate mean meta-testing accuracy.
+                mean_test_test_acc = 0
+                total = 0
+                for name, val in result.items():
+                    if "mean_test_test" in name:
+                        mean_test_test_acc += val
+                        total += 1
+                assert total > 0, "No meta-testing accuracies reported."
+                mean_test_test_acc = mean_test_test_acc / total
+
+                # Collect and report relevant metrics.
+                values = [
+                    dict(name="mean_test_test_acc", value=mean_test_test_acc)
+                ]
+
+                self.sigopt.update_observation(self.suggestion, values=values)
+                print("Full results: ")
+                pprint(result)
+
+
+class MetaCLSigOptExperiment(SigOptExperiment):
+    def update_config_with_suggestion(self, config, suggestion):
+        """
+        Given a SigOpt suggestion, update the learning rate for the inner and outer
+        loops.
+
+        :param config:
+            - optimizer_args: dict of optimizer arguments
+        :param suggestion:
+            - assignments (all optional)
+                - log10_inner_lr: learning rate for inner loop
+                - log10_outer_lr: learning rate for outer loop
+        """
+        super().update_config_with_suggestion(config, suggestion)
+
+        assignments = suggestion.assignments
+
+        assert "optimizer_args" in config
+        optimizer_args = config["optimizer_args"]
+
+        if "log10_outer_lr" in assignments:
+            optimizer_args["lr"] = 10 ** assignments["log10_outer_lr"]
+
+        if "log10_inner_lr" in assignments:
+            config["adaptation_lr"] = 10 ** assignments["log10_inner_lr"]
+
+    @classmethod
+    def get_execution_order(cls):
+        return dict(
+            update_config_with_suggestion=[
+                "MetaCLSigOptExperiment.update_config_with_suggestion"
+            ],
+        )


### PR DESCRIPTION
This includes utilities to run sigopt lr searches with the MetaCL classes. For now, these are in the `projects/meta_cl` directory so they may be ironed out, but later they can be incorporated into Vernon.

General remarks on how to use this can be found in the description of [this JIRA](https://ntaresearch.atlassian.net/browse/RES-1887) and a brief review of the results can be found in the comments below.