### PR TITLE
Sparse Baselines for Transformers

### DIFF
--- a/projects/transformers/README.md
+++ b/projects/transformers/README.md
@@ -18,10 +18,18 @@ In progress, current results:
 
 <br/><br/>
 
+|Bert Sparsity ||
+|:-----------|:-------|
+| sparse_v1  | 42.14% |
+| sparse_v2  | 63.15% |
+| sparse_v3  | 79.68% |
+
+<br/><br/>
+
 **Legend**
 * *sparse_v1:* Static sparse encoder with only the non-attention linear layers sparsified (`model_type=static_sparse_non_attention_bert`)
 * *sparse_v2:* Static sparse encoder with all linear layers sparsified, including attention (`model_type=static_sparse_encoder_bert`)
-* *sparse_v2:* Static sparse encoder (as with v2) as well as static sparse token embeddings (`model_type=fully_static_sparse_bert`)
+* *sparse_v3:* Static sparse encoder (as with v2) as well as static sparse token embeddings (`model_type=fully_static_sparse_bert`)
 
 
 </br>

--- a/projects/transformers/README.md
+++ b/projects/transformers/README.md
@@ -13,13 +13,15 @@ In progress, current results:
 | bert_700k |          79.77 |          75.25 |  47.73 | 83.91/84.22 | 88.27/83.59 |  91.51 | 90.37/86.90 | 62.11 |  91.44 | 86.88/86.70 |  39.06 |  |
 | bert_100k |          75.71 |          72.51 |  40.98 | 78.26/78.65 | 84.05/77.86 |  87.74 | 89.12/85.25 |  58.2 |  88.31 | 83.90/83.80 |  46.88 | 8.619 |
 | sparse_v1_100k |          72.67 |          67.91 |  22.43 | 77.25/77.96 | 85.37/78.82 |  84.65 | 88.23/84.32 | 58.32 |  87.27 | 82.79/82.65 |  29.84 | 10.461 |
-| sparse_v2_100k |  |  |  |  |  |  |  |  |  |  |  |  |
+| sparse_v2_100k |          68.41 |          67.06 |  15.96 | 72.25/73.11 | 80.50/71.35 |  81.23 | 85.78/81.01 | 58.98 |  82.64 | 76.53/76.40 |  56.25 | 16.696 |
+| sparse_v3_100k |          68.25 |          66.92 |  16.35 | 72.00/72.32 | 80.42/70.83 |  80.31 | 85.04/80.49 | 58.98 |  82.52 | 76.96/77.60 |  56.25 | 22.81 |
 
 <br/><br/>
 
 **Legend**
 * *sparse_v1:* Static sparse encoder with only the non-attention linear layers sparsified (`model_type=static_sparse_non_attention_bert`)
 * *sparse_v2:* Static sparse encoder with all linear layers sparsified, including attention (`model_type=static_sparse_encoder_bert`)
+* *sparse_v2:* Static sparse encoder (as with v2) as well as static sparse token embeddings (`model_type=fully_static_sparse_bert`)
 
 
 </br>

--- a/projects/transformers/experiments/sparse_bert.py
+++ b/projects/transformers/experiments/sparse_bert.py
@@ -54,6 +54,19 @@ static_sparse_encoder_bert_100k.update(
     trainer_callbacks=[RezeroWeightsCallback()]
 )
 
+
+fully_static_sparse_bert_100k = deepcopy(bert_100k)
+fully_static_sparse_bert_100k.update(
+    # Model Arguments
+    overwrite_output_dir=False,
+    model_type="fully_static_sparse_bert",
+    config_kwargs=dict(
+        sparsity=0.8,
+    ),
+    trainer_callbacks=[RezeroWeightsCallback()]
+)
+
+
 # Sparse Bert of only two layers and one attention head.
 mini_sparse_bert_debug = deepcopy(debug_bert)
 mini_sparse_bert_debug.update(
@@ -65,7 +78,7 @@ mini_sparse_bert_debug.update(
         hidden_size=64,
         intermediate_size=64 * 4,
     ),
-    trainer_callbacks=[RezeroWeightsCallback()]
+    trainer_callbacks=[RezeroWeightsCallback()],
 )
 
 
@@ -74,4 +87,5 @@ CONFIGS = dict(
     sparse_bert_100k=sparse_bert_100k,
     mini_sparse_bert_debug=mini_sparse_bert_debug,
     static_sparse_encoder_bert_100k=static_sparse_encoder_bert_100k,
+    fully_static_sparse_bert_100k=fully_static_sparse_bert_100k,
 )

--- a/projects/transformers/export_model.py
+++ b/projects/transformers/export_model.py
@@ -40,6 +40,7 @@ def save_pretrained(checkpoint_folder, destination_folder, model_name):
     if not model_name:
         model_name = os.path.split(checkpoint_folder)[-1]
     model = AutoModelForMaskedLM.from_pretrained(checkpoint_folder)
+    print("Saving with model type:", model.__class__.__name__)
     destination_file_path = os.path.join(destination_folder, model_name)
     model.save_pretrained(destination_file_path)
     print(f"Model saved at {destination_file_path}")

--- a/projects/transformers/models/__init__.py
+++ b/projects/transformers/models/__init__.py
@@ -26,3 +26,4 @@ related utilities.
 """
 
 from .static_sparse_bert import *
+from .sparse_embedding import *

--- a/projects/transformers/models/sparse_embedding.py
+++ b/projects/transformers/models/sparse_embedding.py
@@ -1,0 +1,67 @@
+# ----------------------------------------------------------------------
+# Numenta Platform for Intelligent Computing (NuPIC)
+# Copyright (C) 2021, Numenta, Inc.  Unless you have an agreement
+# with Numenta, Inc., for a separate license for this software code, the
+# following terms and conditions apply:
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# See the GNU Affero Public License for more details.
+#
+# You should have received a copy of the GNU Affero Public License
+# along with this program.  If not, see http://www.gnu.org/licenses.
+#
+# http://numenta.org/licenses/
+# ----------------------------------------------------------------------
+
+import numpy as np
+import torch
+
+from nupic.torch.modules.sparse_weights import SparseWeightsBase
+
+__all__ = ["SparseEmbeddings"]
+
+
+class SparseEmbeddings(SparseWeightsBase):
+    """
+    This wraps a torch.nn.Embedding module to sparsify the weights where the sparsity is
+    applied per embedding. The embedding of an arbitrary index j will have the desired
+    sparsity specified through the init.
+
+    Note: A torch.nn.Embedding is already sparse in one sense. Specifically, it's input
+    is expected to be sparse (i.e. an integer specifying the index of the embedding).
+    In contrast, this introduces sparsity in the weights of the embedding layer, which
+    effectively yields sparse output embeddings.
+
+    :param module: A torch.nn.Embedding module
+    :param sparsity: Sparsity to apply to the weights; each output embedding will have
+                     this level of sparsity.
+    """
+
+    def __init__(self, module, sparsity=None):
+        assert len(module.weight.shape) == 2, "Should resemble a nn.Embedding"
+        super(SparseEmbeddings, self).__init__(
+            module, sparsity=sparsity
+        )
+
+        # For each unit, decide which weights are going to be zero
+        num_embeddings = self.module.num_embeddings
+        embedding_dim = self.module.embedding_dim
+        num_nz = int(round((1 - self.sparsity) * embedding_dim))
+        zero_mask = torch.ones(num_embeddings, embedding_dim, dtype=torch.bool)
+        for embedding_j in range(num_embeddings):
+            on_indices = np.random.choice(embedding_dim, num_nz, replace=False)
+            zero_mask[embedding_j, on_indices] = False
+
+        # Use float16 because pytorch distributed nccl doesn't support bools
+        self.register_buffer("zero_mask", zero_mask.half())
+
+        self.rezero_weights()
+
+    def rezero_weights(self):
+        self.module.weight.data[self.zero_mask.bool()] = 0

--- a/projects/transformers/models/static_sparse_bert.py
+++ b/projects/transformers/models/static_sparse_bert.py
@@ -37,6 +37,7 @@ from nupic.research.frameworks.pytorch.model_utils import (
 from nupic.torch.modules import SparseWeights
 
 from .register_bert_model import register_bert_model
+from .sparse_embedding import SparseEmbeddings
 
 logger = logging.get_logger(__name__)
 
@@ -51,7 +52,8 @@ __all__ = [
 class StaticSparseEncoderBertModel(BertModel):
     """
     Sparse Version of Bert that applies static sparsity to all linear layers (included
-    attention) in the encoder network.
+    attention) in the encoder network. Use by this model declaring
+    model_type="static_sparse_encoder_bert".
     """
 
     @dataclass
@@ -94,7 +96,8 @@ class StaticSparseEncoderBertModel(BertModel):
 class StaticSparseNonAttentionBertModel(BertModel):
     """
     Sparse Version of Bert that applies static sparsity to all non-attention linear
-    layers in the encoder network.
+    layers in the encoder network. Use by this model declaring
+    model_type="static_sparse_non_attention_bert".
     """
 
     @dataclass
@@ -136,3 +139,110 @@ class StaticSparseNonAttentionBertModel(BertModel):
             output_layer = encoder.layer[idx].output.dense
             encoder.layer[idx].output.dense = \
                 SparseWeights(output_layer, sparsity=sparsity).to(device)
+
+
+@register_bert_model
+class FullyStaticSparseBertModel(BertModel):
+    """
+    Sparse Version of Bert that applies static sparsity to linear layers; every linear
+    layer in the encoder as well as the word embedding layer. Use by this model
+    declaring model_type="fully_static_sparse_bert".
+    """
+
+    @dataclass
+    class ConfigKWargs:
+        """Keyword arguments to configure sparsity."""
+        sparsity: float = 0.5
+        num_sparse_layers: int = 12
+
+    def __init__(self, config, add_pooling_layer=True):
+        # Call the init one parent class up. Otherwise, the model will be defined twice.
+        BertPreTrainedModel.__init__(self, config)
+        self.config = config
+
+        self.embeddings = BertEmbeddings(config)
+        self.encoder = BertEncoder(config)
+
+        self.pooler = BertPooler(config) if add_pooling_layer else None
+
+        # Sparsify linear modules.
+        self.sparsify_model()
+
+        self.init_weights()
+
+    def sparsify_model(self):
+        """
+        Sparsify all linear layers in encoder as well as the word embedding layer.
+        """
+
+        encoder = self.encoder
+        sparsity = self.config.sparsity
+        device = self.device
+
+        # Perform model surgery by replacing the linear layers with `SparseWeights`.
+        linear_modules = filter_modules(encoder, include_modules=[torch.nn.Linear])
+        for name, module in linear_modules.items():
+            sparse_module = SparseWeights(module, sparsity=sparsity).to(device)
+            set_module_attr(self.encoder, name, sparse_module)
+
+        # Replace the embedding layer in a similar fashion.
+        dense_embeddings = self.embeddings.word_embeddings
+        sparse_embeddings = SparseEmbeddings(dense_embeddings, sparsity=sparsity)
+        self.embeddings.word_embeddings = sparse_embeddings
+
+
+# Import new class to override embedding related functions. # noqa
+# This class was implicitly defined through register_bert_model # noqa
+from . import FullyStaticSparseBertForMaskedLM  # noqa
+
+
+def _get_resized_sparse_embeddings(self, old_embeddings, new_num_tokens=None):
+    """
+    Build a resized Embedding Module from a provided token Embedding Module. Increasing
+    the size will add newly initialized vectors at the end. Reducing the size will
+    remove vectors from the end.
+
+    This is modified from the `Transformers`_ repo to work with SparseEmbeddings modules
+
+    .. _Transformers:
+        https://github.com/huggingface/transformers/blob/0d909f6bd8ca0bc1ec8f42e089b64b4fffc4d230/src/transformers/modeling_utils.py#L645
+
+    :param old_embeddings: Old embeddings to be resized.
+    :type old_embeddings: SparseEmbeddings module
+    :param new_num_tokens: New number of tokens in the embedding matrix.
+    :type new_num_tokens: int
+    """
+    if new_num_tokens is None:
+        return old_embeddings
+
+    old_num_tokens, old_embedding_dim = old_embeddings.weight.size()
+    if old_num_tokens == new_num_tokens:
+        return old_embeddings
+
+    if not isinstance(old_embeddings, SparseEmbeddings):
+        raise TypeError(
+            f"Old embeddings are of type {type(old_embeddings)}, which is not an "
+            f"instance of {SparseEmbeddings}. You should either use a different"
+            "resize function or make sure that `old_embeddings` are an instance "
+            f"of {SparseEmbeddings}."
+        )
+
+    # Build new embeddings
+    new_embeddings = torch.nn.Embedding(new_num_tokens, old_embedding_dim)
+    new_embeddings = SparseEmbeddings(new_embeddings, sparsity=old_embeddings.sparsity)
+    new_embeddings = new_embeddings.to(self.device)
+
+    # initialize all new embeddings (in particular added tokens)
+    self._init_weights(new_embeddings)
+
+    # Copy token embeddings from the previous weights
+    num_tokens_to_copy = min(old_num_tokens, new_num_tokens)
+    old_data = old_embeddings.weight.data[:num_tokens_to_copy, :]
+    new_embeddings.weight.data[:num_tokens_to_copy, :] = old_data
+
+    return new_embeddings
+
+
+FullyStaticSparseBertForMaskedLM._get_resized_embeddings = (
+    _get_resized_sparse_embeddings
+)

--- a/projects/transformers/tests/sparse_embedding_test.py
+++ b/projects/transformers/tests/sparse_embedding_test.py
@@ -1,0 +1,81 @@
+# ----------------------------------------------------------------------
+# Numenta Platform for Intelligent Computing (NuPIC)
+# Copyright (C) 2021, Numenta, Inc.  Unless you have an agreement
+# with Numenta, Inc., for a separate license for this software code, the
+# following terms and conditions apply:
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# See the GNU Affero Public License for more details.
+#
+# You should have received a copy of the GNU Affero Public License
+# along with this program.  If not, see http://www.gnu.org/licenses.
+#
+# http://numenta.org/licenses/
+# ----------------------------------------------------------------------
+
+import sys
+import unittest
+from collections import OrderedDict
+from os.path import expanduser
+
+import torch
+
+sys.path.insert(0, expanduser("~/nta/nupic.research/projects/transformers")) # noqa
+from models import SparseEmbeddings # noqa
+
+
+def create_simple_model():
+    modules = OrderedDict([
+        ("embedding", SparseEmbeddings(torch.nn.Embedding(8, 8), sparsity=0.75)),
+        ("linear", torch.nn.Linear(8, 8))
+    ])
+    return torch.nn.Sequential(modules)
+
+
+class SparseEmbeddingsTest(unittest.TestCase):
+    """
+    This is a test for a SparseEmbeddings layer which should behave very similarly to a
+    SparseWeights layers.
+    """
+
+    def test_forward_and_backward_pass(self):
+        model = create_simple_model()
+        optim = torch.optim.SGD(model.parameters(), lr=0.01)
+
+        # Validate overall sparsity.
+        assert (model.embedding.weight == 0).sum() == 48
+
+        # Validate sparsity per each embedding.
+        num_embeddings = model.embedding.module.num_embeddings
+        for j in range(num_embeddings):
+            embedding_j = model.embedding.weight[j, :]
+            assert (embedding_j == 0).sum() == 6
+
+        # Run one forward and backward pass.
+        x = torch.Tensor([0, 2]).long()
+        y = model(x)
+        targets = torch.randint(8, size=(2,))
+        loss = torch.nn.functional.cross_entropy(y, targets)
+        loss.backward()
+
+        optim.step()
+        model.embedding.rezero_weights()
+
+        # Validate overall sparsity.
+        assert (model.embedding.weight == 0).sum() == 48
+
+        # Validate sparsity per each embedding.
+        num_embeddings = model.embedding.module.num_embeddings
+        for j in range(num_embeddings):
+            embedding_j = model.embedding.weight[j, :]
+            assert (embedding_j == 0).sum() == 6
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
This PR include results for the static sparse baselines:
* sparse_v2_100k - static sparsity through all linear layers in the encoder
* sparse_v3_100k - like v2, but the token embeddings are sparse as well

Corresponding to v3, there's a new `SparseEmbeddings` module and a `FullyStaticSparseBertModel` class that uses this module to sparsify its embeddings. 