### PR TITLE
transformers: hyperparameter search in pretraining with ray tune

### DIFF
--- a/projects/transformers/experiments/__init__.py
+++ b/projects/transformers/experiments/__init__.py
@@ -30,6 +30,7 @@ from .finetuning import CONFIGS as FINETUNING
 from .sparse_bert import CONFIGS as SPARSE_BERT
 from .finetuning import CONFIGS as FINETUNING
 from .distillation import CONFIGS as DISTILLATION
+from .hpsearch import CONFIGS as HPSEARCH
 
 """
 Import and collect all experiment configurations into one CONFIG
@@ -45,3 +46,4 @@ CONFIGS.update(FINETUNING)
 CONFIGS.update(SPARSE_BERT)
 CONFIGS.update(FINETUNING)
 CONFIGS.update(DISTILLATION)
+CONFIGS.update(HPSEARCH)

--- a/projects/transformers/experiments/__init__.py
+++ b/projects/transformers/experiments/__init__.py
@@ -26,11 +26,10 @@ import models
 from .base import CONFIGS as BASE
 from .bert_replication import CONFIGS as BERT_REPLICATION
 from .bertitos import CONFIGS as BERTITOS
-from .finetuning import CONFIGS as FINETUNING
-from .sparse_bert import CONFIGS as SPARSE_BERT
-from .finetuning import CONFIGS as FINETUNING
 from .distillation import CONFIGS as DISTILLATION
+from .finetuning import CONFIGS as FINETUNING
 from .hpsearch import CONFIGS as HPSEARCH
+from .sparse_bert import CONFIGS as SPARSE_BERT
 
 """
 Import and collect all experiment configurations into one CONFIG
@@ -42,8 +41,7 @@ CONFIGS = dict()
 CONFIGS.update(BASE)
 CONFIGS.update(BERT_REPLICATION)
 CONFIGS.update(BERTITOS)
-CONFIGS.update(FINETUNING)
-CONFIGS.update(SPARSE_BERT)
-CONFIGS.update(FINETUNING)
 CONFIGS.update(DISTILLATION)
+CONFIGS.update(FINETUNING)
 CONFIGS.update(HPSEARCH)
+CONFIGS.update(SPARSE_BERT)

--- a/projects/transformers/experiments/distillation.py
+++ b/projects/transformers/experiments/distillation.py
@@ -24,6 +24,7 @@ Base Transformers Experiment configuration.
 
 from copy import deepcopy
 
+from ray import tune
 from transformers import Trainer
 
 from trainer_mixins import DistillationTrainerMixin
@@ -130,9 +131,29 @@ tiny_bert_50k_kd.update(
 )
 
 
+def hp_space_lr_search_loguniform(trial):
+    return dict(
+        learning_rate=tune.grid_search([3, 1, 3e-1, 1e-1, 3e-2, 1e-2, 3e-3, 1e-3])
+    )
+
+
+tiny_bert_50k_kd_lrsearch = deepcopy(tiny_bert_50k_kd)
+tiny_bert_50k_kd_lrsearch.update(
+    learning_rate=1e-2,
+
+    # hyperparameter search
+    hp_space=hp_space_lr_search_loguniform,  # required
+    hp_num_trials=1,
+    hp_validation_dataset_pct=0.1,  # default
+    hp_extra_kwargs=dict()  # default
+
+)
+
+
 # Export configurations in this file
 CONFIGS = dict(
     debug_bert_kd=debug_bert_kd,
     tiny_bert_100k_kd=tiny_bert_100k_kd,
     tiny_bert_50k_kd=tiny_bert_50k_kd,
+    tiny_bert_50k_kd_lrsearch=tiny_bert_50k_kd_lrsearch,
 )

--- a/projects/transformers/experiments/hpsearch.py
+++ b/projects/transformers/experiments/hpsearch.py
@@ -1,0 +1,70 @@
+#  Numenta Platform for Intelligent Computing (NuPIC)
+#  Copyright (C) 2021, Numenta, Inc.  Unless you have an agreement
+#  with Numenta, Inc., for a separate license for this software code, the
+#  following terms and conditions apply:
+#
+#  This program is free software you can redistribute it and/or modify
+#  it under the terms of the GNU Affero Public License version 3 as
+#  published by the Free Software Foundation.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#  See the GNU Affero Public License for more details.
+#
+#  You should have received a copy of the GNU Affero Public License
+#  along with this program.  If not, see htt"://www.gnu.org/licenses.
+#
+#  http://numenta.org/licenses/
+#
+
+"""
+Base Transformers Experiment configuration.
+"""
+
+from copy import deepcopy
+
+from ray import tune
+
+from .base import bert_base
+
+
+def hp_space(trial):
+    return dict(
+        learning_rate=tune.loguniform(1e-4, 1e-2)
+    )
+
+
+debug_hp_search = deepcopy(bert_base)
+debug_hp_search.update(
+
+    finetuning=False,
+
+    #  Data Training arguments
+    dataset_name="wikitext",
+    dataset_config_name="wikitext-2-raw-v1",
+
+    # Training Arguments
+    logging_steps=50,
+    warmup_steps=10,
+    max_steps=50,
+    overwrite_output_dir=True,
+    dataloader_drop_last=True,
+    per_device_train_batch_size=8,
+    per_device_eval_batch_size=8,
+    do_train=True,
+    do_eval=True,
+    do_predict=False,
+
+    # hyperparameter search
+    hp_space=hp_space,  # required
+    hp_num_trials=2,  # required
+    hp_validation_dataset_pct=0.05,  # default
+    hp_extra_kwargs=dict()  # default
+
+)
+
+# Export configurations in this file
+CONFIGS = dict(
+    debug_hp_search=debug_hp_search
+)

--- a/projects/transformers/run.py
+++ b/projects/transformers/run.py
@@ -103,6 +103,13 @@ def main():
             training_args.output_dir, training_args.run_name
         )
 
+        if model_args.use_custom_wandbcallback:
+            # Initialize wandb now to include the logs that follow.
+            # For now, only support early wandb logging when running one experiment.
+            from integrations import CustomWandbCallback
+            if len(cmd_args.experiments) == 1:
+                CustomWandbCallback.early_init(training_args, local_rank)
+
         # Detecting last checkpoint.
         last_checkpoint = None
         if (os.path.isdir(training_args.output_dir) and training_args.do_train

--- a/projects/transformers/run.py
+++ b/projects/transformers/run.py
@@ -51,7 +51,6 @@ from transformers import (
 from transformers.trainer_utils import get_last_checkpoint, is_main_process
 
 from experiments import CONFIGS
-from integrations import CustomWandbCallback
 from run_args import CustomTrainingArguments, DataTrainingArguments, ModelArguments
 from run_utils import (
     TaskResults,
@@ -105,7 +104,6 @@ def main():
 
         # Initialize wandb now to include the logs that follow.
         # For now, only support early wandb logging when running one experiment.
-        if len(cmd_args.experiments) == 1:
             CustomWandbCallback.early_init(training_args, local_rank)
 
         # Detecting last checkpoint.

--- a/projects/transformers/run.py
+++ b/projects/transformers/run.py
@@ -37,6 +37,7 @@ import random
 import sys
 from copy import deepcopy
 from dataclasses import replace
+from functools import partial
 from pprint import pformat
 
 import torch.distributed
@@ -178,18 +179,6 @@ def run_pretraining(
 
     config = init_config(model_args)
     tokenizer = init_tokenizer(model_args)
-    model = init_model(model_args, config, tokenizer)
-
-    # Initialize distillation models
-    if model_args.teacher_models_name_or_path:
-        teacher_models = []
-        for model_name_or_path in model_args.teacher_models_name_or_path:
-            teacher_args = replace(model_args, model_name_or_path=model_name_or_path)
-            teacher_config = init_config(teacher_args)
-            teacher_models.append(init_model(teacher_args, teacher_config, tokenizer))
-
-        model_args.trainer_extra_kwargs["teacher_models"] = teacher_models
-        logging.info(f"{len(teacher_models)} teacher models initialized.")
 
     if tokenized_datasets is None:
         # Tokenizing and preprocessing the datasets for language modeling
@@ -226,20 +215,104 @@ def run_pretraining(
         tokenizer=tokenizer, mlm_probability=data_args.mlm_probability
     )
 
-    # Train and evaluate
-    trainer = init_trainer(
-        model, tokenizer, data_collator, training_args,
-        train_dataset, eval_dataset,
-        trainer_class=model_args.trainer_class,
-        trainer_extra_kwargs=model_args.trainer_extra_kwargs,
-        trainer_callbacks=model_args.trainer_callbacks or None,
-    )
-    if training_args.do_train:
-        train(trainer, training_args.output_dir, last_checkpoint)
+    # Initialize distillation models
+    if model_args.teacher_models_name_or_path:
+        teacher_models = []
+        for model_name_or_path in model_args.teacher_models_name_or_path:
+            teacher_args = replace(model_args, model_name_or_path=model_name_or_path)
+            teacher_config = init_config(teacher_args)
+            teacher_models.append(init_model(teacher_args, teacher_config, tokenizer))
 
+        model_args.trainer_extra_kwargs["teacher_models"] = teacher_models
+        logging.info(f"{len(teacher_models)} teacher models initialized.")
+
+    # Regular training run: init model, trainer, and call train
+    if model_args.hp_num_trials <= 1:
+
+        trainer = init_trainer(
+            tokenizer=tokenizer,
+            data_collator=data_collator,
+            training_args=training_args,
+            train_dataset=train_dataset if training_args.do_train else None,
+            eval_dataset=eval_dataset if training_args.do_eval else None,
+            model=init_model(model_args, config, tokenizer),
+            trainer_class=model_args.trainer_class,
+            trainer_extra_kwargs=model_args.trainer_extra_kwargs,
+            trainer_callbacks=model_args.trainer_callbacks or None,
+        )
+
+        if training_args.do_train:
+            train(trainer, training_args.output_dir, last_checkpoint)
+
+    # Alternative: using hp search
+    else:
+        # Extra trainer configurations required for hpsearch
+        model_args.trainer_extra_kwargs.update(
+            model_init=partial(init_model, model_args, config, tokenizer, False)
+        )
+        training_args.load_best_model_at_end = True
+        training_args.disable_tqdm = True
+        # TODO: sync metric_for_best_model with compute_objective, should be same metric
+        # and accept custom metrics defined by user
+        training_args.metric_for_best_model = "eval_loss"
+        # TODO: load best model and proceed to evaluation normally after hp search
+        training_args.do_eval = False
+        training_args.do_predict = False
+
+        # Get fraction of the validation dataset to use in hp search
+        hp_eval_dataset = eval_dataset.shard(
+            index=1, num_shards=int(1 / model_args.hp_validation_dataset_pct)
+        )
+
+        trainer = init_trainer(
+            tokenizer=tokenizer,
+            data_collator=data_collator,
+            training_args=training_args,
+            train_dataset=train_dataset,
+            eval_dataset=hp_eval_dataset,
+            trainer_class=model_args.trainer_class,
+            trainer_extra_kwargs=model_args.trainer_extra_kwargs,
+            trainer_callbacks=model_args.trainer_callbacks or None,
+        )
+
+        hp_search_kwargs = dict(
+            direction="maximize",
+            backend="ray",
+            n_trials=model_args.hp_num_trials,
+            hp_space=model_args.hp_space,
+            compute_objective=model_args.hp_compute_objective,
+            local_dir=training_args.output_dir,
+            resources_per_trial=dict(
+                cpu=os.cpu_count() / torch.cuda.device_count() - 1,
+                gpu=1
+            ),
+            checkpoint_freq=0,
+            keep_checkpoints_num=0,
+            checkpoint_at_end=False,
+        )
+        # Update any extra kwargs defined in config
+        hp_search_kwargs.update(**model_args.hp_extra_kwargs)
+
+        # Run hp search and save results
+        best_run = trainer.hyperparameter_search(**hp_search_kwargs)
+        logging.info(f"Best run: {best_run}")
+
+        hp_res_file = os.path.join(training_args.output_dir, "hp_search_results.txt")
+        if trainer.is_world_process_zero():
+            with open(hp_res_file, "w") as writer:
+                writer.write("Hyperparameter search best run:\n")
+                writer.write(f"run_id = {best_run.run_id}\n")
+                writer.write(f"{training_args.metric_for_best_model}")
+                writer.write(f"= {best_run.objective}\n")
+                writer.write(f"\nHyperparameters:\n")
+                for key, value in sorted(best_run.hyperparameters.items()):
+                    writer.write(f"{key} = {value}\n")
+
+    # Evaluate in full eval dataset.
+    # if using hp search, load best model before running evaluate
     if training_args.do_eval:
         logging.info("*** Evaluate ***")
-        evaluate_language_model(trainer, training_args.output_dir)
+        evaluate_language_model(trainer, eval_dataset, training_args.output_dir)
 
 
 def run_finetuning_single_task(
@@ -294,8 +367,12 @@ def run_finetuning_single_task(
 
     # Train
     trainer = init_trainer(
-        model, tokenizer, data_collator, training_args,
-        train_dataset, eval_dataset,
+        tokenizer=tokenizer,
+        data_collator=data_collator,
+        training_args=training_args,
+        train_dataset=train_dataset if training_args.do_train else None,
+        eval_dataset=eval_dataset if training_args.do_eval else None,
+        model=init_model(model_args, config, tokenizer),
         trainer_callbacks=model_args.trainer_callbacks or None,
         finetuning=True, task_name=data_args.task_name, is_regression=is_regression
     )

--- a/projects/transformers/run.py
+++ b/projects/transformers/run.py
@@ -53,6 +53,7 @@ from transformers.integrations import is_wandb_available
 from transformers.trainer_utils import get_last_checkpoint, is_main_process
 
 from experiments import CONFIGS
+from integrations import CustomWandbCallback
 from run_args import CustomTrainingArguments, DataTrainingArguments, ModelArguments
 from run_utils import (
     TaskResults,

--- a/projects/transformers/run.py
+++ b/projects/transformers/run.py
@@ -102,10 +102,6 @@ def main():
             training_args.output_dir, training_args.run_name
         )
 
-        # Initialize wandb now to include the logs that follow.
-        # For now, only support early wandb logging when running one experiment.
-            CustomWandbCallback.early_init(training_args, local_rank)
-
         # Detecting last checkpoint.
         last_checkpoint = None
         if (os.path.isdir(training_args.output_dir) and training_args.do_train

--- a/projects/transformers/run_args.py
+++ b/projects/transformers/run_args.py
@@ -48,6 +48,13 @@ class ModelArguments:
     Arguments pertaining to which model/config/tokenizer we are going to fine-tune,
     or train from scratch.
     """
+    use_custom_wandbcallback: bool = field(
+        default=False,
+        metadata={
+            "help": "Whether or not to use custom wandback callbacks defined in "
+                    "./integrations."
+        },
+    )
     finetuning: bool = field(
         default=False,
         metadata={

--- a/projects/transformers/run_args.py
+++ b/projects/transformers/run_args.py
@@ -48,13 +48,6 @@ class ModelArguments:
     Arguments pertaining to which model/config/tokenizer we are going to fine-tune,
     or train from scratch.
     """
-    use_custom_wandbcallback: bool = field(
-        default=False,
-        metadata={
-            "help": "Whether or not to use custom wandback callbacks defined in "
-                    "./integrations."
-        },
-    )
     finetuning: bool = field(
         default=False,
         metadata={

--- a/projects/transformers/run_args.py
+++ b/projects/transformers/run_args.py
@@ -163,13 +163,13 @@ class ModelArguments:
     hp_validation_dataset_pct: float = field(
         default=0.05,
         metadata={
-            "help": "Percentage of the validation dataset to use durying hp search"
+            "help": "Percentage of the validation dataset to be used in hp search"
         }
     )
     hp_compute_objective: Callable = field(
         default=compute_objective_eval_loss,
         metadata={
-            "help": "Function that objective to be used in hyperparameter search "
+            "help": "Defines the objective function be used in hyperparameter search"
         }
     )
     hp_extra_kwargs: Dict = field(

--- a/projects/transformers/run_args.py
+++ b/projects/transformers/run_args.py
@@ -23,7 +23,7 @@ from typing import Callable, Dict, List, Optional
 
 from transformers import MODEL_FOR_MASKED_LM_MAPPING, Trainer, TrainingArguments
 
-from run_utils import TASK_TO_KEYS
+from run_utils import TASK_TO_KEYS, compute_objective_eval_loss
 
 MODEL_CONFIG_CLASSES = list(MODEL_FOR_MASKED_LM_MAPPING.keys())
 MODEL_TYPES = tuple(conf.model_type for conf in MODEL_CONFIG_CLASSES)
@@ -122,11 +122,10 @@ class ModelArguments:
             "help": "Allow user to define custom training arguments per task."
         },
     )
-    trainer_callbacks: Dict = field(
-        default_factory=dict,
+    trainer_callbacks: List = field(
+        default_factory=list,
         metadata={
-            "help": "Whether to create a new results file. If set to False, will only"
-                    "attempt to update existing entries"
+            "help": "List of callbacks to trainer"
         },
     )
     trainer_class: Callable = field(
@@ -147,6 +146,37 @@ class ModelArguments:
         metadata={
             "help": "Extra keyword arguments to be passed to Trainer. Can be passed "
                     "to pass extra arguments when trainer mixins are used."
+        }
+    )
+    hp_space: Callable = field(
+        default=lambda: {},
+        metadata={
+            "help": "Hyperparameters to search for in the model"
+        }
+    )
+    hp_num_trials: int = field(
+        default=0,
+        metadata={
+            "help": "How many trials to run during hyperparameter search"
+        }
+    )
+    hp_validation_dataset_pct: float = field(
+        default=0.05,
+        metadata={
+            "help": "Percentage of the validation dataset to use durying hp search"
+        }
+    )
+    hp_compute_objective: Callable = field(
+        default=compute_objective_eval_loss,
+        metadata={
+            "help": "Function that objective to be used in hyperparameter search "
+        }
+    )
+    hp_extra_kwargs: Dict = field(
+        default_factory=dict,
+        metadata={
+            "help": "Dictionary with extra parameters to be passed to "
+                    "`trainer.hyperparameter_search`. Includse arguments to `tune.run`"
         }
     )
 

--- a/projects/transformers/run_utils.py
+++ b/projects/transformers/run_utils.py
@@ -168,10 +168,10 @@ def test_tasks(trainer, output_dir, tasks, test_datasets, is_regression, label_l
                         writer.write(f"{index}\t{item}\n")
 
 
-def evaluate_language_model(trainer, output_dir):
+def evaluate_language_model(trainer, eval_dataset, output_dir):
     """Evaluate language model. Returns dict with results on perplexity metric. """
     results = {}
-    eval_output = trainer.evaluate()
+    eval_output = trainer.evaluate(eval_dataset)
 
     perplexity = math.exp(eval_output["eval_loss"])
     results["perplexity"] = perplexity
@@ -665,12 +665,12 @@ def init_model(model_args, config, tokenizer, finetuning=False):
 
 
 def init_trainer(
-    model,
     tokenizer,
     data_collator,
     training_args,
     train_dataset,
     eval_dataset,
+    model=None,
     trainer_callbacks=None,
     finetuning=False,
     task_name=None,
@@ -688,8 +688,8 @@ def init_trainer(
         model=model,
         args=training_args,
         tokenizer=tokenizer,
-        train_dataset=train_dataset if training_args.do_train else None,
-        eval_dataset=eval_dataset if training_args.do_eval else None,
+        train_dataset=train_dataset,
+        eval_dataset=eval_dataset,
         data_collator=data_collator,
         callbacks=trainer_callbacks,
     )
@@ -861,3 +861,7 @@ def hash_dataset_folder_name(data_args):
     hashed_folder_name = blake2b(dataset_folder.encode(), digest_size=20).hexdigest()
     print(f"Hashing dataset folder name '{dataset_folder}' to '{hashed_folder_name}'")
     return hashed_folder_name
+
+
+def compute_objective_eval_loss(metrics):
+    return metrics["eval_loss"]

--- a/projects/transformers/run_utils.py
+++ b/projects/transformers/run_utils.py
@@ -25,10 +25,12 @@ import logging
 import math
 import os
 from collections import Counter, defaultdict
+from dataclasses import replace
 from functools import partial
 from hashlib import blake2b
 
 import numpy as np
+import torch
 from datasets import concatenate_datasets, load_dataset, load_from_disk
 from datasets.dataset_dict import DatasetDict
 from scipy.stats import pearsonr, spearmanr
@@ -55,10 +57,12 @@ __all__ = [
     "init_datasets_mlm",
     "init_datasets_task",
     "init_model",
+    "init_teacher_models",
     "init_tokenizer",
     "init_trainer",
     "preprocess_datasets_mlm",
     "preprocess_datasets_task",
+    "run_hyperparameter_search",
     "test_tasks",
     "train",
 ]
@@ -861,6 +865,96 @@ def hash_dataset_folder_name(data_args):
     hashed_folder_name = blake2b(dataset_folder.encode(), digest_size=20).hexdigest()
     print(f"Hashing dataset folder name '{dataset_folder}' to '{hashed_folder_name}'")
     return hashed_folder_name
+
+
+def init_teacher_models(model_args, tokenizer):
+    """Initialize and return list of teacher models"""
+
+    teacher_models = []
+    for model_name_or_path in model_args.teacher_models_name_or_path:
+        teacher_args = replace(model_args, model_name_or_path=model_name_or_path)
+        teacher_config = init_config(teacher_args)
+        teacher_models.append(init_model(teacher_args, teacher_config, tokenizer))
+
+    logging.info(f"{len(teacher_models)} teacher models initialized.")
+
+    return teacher_models
+
+
+def run_hyperparameter_search(
+    model_args,
+    config,
+    tokenizer,
+    data_collator,
+    training_args,
+    train_dataset,
+    eval_dataset,
+):
+    """
+    Run hyperparameter search using Ray Tune
+    Not tested when using multiple instances with torch.distributed.launch
+    """
+
+    model_args.trainer_extra_kwargs.update(
+        model_init=partial(init_model, model_args, config, tokenizer, False)
+    )
+    training_args.load_best_model_at_end = True
+    training_args.disable_tqdm = True
+    # TODO: sync metric_for_best_model with compute_objective, should be same metric
+    # and accept custom metrics defined by user
+    training_args.metric_for_best_model = "eval_loss"
+    # TODO: load best model and proceed to evaluation normally after hp search
+    training_args.do_eval = False
+    training_args.do_predict = False
+
+    # Get fraction of the validation dataset to use in hp search
+    hp_eval_dataset = eval_dataset.shard(
+        index=1, num_shards=int(1 / model_args.hp_validation_dataset_pct)
+    )
+
+    trainer = init_trainer(
+        tokenizer=tokenizer,
+        data_collator=data_collator,
+        training_args=training_args,
+        train_dataset=train_dataset,
+        eval_dataset=hp_eval_dataset,
+        trainer_class=model_args.trainer_class,
+        trainer_extra_kwargs=model_args.trainer_extra_kwargs,
+        trainer_callbacks=model_args.trainer_callbacks or None,
+    )
+
+    hp_search_kwargs = dict(
+        direction="maximize",
+        backend="ray",
+        n_trials=model_args.hp_num_trials,
+        hp_space=model_args.hp_space,
+        compute_objective=model_args.hp_compute_objective,
+        local_dir=training_args.output_dir,
+        resources_per_trial=dict(
+            cpu=os.cpu_count() / torch.cuda.device_count() - 1,
+            gpu=1
+        ),
+        checkpoint_freq=0,
+        keep_checkpoints_num=0,
+        checkpoint_at_end=False,
+    )
+    # Update any extra kwargs defined in config
+    hp_search_kwargs.update(**model_args.hp_extra_kwargs)
+
+    # Run hp search and save results
+    best_run = trainer.hyperparameter_search(**hp_search_kwargs)
+    logging.info(f"Best run: {best_run}")
+
+    hp_res_file = os.path.join(training_args.output_dir, "hp_search_results.txt")
+    if trainer.is_world_process_zero():
+        with open(hp_res_file, "w") as writer:
+            writer.write("Hyperparameter search best run:\n")
+            writer.write(f"run_id = {best_run.run_id}\n")
+            writer.write(f"{training_args.metric_for_best_model}")
+            writer.write(f"= {best_run.objective}\n")
+            writer.write(f"\nHyperparameters:\n")
+            for key, value in sorted(best_run.hyperparameters.items()):
+                writer.write(f"{key} = {value}\n")
 
 
 def compute_objective_eval_loss(metrics):

--- a/projects/transformers/scripts/dataloading_utils.py
+++ b/projects/transformers/scripts/dataloading_utils.py
@@ -1,0 +1,170 @@
+#  Numenta Platform for Intelligent Computing (NuPIC)
+#  Copyright (C) 2021, Numenta, Inc.  Unless you have an agreement
+#  with Numenta, Inc., for a separate license for this software code, the
+#  following terms and conditions apply:
+#
+#  This program is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU Affero Public License version 3 as
+#  published by the Free Software Foundation.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#  See the GNU Affero Public License for more details.
+#
+#  You should have received a copy of the GNU Affero Public License
+#  along with this program.  If not, see http://www.gnu.org/licenses.
+#
+#  http://numenta.org/licenses/
+#
+
+"""Dataloading functions"""
+
+import functools
+import os
+from collections import namedtuple
+from hashlib import blake2b
+
+import torch
+import transformers
+from datasets import load_from_disk
+from torch.utils.data.dataloader import DataLoader
+from torch.utils.data.sampler import RandomSampler
+from transformers import AutoTokenizer
+
+
+def get_dataset_wkbc():
+    """Returns a dataloader with customized 1% wikipedia + 8% book corpus dataset"""
+
+    # define data args
+    data_args = dict(
+        max_seq_length=128,
+        dataset_name=("wikipedia_plus_bookcorpus",),
+        dataset_config_name=(None,),
+        tokenized_data_cache_dir="/mnt/efs/results/preprocessed-datasets/text",
+        pad_to_max_length=False,
+        data_collator="DataCollatorForWholeWordMask",
+        mlm_probability=0.15,
+    )
+    data_args = namedtuple("data_args", data_args)(**data_args)
+
+    # load tokenized dataset
+    dataset_folder = hash_dataset_folder_name(data_args)
+    dataset_path = os.path.join(
+        os.path.abspath(data_args.tokenized_data_cache_dir), str(dataset_folder)
+    )
+    tokenized_datasets = load_from_disk(dataset_path)
+
+    # load tokenizer
+    tokenizer_kwargs = dict(
+        revision="main",
+        cache_dir="/mnt/efs/results/pretrained-models/huggingface",
+        use_fast=True,
+        use_auth_token=False,
+    )
+    tokenizer = AutoTokenizer.from_pretrained("bert-base-cased", **tokenizer_kwargs)
+
+    # load data collator
+    data_collator = getattr(transformers, data_args.data_collator)(
+        tokenizer=tokenizer, mlm_probability=data_args.mlm_probability
+    )
+
+    print("Dataset loaded.")
+
+    DataAttributes = namedtuple(
+        "DataAttributes",
+        ["train_dataset", "eval_dataset", "data_collator", "tokenizer"]
+    )
+    data_attributes = DataAttributes(
+        tokenized_datasets["train"],
+        tokenized_datasets["validation"],
+        data_collator,
+        tokenizer,
+    )
+
+    return data_attributes
+
+
+def get_dataloader_wkbc(batch_size=32, load_validation_dataloader=False):
+    """Returns a dataloader with customized 1% wikipedia + 8% book corpus dataset"""
+
+    data_attrs = get_dataset_wkbc()
+
+    train_dataloader = DataLoader(
+        data_attrs.train_dataset,
+        batch_size=batch_size,
+        collate_fn=data_attrs.data_collator,
+        sampler=RandomSampler(data_attrs.train_dataset)
+    )
+    if load_validation_dataloader:
+        eval_dataloader = DataLoader(
+            data_attrs.eval_dataset,
+            batch_size=batch_size,
+            collate_fn=data_attrs.data_collator,
+        )
+        return train_dataloader, eval_dataloader
+    else:
+        return train_dataloader
+
+
+def hash_dataset_folder_name(data_args):
+    """
+    Creates a hashed name for the dataset folder comprised of the dataset_name and
+    dataset_name_config. As well, the following data_args are included unless their
+    default values are used.
+        - max_seq_length (default None)
+
+    More arguments can be added to the hashed name as needed.
+    """
+    defaults = dict(
+        max_seq_length=None,
+    )
+
+    dataset_folder = "-".join([
+        f"{name}_{config}" for name, config in
+        zip(data_args.dataset_name, data_args.dataset_config_name)
+    ])
+
+    for arg, default in defaults.items():
+        if getattr(data_args, arg) != default:
+            non_default = getattr(data_args, arg)
+            dataset_folder += f" ({arg}={non_default})"
+
+    hashed_folder_name = blake2b(dataset_folder.encode(), digest_size=20).hexdigest()
+    print(f"Hashing dataset folder name '{dataset_folder}' to '{hashed_folder_name}'")
+    return hashed_folder_name
+
+
+def resize_position_embeddings(model, new_seq_length):
+    """
+    Resizes model's position embeddings matrices if the size of max position embedding
+    doesn't match new sequence length.
+    (size of position embedding equals size of the attention window)
+
+    :param :new_seq_length Tokenizer sequence length.
+    """
+
+    # Functions to recursively get and set attributes. Source:
+    # https://stackoverflow.com/questions/31174295/getattr-and-setattr-on-nested-subobjects-chained-properties  # noqa: E501
+    def rsetattr(obj, attr, val):
+        pre, _, post = attr.rpartition(".")
+        return setattr(rgetattr(obj, pre) if pre else obj, post, val)
+
+    def rgetattr(obj, attr, *args):
+        def _getattr(obj, attr):
+            return getattr(obj, attr, *args)
+
+        return functools.reduce(_getattr, [obj] + attr.split("."))
+
+    # Find and replace all position embeddings if the size of position embedding
+    # doesn't match new sequence length
+    for module_name, module in model.named_modules():
+        if "position_embeddings" in module_name:
+            original_embed_data = module.weight.data
+            max_position_embeddings, embed_hidden_size = original_embed_data.size()
+            if max_position_embeddings != new_seq_length:
+                new_embed = torch.nn.Embedding(new_seq_length, embed_hidden_size)
+                new_embed.weight.data[:, :] = original_embed_data[:new_seq_length, :]
+                rsetattr(model, module_name, new_embed)
+
+    return model

--- a/projects/transformers/scripts/hpsearch_test.py
+++ b/projects/transformers/scripts/hpsearch_test.py
@@ -1,0 +1,150 @@
+#  Numenta Platform for Intelligent Computing (NuPIC)
+#  Copyright (C) 2021, Numenta, Inc.  Unless you have an agreement
+#  with Numenta, Inc., for a separate license for this software code, the
+#  following terms and conditions apply:
+#
+#  This program is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU Affero Public License version 3 as
+#  published by the Free Software Foundation.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#  See the GNU Affero Public License for more details.
+#
+#  You should have received a copy of the GNU Affero Public License
+#  along with this program.  If not, see http://www.gnu.org/licenses.
+#
+#  http://numenta.org/licenses/
+#
+
+from ray import tune
+from transformers import (
+    AutoConfig,
+    AutoModelForMaskedLM,
+    BertConfig,
+    Trainer,
+    TrainingArguments,
+)
+
+from dataloading_utils import get_dataset_wkbc, resize_position_embeddings
+
+if __name__ == "__main__":
+
+    # ------- Prepare Data
+    data_attrs = get_dataset_wkbc()
+    print(f"train dataset size: {len(data_attrs.train_dataset):,}", )
+    print(f"eval dataset size: {len(data_attrs.eval_dataset):,}")
+
+    # ------- Prepare Model
+
+    def model_init():
+        config_kwargs = dict(
+            num_hidden_layers=2,
+            num_attention_heads=2,
+            hidden_size=128,
+            intermediate_size=512,
+            vocab_size=28996,
+            max_position_embeddings=128,
+        )
+        config = BertConfig(**config_kwargs)
+        return AutoModelForMaskedLM.from_config(config)
+
+    def model_init_pretrained():
+        # load a a
+        model_name_or_path = (
+            "/mnt/efs/results/pretrained-models/transformers-local/bert_1mi"
+        )
+        teacher_config = AutoConfig.from_pretrained(
+            model_name_or_path, revision="main", use_auth_token=False,
+            local_files_only=True
+        )
+        teacher_model = AutoModelForMaskedLM.from_pretrained(
+            model_name_or_path, config=teacher_config, use_auth_token=False
+        )
+        teacher_model = resize_position_embeddings(teacher_model, new_seq_length=128)
+        return teacher_model
+
+    # def compute_metrics(ep):
+    #     """
+    #     The function that will be used to compute metrics at evaluation. Must take a
+    #     :class:`~transformers.EvalPrediction` and return a dictionary string to metric
+    #     values.
+    #     """
+    #     return {"accuracy": (ep.preds == ep.labels).astype(np.float32).mean().item()}
+
+    # Evaluate during training and a bit more often than the default to be able to
+    # prune bad trials early. Disabling tqdm is a matter of preference.
+    training_args = TrainingArguments(
+        eval_accumulation_steps=None,  # required?
+        dataloader_drop_last=True,
+        overwrite_output_dir=True,
+        per_device_train_batch_size=8,
+        per_device_eval_batch_size=8,
+        warmup_steps=20,
+        max_steps=100,
+        do_train=True,
+        do_eval=False,
+        do_predict=False,
+        output_dir="./",
+        disable_tqdm=True,
+        load_best_model_at_end=True,  # will assign to self.model,
+        # metric_for_best_model="accuracy",
+        # evaluate_during_training=True  # not available in recent
+    )
+
+    # Create Trainer
+    trainer = Trainer(
+        args=training_args,
+        model_init=model_init_pretrained,
+        # compute_metrics=compute_metrics,
+        tokenizer=data_attrs.tokenizer,
+        train_dataset=data_attrs.train_dataset,
+        eval_dataset=data_attrs.eval_dataset.shard(index=1, num_shards=100),
+        data_collator=data_attrs.data_collator,
+    )
+
+    # ------- Optimization
+
+    def hp_space(trial):
+        return dict(
+            learning_rate=tune.loguniform(1e-4, 1e-2),
+        )
+
+    # def compute_objective(metrics):
+    #     """
+    #     The default objective to maximize/minimize when doing an hyperparameter search
+    #     It is the evaluation loss if no metrics are provided to the
+    #     :class:`~transformers.Trainer`, the sum of all metrics otherwise.
+
+    #     Args:
+    #         metrics (:obj:`Dict[str, float]`): The metrics returned by evaluate method
+
+    #     Return:
+    #         :obj:`float`: The objective to minimize or maximize
+    #     """
+    #     return metrics["accuracy"]
+
+    def custom_compute_objective(metrics):
+        return metrics["eval_loss"]
+
+    # this is opposed to run
+    # if I do hp search, this goes in place of the best evaluation
+
+    # use sharding to evaluate faster
+
+    best_trial = trainer.hyperparameter_search(
+        direction="maximize",
+        backend="ray",
+        n_trials=3,  # number of hyperparameter samples
+        hp_space=hp_space,
+        compute_objective=custom_compute_objective,
+        # other parameters:
+        # https://docs.ray.io/en/latest/tune/api_docs/suggestion.html
+        # search_alg=ray.tune.suggest.hyperopt.HyperOptSearch(),
+        # https://docs.ray.io/en/latest/tune/api_docs/schedulers.html
+        # scheduler=AsyncHyperBand(),  # aggressive termination of trials
+        # n_jobs=4,  # number of parallel jobs, if multiple GPUs
+    )
+
+    print(best_trial)

--- a/projects/transformers/scripts/kd_test.py
+++ b/projects/transformers/scripts/kd_test.py
@@ -17,46 +17,11 @@
 #
 #  http://numenta.org/licenses/
 #
-import functools
-import os
-from collections import namedtuple
-from hashlib import blake2b
-
 import torch
 import torch.nn.functional as F
-import transformers
-from datasets import load_from_disk
-from torch.utils.data.dataloader import DataLoader
-from torch.utils.data.sampler import RandomSampler
-from transformers import AutoConfig, AutoModelForMaskedLM, AutoTokenizer, BertConfig
+from transformers import AutoConfig, AutoModelForMaskedLM, BertConfig
 
-
-def hash_dataset_folder_name(data_args):
-    """
-    Creates a hashed name for the dataset folder comprised of the dataset_name and
-    dataset_name_config. As well, the following data_args are included unless their
-    default values are used.
-        - max_seq_length (default None)
-
-    More arguments can be added to the hashed name as needed.
-    """
-    defaults = dict(
-        max_seq_length=None,
-    )
-
-    dataset_folder = "-".join([
-        f"{name}_{config}" for name, config in
-        zip(data_args.dataset_name, data_args.dataset_config_name)
-    ])
-
-    for arg, default in defaults.items():
-        if getattr(data_args, arg) != default:
-            non_default = getattr(data_args, arg)
-            dataset_folder += f" ({arg}={non_default})"
-
-    hashed_folder_name = blake2b(dataset_folder.encode(), digest_size=20).hexdigest()
-    print(f"Hashing dataset folder name '{dataset_folder}' to '{hashed_folder_name}'")
-    return hashed_folder_name
+from dataloading_utils import get_dataloader_wkbc, resize_position_embeddings
 
 
 def soft_cross_entropy_masked(output, target, padding_mask):
@@ -153,83 +118,10 @@ def calculate_batch_acc(batch, outputs):
     return total_correct / total_predicted
 
 
-def resize_position_embeddings(model, new_seq_length):
-    """
-    Resizes model's position embeddings matrices if the size of max position embedding
-    doesn't match new sequence length.
-    (size of position embedding equals size of the attention window)
-
-    :param :new_seq_length Tokenizer sequence length.
-    """
-
-    # Functions to recursively get and set attributes. Source:
-    # https://stackoverflow.com/questions/31174295/getattr-and-setattr-on-nested-subobjects-chained-properties  # noqa: E501
-    def rsetattr(obj, attr, val):
-        pre, _, post = attr.rpartition(".")
-        return setattr(rgetattr(obj, pre) if pre else obj, post, val)
-
-    def rgetattr(obj, attr, *args):
-        def _getattr(obj, attr):
-            return getattr(obj, attr, *args)
-
-        return functools.reduce(_getattr, [obj] + attr.split("."))
-
-    # Find and replace all position embeddings if the size of position embedding
-    # doesn't match new sequence length
-    for module_name, module in model.named_modules():
-        if "position_embeddings" in module_name:
-            original_embed_data = module.weight.data
-            max_position_embeddings, embed_hidden_size = original_embed_data.size()
-            if max_position_embeddings != new_seq_length:
-                new_embed = torch.nn.Embedding(new_seq_length, embed_hidden_size)
-                new_embed.weight.data[:, :] = original_embed_data[:new_seq_length, :]
-                rsetattr(model, module_name, new_embed)
-
-    return model
-
-
 if __name__ == "__main__":
 
-    # ----- load datasets, tokenizer, data collator and data loader
-    # define data args
-    data_args = dict(
-        max_seq_length=128,
-        dataset_name=("wikipedia_plus_bookcorpus",),
-        dataset_config_name=(None,),
-        tokenized_data_cache_dir="/mnt/efs/results/preprocessed-datasets/text",
-        pad_to_max_length=False,
-        data_collator="DataCollatorForWholeWordMask",
-        mlm_probability=0.15,
-    )
-    data_args = namedtuple("data_args", data_args)(**data_args)
-
-    # load tokenized dataset
-    dataset_folder = hash_dataset_folder_name(data_args)
-    dataset_path = os.path.join(
-        os.path.abspath(data_args.tokenized_data_cache_dir), str(dataset_folder)
-    )
-    tokenized_datasets = load_from_disk(dataset_path)
-
-    # load tokenizer
-    tokenizer_kwargs = dict(
-        revision="main",
-        cache_dir="/mnt/efs/results/pretrained-models/huggingface",
-        use_fast=True,
-        use_auth_token=False,
-    )
-    tokenizer = AutoTokenizer.from_pretrained("bert-base-cased", **tokenizer_kwargs)
-
-    # load data collator
-    data_collator = getattr(transformers, data_args.data_collator)(
-        tokenizer=tokenizer, mlm_probability=data_args.mlm_probability
-    )
-
-    # load dataloader
-    dataset = tokenized_datasets["train"]
-    dataloader = DataLoader(
-        dataset, batch_size=32, collate_fn=data_collator, sampler=RandomSampler(dataset)
-    )
-    print("Data utilities loaded.")
+    # load data
+    dataloader = get_dataloader_wkbc(batch_size=32)
 
     # ----- load models
     # load student model


### PR DESCRIPTION
Experimental hyperparameter search in pretraining using ray tune. Not polished, but it works, so I thought it would be best to push it so others can use it and possibly improve it. 

It includes:
- Run hyperparameter search with ray. See debug_hp_search in experiments/hpsearch.py for an example.
- Saves best results to a txt file in output dir, also logs to console. As a todo, we should save this in a more easy to handle format (csv?). Ray should also have the results of hp search in a better format. 
- Save results to same output dir, under a subdir structure defined in `transformers.trainer_utils.run_hp_search_ray`. If this structure is not ideal we can redefine that method.
- Results are being saved in wandb, but we might want to change how they are saved (such as the experiment name) for better organization

Pending:
- Loading best model after hp search is not working (see todo). My plan is to load the best model at the end, and then run the evaluation normally in the full dataset. I will work on that next.
- Didn't test with  multiple instances
- Haven't experimented with other objectives other than eval_loss
