### PR TITLE
Address issues with wandb early init as well as transformers dependencies 

### DIFF
--- a/projects/transformers/integrations.py
+++ b/projects/transformers/integrations.py
@@ -79,52 +79,6 @@ class CustomWandbCallback(WandbCallback):
 
         return wandb.run.id
 
-    def setup(self, args, state, model, reinit, **kwargs):
-        """
-        Setup the optional Weights & Biases (`wandb`) integration.
-        """
-        if self._wandb is None:
-            return
-
-        self._initialized = True
-        if state.is_world_process_zero:
-            logger.info(
-                "Automatic Weights & Biases logging enabled, "
-                "to disable set os.environ['WANDB_DISABLED'] = 'true'"
-            )
-            combined_dict = {**args.to_sanitized_dict()}
-
-            if hasattr(model, "config") and model.config is not None:
-                model_config = model.config.to_dict()
-                combined_dict = {**model_config, **combined_dict}
-
-            trial_name = state.trial_name
-            init_args = {}
-            if trial_name is not None:
-                run_name = trial_name
-                init_args["group"] = args.run_name
-            else:
-                run_name = args.run_name
-
-            if reinit or wandb.run is None:
-                self._wandb.init(
-                    project=os.getenv("WANDB_PROJECT", "huggingface"),
-                    config=combined_dict,
-                    name=run_name,
-                    reinit=reinit,
-                    **init_args,
-                )
-            else:
-                wandb.config.update(combined_dict)
-
-            # keep track of model topology and gradients, unsupported on TPU
-            if not is_torch_tpu_available() and os.getenv("WANDB_WATCH") != "false":
-                self._wandb.watch(
-                    model,
-                    log=os.getenv("WANDB_WATCH", "gradients"),
-                    log_freq=max(100, args.logging_steps)
-                )
-
     def on_evaluate(self, args, state, control, metrics=None, **kwargs):
         """
         Add the following logs to the run summary

--- a/projects/transformers/integrations.py
+++ b/projects/transformers/integrations.py
@@ -26,7 +26,6 @@ import wandb
 from transformers.integrations import (
     INTEGRATION_TO_CALLBACK,
     WandbCallback,
-    is_torch_tpu_available,
     is_wandb_available,
     logger,
 )

--- a/projects/transformers/requirements.txt
+++ b/projects/transformers/requirements.txt
@@ -20,6 +20,9 @@
 #
 # ------------------------------------------------------------------------------
 # Run pip install -r requirements.txt to reproduce the currently tested environment
-# Last update: 2/17/2021
--e git+https://github.com/huggingface/transformers@e94d63f6cbf5efe288e41d9840a96a5857090617#egg=transformers
--e git+https://github.com/huggingface/datasets@58555b2734b8a18d70b5a2418129f26fedd96a39#egg=datasets
+# Last update: 3/29/2021
+
+git+git:https://github.com/huggingface/transformers@master#egg=transformers
+datasets>=1.5.0
+torch>=1.8.1
+wandb>=0.10.23

--- a/projects/transformers/requirements.txt
+++ b/projects/transformers/requirements.txt
@@ -26,3 +26,5 @@ git+git:https://github.com/huggingface/transformers@master#egg=transformers
 datasets>=1.5.0
 torch>=1.8.1
 wandb>=0.10.23
+ray>=1.2.0
+pickle5>=0.0.11

--- a/projects/transformers/run.py
+++ b/projects/transformers/run.py
@@ -48,6 +48,7 @@ from transformers import (
     default_data_collator,
     set_seed,
 )
+from transformers.integrations import is_wandb_available
 from transformers.trainer_utils import get_last_checkpoint, is_main_process
 
 from experiments import CONFIGS
@@ -105,7 +106,7 @@ def main():
 
         # Initialize wandb now to include the logs that follow.
         # For now, only support early wandb logging when running one experiment.
-        if len(cmd_args.experiments) == 1:
+        if is_wandb_available() and len(cmd_args.experiments) == 1:
             CustomWandbCallback.early_init(training_args, local_rank)
 
         # Detecting last checkpoint.


### PR DESCRIPTION
This fixes a bug where run.py tries to initialize wandb even if it's not installed. This also updates the wandb callback to work with the latest transformers version (`4.5.0.dev0`).

The versions for transformers, datasets, wandb, and torch are now specified in a  `requirements.txt` file so they may all be install via `pip install -r requirements.txt`.

Feedback is welcome on the versions. The goal here is to make sure they are detailed enough to avoid bugs (like the wandb bug addressed in this PR) while still making new transformers and torch features readily available. 