### PR TITLE
Representation overlap mixin

### DIFF
--- a/nupic/research/frameworks/dendrites/metrics/__init__.py
+++ b/nupic/research/frameworks/dendrites/metrics/__init__.py
@@ -28,9 +28,9 @@ from .metrics import (
     hidden_activations_by_unit,
     mean_selected_activations,
     percent_active_dendrites,
-    representation_overlap_distributions,
     representation_overlap_matrix,
     representation_overlap_stats,
+    representation_overlap_values,
     winning_segment_indices,
 )
 from .plotting import (

--- a/nupic/research/frameworks/dendrites/metrics/__init__.py
+++ b/nupic/research/frameworks/dendrites/metrics/__init__.py
@@ -28,6 +28,9 @@ from .metrics import (
     hidden_activations_by_unit,
     mean_selected_activations,
     percent_active_dendrites,
+    repr_overlap_distributions,
+    repr_overlap_matrix,
+    repr_overlap_stats,
     winning_segment_indices,
 )
 from .plotting import (
@@ -39,5 +42,7 @@ from .plotting import (
     plot_mean_selected_activations,
     plot_overlap_scores_distribution,
     plot_percent_active_dendrites,
+    plot_repr_overlap_distributions,
+    plot_repr_overlap_matrix,
     plot_winning_segment_distributions,
 )

--- a/nupic/research/frameworks/dendrites/metrics/__init__.py
+++ b/nupic/research/frameworks/dendrites/metrics/__init__.py
@@ -28,9 +28,9 @@ from .metrics import (
     hidden_activations_by_unit,
     mean_selected_activations,
     percent_active_dendrites,
-    repr_overlap_distributions,
-    repr_overlap_matrix,
-    repr_overlap_stats,
+    representation_overlap_distributions,
+    representation_overlap_matrix,
+    representation_overlap_stats,
     winning_segment_indices,
 )
 from .plotting import (
@@ -42,7 +42,7 @@ from .plotting import (
     plot_mean_selected_activations,
     plot_overlap_scores_distribution,
     plot_percent_active_dendrites,
-    plot_repr_overlap_distributions,
-    plot_repr_overlap_matrix,
+    plot_representation_overlap_distributions,
+    plot_representation_overlap_matrix,
     plot_winning_segment_distributions,
 )

--- a/nupic/research/frameworks/dendrites/metrics/metrics.py
+++ b/nupic/research/frameworks/dendrites/metrics/metrics.py
@@ -354,7 +354,7 @@ def representation_overlap_matrix(activations, targets):
         return overlap_matrix
 
 
-def representation_overlap_distributions(activations, targets):
+def representation_overlap_values(activations, targets):
     """
     Returns (list of floats, list of floats) where the first list gives representation
     overlap values between all pairs of samples in different classes, and the second

--- a/nupic/research/frameworks/dendrites/metrics/metrics.py
+++ b/nupic/research/frameworks/dendrites/metrics/metrics.py
@@ -316,7 +316,7 @@ def entropy(x):
     return _entropy, _max_entropy
 
 
-def repr_overlap_matrix(activations, targets):
+def representation_overlap_matrix(activations, targets):
     """
     Returns a 2D torch tensor with shape (num_categories, num_categories) where cell
     c1, c2 gives the mean value of pairwise representation overlap across all pairs of
@@ -333,7 +333,7 @@ def repr_overlap_matrix(activations, targets):
     """
     with torch.no_grad():
 
-        repr_overlaps = repr_overlap_stats(activations, targets)
+        overlap_values = representation_overlap_stats(activations, targets)
 
         # Assume the following:
         # - target values are zero-based
@@ -348,13 +348,13 @@ def repr_overlap_matrix(activations, targets):
         for t1 in range(num_categories):
             for t2 in range(1 + t1):
 
-                mean_overlap_val = np.mean(repr_overlaps[t1][t2])
+                mean_overlap_val = np.mean(overlap_values[t1][t2])
                 overlap_matrix[t1, t2] = mean_overlap_val
 
         return overlap_matrix
 
 
-def repr_overlap_distributions(activations, targets):
+def representation_overlap_distributions(activations, targets):
     """
     Returns (list of floats, list of floats) where the first list gives representation
     overlap values between all pairs of samples in different classes, and the second
@@ -369,7 +369,7 @@ def repr_overlap_distributions(activations, targets):
     :param targets: 1D torch tensor with shape (batch_size,) where entry b gives the
                     target label for example b
     """
-    repr_overlaps = repr_overlap_stats(activations, targets)
+    overlap_values = representation_overlap_stats(activations, targets)
 
     # Assume the following:
     # - target values are zero-based
@@ -383,17 +383,17 @@ def repr_overlap_distributions(activations, targets):
         for t2 in range(1 + t1):
 
             if t1 == t2:
-                intra_class_overlaps.extend(repr_overlaps[t1][t2])
+                intra_class_overlaps.extend(overlap_values[t1][t2])
             else:
-                inter_class_overlaps.extend(repr_overlaps[t1][t2])
+                inter_class_overlaps.extend(overlap_values[t1][t2])
 
     return inter_class_overlaps, intra_class_overlaps
 
 
-def repr_overlap_stats(activations, targets):
+def representation_overlap_stats(activations, targets):
     """
-    Returns `repr_overlaps`: a dict of dicts, where
-    repr_overlaps[class_id_1][class_id_2] is list of representation overlap values
+    Returns `overlap_values`: a dict of dicts, where
+    overlap_values[class_id_1][class_id_2] is list of representation overlap values
     between all pairs in class_id_1 and class_id_2; self-paired examples are excluded
     in the case where the two classes are the same.
     """
@@ -402,11 +402,11 @@ def repr_overlap_stats(activations, targets):
         num_categories = 1 + targets.max().item()
         _, num_units = activations.size()
 
-        repr_overlaps = {}
+        overlap_values = {}
 
         for t1 in range(num_categories):
 
-            repr_overlaps[t1] = {}
+            overlap_values[t1] = {}
 
             for t2 in range(1 + t1):
 
@@ -434,6 +434,6 @@ def repr_overlap_stats(activations, targets):
                 else:
                     overlap_vals = overlap_vals.flatten().tolist()
 
-                repr_overlaps[t1][t2] = overlap_vals
+                overlap_values[t1][t2] = overlap_vals
 
-        return repr_overlaps
+        return overlap_values

--- a/nupic/research/frameworks/dendrites/metrics/plotting.py
+++ b/nupic/research/frameworks/dendrites/metrics/plotting.py
@@ -33,8 +33,8 @@ from .metrics import (
     hidden_activations_by_unit,
     mean_selected_activations,
     percent_active_dendrites,
-    representation_overlap_distributions,
     representation_overlap_matrix,
+    representation_overlap_values,
     winning_segment_indices,
 )
 
@@ -514,15 +514,14 @@ def plot_representation_overlap_distributions(activations, targets):
     :param targets: 1D torch tensor with shape (batch_size,) where entry b gives the
                     target label for example b
     """
-    inter_class_ol, intra_class_ol = representation_overlap_distributions(activations,
-                                                                          targets)
+    inter_class_ol, intra_class_ol = representation_overlap_values(activations,
+                                                                   targets)
     figures = []
 
     for fig_num, ol in enumerate((inter_class_ol, intra_class_ol)):
 
         plt.figure(fig_num)
-        plt.hist(x=ol, bins=np.arange(0.0, 1.0, 0.02), color="tab:blue",
-                 edgecolor="k")
+        plt.hist(x=ol, bins=np.arange(0.0, 1.0, 0.02), color="tab:blue", edgecolor="k")
 
         plt.xticks(np.arange(0.0, 1.0, 0.2))
         plt.xlabel("Fraction of overlap")

--- a/nupic/research/frameworks/dendrites/metrics/plotting.py
+++ b/nupic/research/frameworks/dendrites/metrics/plotting.py
@@ -342,7 +342,6 @@ def plot_dendrite_overlap_matrix(winning_mask, targets, category_names=None,
             overlap_matrix[i, j] = np.nan
 
     # Anchor the colorbar to the range [0, 1]
-    # vmax = np.max(overlap_matrix)
     plt.cla()
     fig, ax = plt.subplots()
     ax.imshow(overlap_matrix, cmap="OrRd", vmin=0.0, vmax=1.0)
@@ -440,11 +439,7 @@ def plot_entropy_distribution(winning_mask, targets):
     return figure
 
 
-def plot_winning_segment_distributions(
-    winning_mask,
-    num_units_to_plot=1,
-    seed=0
-):
+def plot_winning_segment_distributions(winning_mask, num_units_to_plot=1, seed=0):
     """
     Plot the distribution of winning segments for the list of units (defaults to just
     the first):

--- a/nupic/research/frameworks/dendrites/metrics/plotting.py
+++ b/nupic/research/frameworks/dendrites/metrics/plotting.py
@@ -525,7 +525,7 @@ def plot_representation_overlap_distributions(activations, targets):
 
         plt.xticks(np.arange(0.0, 1.0, 0.2))
         plt.xlabel("Fraction of overlap")
-        plt.ylabel("Pairwise frequency")
+        plt.ylabel("Number of pairs")
         plt.xlim(0.0, 1.0)
         plt.grid(True)
         plt.tight_layout()

--- a/nupic/research/frameworks/dendrites/metrics/plotting.py
+++ b/nupic/research/frameworks/dendrites/metrics/plotting.py
@@ -33,8 +33,8 @@ from .metrics import (
     hidden_activations_by_unit,
     mean_selected_activations,
     percent_active_dendrites,
-    repr_overlap_distributions,
-    repr_overlap_matrix,
+    representation_overlap_distributions,
+    representation_overlap_matrix,
     winning_segment_indices,
 )
 
@@ -441,7 +441,8 @@ def plot_entropy_distribution(winning_mask, targets):
     return figure
 
 
-def plot_repr_overlap_matrix(activations, targets, category_names=None, annotate=True):
+def plot_representation_overlap_matrix(activations, targets, category_names=None,
+                                       annotate=True):
     """
     Returns a heatmap with shape (num_categories, num_categories) where cell c1, c2
     gives the mean value of pairwise representation overlaps across all pairs of
@@ -459,7 +460,7 @@ def plot_repr_overlap_matrix(activations, targets, category_names=None, annotate
     """
     num_categories = 1 + targets.max().item()
 
-    overlap_matrix = repr_overlap_matrix(activations, targets)
+    overlap_matrix = representation_overlap_matrix(activations, targets)
     overlap_matrix = overlap_matrix.detach().cpu().numpy()
 
     # `overlap_matrix` is symmetric, hence we can set all values above the main
@@ -501,7 +502,7 @@ def plot_repr_overlap_matrix(activations, targets, category_names=None, annotate
     return figure
 
 
-def plot_repr_overlap_distributions(activations, targets):
+def plot_representation_overlap_distributions(activations, targets):
     """
     Returns a tuple of histograms that show pairwise representation overlaps between
     samples whose representations are given by `activations`. The first histogram
@@ -513,7 +514,8 @@ def plot_repr_overlap_distributions(activations, targets):
     :param targets: 1D torch tensor with shape (batch_size,) where entry b gives the
                     target label for example b
     """
-    inter_class_ol, intra_class_ol = repr_overlap_distributions(activations, targets)
+    inter_class_ol, intra_class_ol = representation_overlap_distributions(activations,
+                                                                          targets)
     figures = []
 
     for fig_num, ol in enumerate((inter_class_ol, intra_class_ol)):

--- a/nupic/research/frameworks/vernon/mixins/__init__.py
+++ b/nupic/research/frameworks/vernon/mixins/__init__.py
@@ -19,11 +19,16 @@
 # http://numenta.org/licenses/
 # ----------------------------------------------------------------------
 
-from .constrain_parameters import ConstrainParameters
+from .composite_loss import CompositeLoss
 from .configure_optimizer_param_groups import ConfigureOptimizerParamGroups
+from .constrain_parameters import ConstrainParameters
+from .cutmix import CutMix, CutMixKnowledgeDistillation
 from .delay_load_checkpoint import *
+from .dendrite_metrics import *
+from .ewc import ElasticWeightConsolidation
 from .export_model import ExportModel
 from .extra_validations_per_epoch import *
+from .hidden_activations import *
 from .knowledge_distillation import KnowledgeDistillation, KnowledgeDistillationCL
 from .legacy_imagenet_config import LegacyImagenetConfig
 from .load_preprocessed_data import LoadPreprocessedData
@@ -32,25 +37,21 @@ from .log_covariance import LogCovariance
 from .log_every_learning_rate import LogEveryLearningRate
 from .log_every_loss import LogEveryLoss
 from .lr_range_test import LRRangeTest, create_lr_test_experiment
-from .maxup import MaxupStandard, MaxupPerSample
+from .maxup import MaxupPerSample, MaxupStandard
 from .multi_cycle_lr import MultiCycleLR
+from .oml import OnlineMetaLearning
 from .profile import Profile
 from .profile_autograd import ProfileAutograd
 from .prune_low_magnitude import PruneLowMagnitude
 from .prune_low_snr import PruneLowSNR
+from .quantization_aware import QuantizationAware
+from .reduce_lr_after_task import ReduceLRAfterTask
 from .regularize_loss import RegularizeLoss
+from .representation_overlap import *
 from .rezero_weights import RezeroWeights
 from .save_final_checkpoint import SaveFinalCheckpoint
 from .step_based_logging import *
 from .track_representation_sparsity import *
 from .update_boost_strength import UpdateBoostStrength
 from .update_dendrite_boost_strength import UpdateDendriteBoostStrength
-from .cutmix import CutMix, CutMixKnowledgeDistillation
-from .composite_loss import CompositeLoss
-from .quantization_aware import QuantizationAware
-from .reduce_lr_after_task import ReduceLRAfterTask
 from .vary_batch_size import VaryBatchSize
-from .ewc import ElasticWeightConsolidation
-from .oml import OnlineMetaLearning
-from .dendrite_metrics import *
-from .hidden_activations import *

--- a/nupic/research/frameworks/vernon/mixins/representation_overlap.py
+++ b/nupic/research/frameworks/vernon/mixins/representation_overlap.py
@@ -102,7 +102,6 @@ class PlotRepresentationOverlap(metaclass=abc.ABCMeta):
         # to the tensors being collected by the hooks.
         self.ro_targets = torch.tensor([]).long()
 
-
     def run_epoch(self):
 
         # Run the epoch with tracking enabled.

--- a/nupic/research/frameworks/vernon/mixins/representation_overlap.py
+++ b/nupic/research/frameworks/vernon/mixins/representation_overlap.py
@@ -1,0 +1,177 @@
+# ----------------------------------------------------------------------
+# Numenta Platform for Intelligent Computing (NuPIC)
+# Copyright (C) 2021, Numenta, Inc.  Unless you have an agreement
+# with Numenta, Inc., for a separate license for this software code, the
+# following terms and conditions apply:
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# See the GNU Affero Public License for more details.
+#
+# You should have received a copy of the GNU Affero Public License
+# along with this program.  If not, see http://www.gnu.org/licenses.
+#
+# http://numenta.org/licenses/
+# ----------------------------------------------------------------------
+
+import abc
+from copy import deepcopy
+from pprint import pformat
+
+import torch
+
+from nupic.research.frameworks.dendrites import (
+    plot_repr_overlap_distributions,
+    plot_repr_overlap_matrix,
+)
+from nupic.research.frameworks.pytorch.hooks import (
+    ModelHookManager,
+    TrackHiddenActivationsHook,
+)
+from nupic.research.frameworks.pytorch.model_utils import filter_modules
+
+__all__ = [
+    "PlotRepresentationOverlap",
+]
+
+
+class PlotRepresentationOverlap(metaclass=abc.ABCMeta):
+    """
+    Mixin for plotting a module's inter- and intra-class representation overlap.
+
+    :param config: a dict containing the following
+
+        - plot_representation_overlap_args: a dict containing the following
+
+            - include_modules: (optional) a list of module types to track
+            - include_names: (optional) a list of module names to track e.g.
+                             "features.stem"
+            - include_patterns: (optional) a list of regex patterns to compare to the
+                                names; for instance, all feature parameters in ResNet
+                                can be included through "features.*"
+            - plot_freq: (optional) how often to create the plot, measured in training
+                         iterations; defaults to 1
+            - plot_args: (optional) either a dictionary or a callable that takes no
+                             arguments and returns a dictionary; for instance this may
+                             be used to return a random sample of integers specifying
+                             units to plot; called only once at setup
+            - max_samples_to_plot: (optional) how many of samples to use for plotting;
+                                   only the newest will be used; defaults to 5000
+
+    Example config:
+    ```
+    config=dict(
+        plot_representation_overlap_args=dict(
+            include_modules=[torch.nn.ReLU, KWinners],
+            plot_freq=1,
+            plot_args=dict(annotate=False),
+            max_samples_to_plot=2000
+        )
+    )
+    ```
+    """
+
+    def setup_experiment(self, config):
+        super().setup_experiment(config)
+
+        # Process config args
+        ro_args = config.get("plot_representation_overlap_args", {})
+        ro_plot_freq, filter_args, ro_max_samples = self.process_ro_args(ro_args)
+
+        self.ro_plot_freq = ro_plot_freq
+        self.ro_max_samples = ro_max_samples
+
+        # Register hook for tracking hidden activations - useful for representation
+        # overlap
+        named_modules = filter_modules(self.model, **filter_args)
+        hook_args = dict(max_samples_to_track=self.ro_max_samples)
+        self.ro_hook = ModelHookManager(named_modules,
+                                        TrackHiddenActivationsHook,
+                                        hook_args=hook_args)
+
+        # Log the names of the modules being tracked
+        tracked_names = pformat(list(named_modules.keys()))
+        self.logger.info(f"Tracking representation overlap of modules: {tracked_names}")
+
+        # The targets will be collected in `self.error_loss` in a 1:1 fashion
+        # to the tensors being collected by the hooks.
+        self.ro_targets = torch.tensor([]).long()
+
+    def process_ro_args(self, ro_args):
+
+        ro_args = deepcopy(ro_args)
+
+        # Collect information about which modules to apply hooks to
+        include_names = ro_args.pop("include_names", [])
+        include_modules = ro_args.pop("include_modules", [])
+        include_patterns = ro_args.pop("include_patterns", [])
+        filter_args = dict(
+            include_names=include_names,
+            include_modules=include_modules,
+            include_patterns=include_patterns,
+        )
+
+        # Others args
+        plot_freq = ro_args.get("plot_freq", 1)
+        plot_args = ro_args.get("plot_args", {})
+        max_samples = ro_args.get("max_samples_to_plot", 1000)
+
+        assert isinstance(plot_freq, int)
+        assert isinstance(plot_args, dict)
+        assert isinstance(max_samples, int)
+        assert plot_freq > 0
+        assert max_samples > 0
+
+        return plot_freq, filter_args, max_samples
+
+    def run_epoch(self):
+
+        # Run the epoch with tracking enabled.
+        with self.ro_hook:
+            results = super().run_epoch()
+
+        # The epoch was iterated in `run_epoch` so epoch 0 is really epoch 1 here.
+        iteration = self.current_epoch + 1
+
+        # Create visualization, and update results dict.
+        if iteration % self.ro_plot_freq == 0:
+
+            for name, _, activations in self.ro_hook.get_statistics():
+
+                # Representation overlap matrix
+                visual = plot_repr_overlap_matrix(activations, self.ro_targets)
+                results.update({f"repr_overlap_matrix/{name}": visual})
+
+                # Representation overlap distributions:
+                #  * inter-class pairs
+                #  * intra-class pairs
+                inter_ol, intra_ol = plot_repr_overlap_distributions(activations,
+                                                                     self.ro_targets)
+                results.update({f"repr_overlap_interclass/{name}": inter_ol})
+                results.update({f"repr_overlap_intraclass/{name}": intra_ol})
+
+        return results
+
+    def error_loss(self, output, target, reduction="mean"):
+        """
+        This computes the loss and then saves the targets computed on this loss. This
+        mixin assumes these targets correspond, in a 1:1 fashion, to the samples seen
+        in the forward pass.
+        """
+        loss = super().error_loss(output, target, reduction=reduction)
+        if self.ro_hook.tracking:
+
+            # Targets were initialized on the cpu which could differ from the
+            # targets collected during the forward pass.
+            self.ro_targets = self.ro_targets.to(target.device)
+
+            # Concatenate and discard the older targets.
+            self.ro_targets = torch.cat([target, self.ro_targets], dim=0)
+            self.ro_targets = self.ro_targets[:self.ro_max_samples]
+
+        return loss

--- a/nupic/research/frameworks/vernon/mixins/representation_overlap.py
+++ b/nupic/research/frameworks/vernon/mixins/representation_overlap.py
@@ -81,7 +81,7 @@ class PlotRepresentationOverlap(metaclass=abc.ABCMeta):
 
         # Process config args
         ro_args = config.get("plot_representation_overlap_args", {})
-        ro_plot_freq, filter_args, ro_max_samples = self.process_ro_args(ro_args)
+        ro_plot_freq, filter_args, ro_max_samples = process_ro_args(ro_args)
 
         self.ro_plot_freq = ro_plot_freq
         self.ro_max_samples = ro_max_samples
@@ -102,32 +102,6 @@ class PlotRepresentationOverlap(metaclass=abc.ABCMeta):
         # to the tensors being collected by the hooks.
         self.ro_targets = torch.tensor([]).long()
 
-    def process_ro_args(self, ro_args):
-
-        ro_args = deepcopy(ro_args)
-
-        # Collect information about which modules to apply hooks to
-        include_names = ro_args.pop("include_names", [])
-        include_modules = ro_args.pop("include_modules", [])
-        include_patterns = ro_args.pop("include_patterns", [])
-        filter_args = dict(
-            include_names=include_names,
-            include_modules=include_modules,
-            include_patterns=include_patterns,
-        )
-
-        # Others args
-        plot_freq = ro_args.get("plot_freq", 1)
-        plot_args = ro_args.get("plot_args", {})
-        max_samples = ro_args.get("max_samples_to_plot", 1000)
-
-        assert isinstance(plot_freq, int)
-        assert isinstance(plot_args, dict)
-        assert isinstance(max_samples, int)
-        assert plot_freq > 0
-        assert max_samples > 0
-
-        return plot_freq, filter_args, max_samples
 
     def run_epoch(self):
 
@@ -179,3 +153,31 @@ class PlotRepresentationOverlap(metaclass=abc.ABCMeta):
             self.ro_targets = self.ro_targets[:self.ro_max_samples]
 
         return loss
+
+
+def process_ro_args(ro_args):
+
+    ro_args = deepcopy(ro_args)
+
+    # Collect information about which modules to apply hooks to
+    include_names = ro_args.pop("include_names", [])
+    include_modules = ro_args.pop("include_modules", [])
+    include_patterns = ro_args.pop("include_patterns", [])
+    filter_args = dict(
+        include_names=include_names,
+        include_modules=include_modules,
+        include_patterns=include_patterns,
+    )
+
+    # Others args
+    plot_freq = ro_args.get("plot_freq", 1)
+    plot_args = ro_args.get("plot_args", {})
+    max_samples = ro_args.get("max_samples_to_plot", 1000)
+
+    assert isinstance(plot_freq, int)
+    assert isinstance(plot_args, dict)
+    assert isinstance(max_samples, int)
+    assert plot_freq > 0
+    assert max_samples > 0
+
+    return plot_freq, filter_args, max_samples

--- a/nupic/research/frameworks/vernon/mixins/representation_overlap.py
+++ b/nupic/research/frameworks/vernon/mixins/representation_overlap.py
@@ -26,8 +26,8 @@ from pprint import pformat
 import torch
 
 from nupic.research.frameworks.dendrites import (
-    plot_repr_overlap_distributions,
-    plot_repr_overlap_matrix,
+    plot_representation_overlap_distributions,
+    plot_representation_overlap_matrix,
 )
 from nupic.research.frameworks.pytorch.hooks import (
     ModelHookManager,
@@ -143,17 +143,21 @@ class PlotRepresentationOverlap(metaclass=abc.ABCMeta):
 
             for name, _, activations in self.ro_hook.get_statistics():
 
+                metric_str = "representation_overlap"
+
                 # Representation overlap matrix
-                visual = plot_repr_overlap_matrix(activations, self.ro_targets)
-                results.update({f"repr_overlap_matrix/{name}": visual})
+                visual = plot_representation_overlap_matrix(activations,
+                                                            self.ro_targets)
+                results.update({f"{metric_str}_matrix/{name}": visual})
 
                 # Representation overlap distributions:
                 #  * inter-class pairs
                 #  * intra-class pairs
-                inter_ol, intra_ol = plot_repr_overlap_distributions(activations,
-                                                                     self.ro_targets)
-                results.update({f"repr_overlap_interclass/{name}": inter_ol})
-                results.update({f"repr_overlap_intraclass/{name}": intra_ol})
+                plots = plot_representation_overlap_distributions(activations,
+                                                                  self.ro_targets)
+                inter_overlaps, intra_overlaps = plots
+                results.update({f"{metric_str}_interclass/{name}": inter_overlaps})
+                results.update({f"{metric_str}_intraclass/{name}": intra_overlaps})
 
         return results
 

--- a/projects/dendrites/supermasks/random_supermasks.py
+++ b/projects/dendrites/supermasks/random_supermasks.py
@@ -39,8 +39,8 @@ from nupic.research.frameworks.dendrites import (
     plot_mean_selected_activations,
     plot_overlap_scores_distribution,
     plot_percent_active_dendrites,
-    plot_repr_overlap_distributions,
-    plot_repr_overlap_matrix,
+    plot_representation_overlap_distributions,
+    plot_representation_overlap_matrix,
 )
 from nupic.research.frameworks.dendrites.routing import generate_context_vectors
 from nupic.research.frameworks.vernon import SupervisedExperiment, mixins
@@ -214,11 +214,12 @@ def plot_representation_overlap_from_hooks():
 
         targets = exp.ro_targets
 
-        visual = plot_repr_overlap_matrix(activations, targets)
-        results.update({f"repr_overlap_matrix/{name}": visual})
-        visual_1, visual_2 = plot_repr_overlap_distributions(activations, targets)
-        results.update({f"repr_overlap_inter/{name}": visual_1})
-        results.update({f"repr_overlap_intra/{name}": visual_2})
+        visual = plot_representation_overlap_matrix(activations, targets)
+        results.update({f"representation_overlap_matrix/{name}": visual})
+        visual_1, visual_2 = plot_representation_overlap_distributions(activations,
+                                                                       targets)
+        results.update({f"representation_overlap_inter/{name}": visual_1})
+        results.update({f"representation_overlap_intra/{name}": visual_2})
 
     return results
 

--- a/tests/unit/frameworks/vernon/hidden_activations_test.py
+++ b/tests/unit/frameworks/vernon/hidden_activations_test.py
@@ -134,7 +134,7 @@ class PlotHiddenActivationsTest(unittest.TestCase):
 
     def test_no_tracking_args_given_supervised_experiment(self):
         """
-        Test the edge case where where hidden activations are not tracked in the
+        Test the edge case where hidden activations are not tracked in the
         supervised setting.
         """
 

--- a/tests/unit/frameworks/vernon/representation_overlap_test.py
+++ b/tests/unit/frameworks/vernon/representation_overlap_test.py
@@ -99,7 +99,7 @@ class PlotRepresentationOverlapTest(unittest.TestCase):
     This is a test class for the `PlotRepresentationOverlap` mixin.
     """
 
-    def test_repr_overlap_tracking_supervised_experiment(self):
+    def test_representation_overlap_tracking_supervised_experiment(self):
         """
         Test whether the mixin tracks representation overlap values in the supervised
         setting.
@@ -118,9 +118,9 @@ class PlotRepresentationOverlapTest(unittest.TestCase):
 
             # The plot frequency is 2 and should be logged every 2 epochs.
             if i % 2 == 0:
-                self.assertTrue("repr_overlap_matrix/kwinners" in ret)
-                self.assertTrue("repr_overlap_interclass/kwinners" in ret)
-                self.assertTrue("repr_overlap_intraclass/kwinners" in ret)
+                self.assertTrue("representation_overlap_matrix/kwinners" in ret)
+                self.assertTrue("representation_overlap_interclass/kwinners" in ret)
+                self.assertTrue("representation_overlap_intraclass/kwinners" in ret)
 
             # All the the tensors tracked should be of the same batch size.
             batch_size1 = exp.ro_targets.size(0)
@@ -155,7 +155,7 @@ class PlotRepresentationOverlapTest(unittest.TestCase):
 
             # Validate that nothing is being tracked.
             for k in ret.keys():
-                self.assertTrue("repr_overlap" not in k)
+                self.assertTrue("representation_overlap" not in k)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
The new mixin `PlotRepresentationOverlap` helps visualize overlaps in hidden representations. [Here](https://drive.google.com/file/d/1GU1eg25XG_qUmiGVzmYbTwc9eMI2GGtY/view?usp=sharing) is visual that shows the resulting figures. The figures on the left are the intra- and inter-class distributions of pairwise overlaps, and the figure on the right is a matrix where cell i, j gives the mean representation overlap in all pairs (x, y) where x belongs to class i, and y to class j.

This mixin class is very similar to `PlotDendriteMetrics` and `PlotHiddenActivations`. This mixin uses the `TrackHiddenActivationsHook` since this suffices for computing overlaps, instead of defining its own hook.

Additional functions to compute these metrics and plot them are included in the dendrites' metrics folder. Unit test cases are included.