### PR TITLE
RES-2013: Fix issue restoring quantized checkpoints

### DIFF
--- a/nupic/research/frameworks/vernon/network_utils.py
+++ b/nupic/research/frameworks/vernon/network_utils.py
@@ -61,12 +61,17 @@ def get_compatible_state_dict(state_dict, model):
     """
     Make sure checkpoint is compatible with model
     """
+    # Copy metadata attribute inserted into the OrderedDict by pytorch serializer
+    metadata = getattr(state_dict, "_metadata", None)
     state_dict = upgrade_to_masked_sparseweights(state_dict)
 
     if model.state_dict().keys() != state_dict.keys():
         state_dict = OrderedDict(
             zip(model.state_dict().keys(), state_dict.values()))
 
+    # Restore pytorch serializer metadata
+    if metadata is not None:
+        state_dict._metadata = metadata
     return state_dict
 
 


### PR DESCRIPTION
Fix issue restoring quantized checkpoints where ConvBn2d relies on the custom pytorch "_metadata" field during deserialization