### PR TITLE
Auto-include StepBasedLogging with RegularizeLoss

### DIFF
--- a/nupic/research/frameworks/vernon/mixins/regularize_loss.py
+++ b/nupic/research/frameworks/vernon/mixins/regularize_loss.py
@@ -21,8 +21,10 @@
 
 import torch
 
+from nupic.research.frameworks.vernon.mixins.step_based_logging import StepBasedLogging
 
-class RegularizeLoss(object):
+
+class RegularizeLoss(StepBasedLogging):
     """
     Implement the complexity_loss as the sum all module.regularization()
     functions, times some specified scalar.


### PR DESCRIPTION
Currently if you use RegularizeLoss without another mixin that includes StepBasedLogging, you get:

```
KeyError: ‘expand_result_to_time_series’
```

This change fixes that.

(Thanks @alexcuozzo-1 for catching this)