### PR TITLE
OneCycle LR & RigL Experiments

### DIFF
--- a/nupic/research/frameworks/dynamic_sparse/__init__.py
+++ b/nupic/research/frameworks/dynamic_sparse/__init__.py
@@ -1,0 +1,23 @@
+# ----------------------------------------------------------------------
+# Numenta Platform for Intelligent Computing (NuPIC)
+# Copyright (C) 2021, Numenta, Inc.  Unless you have an agreement
+# with Numenta, Inc., for a separate license for this software code, the
+# following terms and conditions apply:
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# See the GNU Affero Public License for more details.
+#
+# You should have received a copy of the GNU Affero Public License
+# along with this program.  If not, see http://www.gnu.org/licenses.
+#
+# http://numenta.org/licenses/
+# ----------------------------------------------------------------------
+
+from .global_pruning import *
+from .prune_scheduler import *

--- a/nupic/research/frameworks/dynamic_sparse/global_pruning.py
+++ b/nupic/research/frameworks/dynamic_sparse/global_pruning.py
@@ -24,12 +24,12 @@ from torch.nn.utils import parameters_to_vector
 from nupic.research.frameworks.pytorch.mask_utils import get_topk_submask
 
 __all__ = [
-    "global_prune_by_weight",
-    "global_add_by_grad",
+    "global_prune_by_abs_weight",
+    "global_add_by_abs_grad",
 ]
 
 
-def global_prune_by_weight(sparse_modules, prune_fraction):
+def global_prune_by_abs_weight(sparse_modules, prune_fraction):
     """
     Globally prune 'num_remove' weights from a list of sparse modules by ranking and
     selecting the top absolute weights. Modules are pruned adjusting their `zero_masks`;
@@ -71,7 +71,7 @@ def global_prune_by_weight(sparse_modules, prune_fraction):
     return num_remove
 
 
-def global_add_by_grad(sparse_modules, num_add):
+def global_add_by_abs_grad(sparse_modules, num_add):
     """
     Adds weights globally (among all given sparse modules) by ranking and selecting the
     top absolute gradients. Weights are added by adjusting the `zero_masks` of their

--- a/nupic/research/frameworks/dynamic_sparse/global_pruning.py
+++ b/nupic/research/frameworks/dynamic_sparse/global_pruning.py
@@ -1,0 +1,103 @@
+# ----------------------------------------------------------------------
+# Numenta Platform for Intelligent Computing (NuPIC)
+# Copyright (C) 2021, Numenta, Inc.  Unless you have an agreement
+# with Numenta, Inc., for a separate license for this software code, the
+# following terms and conditions apply:
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# See the GNU Affero Public License for more details.
+#
+# You should have received a copy of the GNU Affero Public License
+# along with this program.  If not, see http://www.gnu.org/licenses.
+#
+# http://numenta.org/licenses/
+# ----------------------------------------------------------------------
+
+from torch.nn.utils import parameters_to_vector
+
+from nupic.research.frameworks.pytorch.mask_utils import get_topk_submask
+
+__all__ = [
+    "global_prune_by_weight",
+    "global_add_by_grad",
+]
+
+
+def global_prune_by_weight(sparse_modules, prune_fraction):
+    """
+    Globally prune 'num_remove' weights from a list of sparse modules by ranking and
+    selecting the top absolute weights. Modules are pruned adjusting their `zero_masks`;
+    switching off the weight occurs by changing 0 to 1. Be sure to call
+    `rezero_weights` following this function to zero out the pruned weights.
+
+    :param sparse_modules: list of modules of type SparseWeightsBase
+    :param prune_fraction: fraction of weights to prune; between 0 and 1
+    """
+    assert 0 <= prune_fraction <= 1
+
+    # Flatten parameters to compare them all at once for global pruningn.
+    flattened_params = parameters_to_vector([m.weight for m in sparse_modules])
+    flattened_off_mask = parameters_to_vector([m.zero_mask for m in sparse_modules])
+    flattened_on_mask = ~flattened_off_mask.bool()
+
+    # Calculate the number of parameters to keep.
+    total_on = flattened_on_mask.sum().item()
+    num_remove = int(round(total_on * prune_fraction))
+    num_keep = total_on - num_remove
+
+    # Prune by only keeping the top weights ranked by their absolute values.
+    topk_mask = get_topk_submask(
+        k=num_keep,
+        values=flattened_params.abs(),
+        mask=flattened_on_mask,
+        largest=True
+    )
+
+    # Pointer for slicing the mask to match the shape of each parameter
+    pointer = 0
+    for module in sparse_modules:
+
+        num_params = module.weight.numel()
+        keep_mask = topk_mask[pointer: pointer + num_params].view_as(module.weight)
+        module.zero_mask[:] = ~keep_mask
+        pointer += num_params
+
+    return num_remove
+
+
+def global_add_by_grad(sparse_modules, num_add):
+    """
+    Adds weights globally (among all given sparse modules) by ranking and selecting the
+    top absolute gradients. Weights are added by adjusting the `zero_masks` of their
+    modules; switching on the weight occurs by changing 1 to 0. Be sure to call
+    `rezero_weights` following this function to initialize the new weights to zero.
+
+    :param sparse_modules: list of modules of type SparseWeightsBase
+    :param num_add: number of weights to add
+    """
+
+    flattened_grads = parameters_to_vector([m.weight.grad for m in sparse_modules])
+    flattened_mask = parameters_to_vector([m.zero_mask for m in sparse_modules]).bool()
+
+    # Find a mask of the top grads for weights that are currently off.
+    topk_mask = get_topk_submask(
+        k=num_add,
+        values=flattened_grads.abs(),
+        mask=flattened_mask,
+        largest=True
+    )
+
+    # Pointer for slicing the mask to match the shape of each parameter.
+    pointer = 0
+    for module in sparse_modules:
+
+        num_params = module.weight.numel()
+        add_mask = topk_mask[pointer: pointer + num_params].view_as(module.weight)
+        module.zero_mask[add_mask] = 0
+        pointer += num_params

--- a/nupic/research/frameworks/dynamic_sparse/global_pruning.py
+++ b/nupic/research/frameworks/dynamic_sparse/global_pruning.py
@@ -41,7 +41,7 @@ def global_prune_by_abs_weight(sparse_modules, prune_fraction):
     """
     assert 0 <= prune_fraction <= 1
 
-    # Flatten parameters to compare them all at once for global pruningn.
+    # Flatten parameters to compare them all at once for global pruning.
     flattened_params = parameters_to_vector([m.weight for m in sparse_modules])
     flattened_off_mask = parameters_to_vector([m.zero_mask for m in sparse_modules])
     flattened_on_mask = ~flattened_off_mask.bool()

--- a/nupic/research/frameworks/dynamic_sparse/prune_scheduler.py
+++ b/nupic/research/frameworks/dynamic_sparse/prune_scheduler.py
@@ -1,0 +1,93 @@
+# ----------------------------------------------------------------------
+# Numenta Platform for Intelligent Computing (NuPIC)
+# Copyright (C) 2021, Numenta, Inc.  Unless you have an agreement
+# with Numenta, Inc., for a separate license for this software code, the
+# following terms and conditions apply:
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# See the GNU Affero Public License for more details.
+#
+# You should have received a copy of the GNU Affero Public License
+# along with this program.  If not, see http://www.gnu.org/licenses.
+#
+# http://numenta.org/licenses/
+# ----------------------------------------------------------------------
+
+import abc
+
+import numpy as np
+
+__all__ = [
+    "PruneSchedulerBase",
+    "CosineDecayPruneScheduler",
+]
+
+
+class PruneSchedulerBase(object, metaclass=abc.ABCMeta):
+    """
+    This class calculates a pruning schedule through the methods
+        * `get_prune_fraction`
+        * `get_num_add`
+    """
+    def __init__(self):
+        # Keep track of the number of cycles of pruning.
+        self._step_count = 0
+
+    @abc.abstractclassmethod
+    def get_prune_fraction(self):
+        """
+        Retrieve percentage of weights to prune.
+
+        :return: pruning rate (between 0 and 1)
+        """
+        raise NotImplementedError
+
+    @abc.abstractclassmethod
+    def get_num_add(self, num_removed):
+        """
+        Retrieve number of weights to add following pruning.
+
+        :param num_removed: number of param removed in pruning step
+
+        :return type: int
+        """
+        raise NotImplementedError
+
+    def step(self):
+        self._step_count += 1
+
+
+class CosineDecayPruneScheduler(PruneSchedulerBase):
+    """
+    This class enables a tapering of an initial pruning-rate while
+    `get_num_add` always returns how much has been removed.
+
+    :param prune_fraction: starting pruning rate between 0 and 1
+    :param total_steps: total number of steps of training; this can be
+                        training iterations or epochs depending on how often the user
+                        calls self.step()
+    :param warmup_steps: how many steps to wait before pruning starts
+    """
+    def __init__(self, prune_fraction, total_steps, warmup_steps=0):
+        super().__init__()
+        self.prune_fraction = prune_fraction
+        self.total_steps = total_steps - warmup_steps
+        self.warmup_steps = warmup_steps
+
+    def get_prune_fraction(self):
+        step_count = self._step_count - self.warmup_steps
+        if step_count < 0:
+            return 0
+
+        return 0.5 * self.prune_fraction * (
+            1 + np.cos((step_count * np.pi) / (self.total_steps - 1))
+        )
+
+    def get_num_add(self, num_removed):
+        return num_removed

--- a/projects/transformers/callbacks/sparsity.py
+++ b/projects/transformers/callbacks/sparsity.py
@@ -173,7 +173,7 @@ class RigLCallback(TrainerCallback):
 
         # Log pruning stats.
         actual_pruned = param_sparsity1 - param_sparsity0
-        actual_pruned_on_params = actual_pruned / mask_sparsity0
+        actual_pruned_on_params = actual_pruned / (1 - mask_sparsity0)
 
         logging.info(f"RigLCallback:")
         logging.info(f"Target: remove {prune_fraction} frac of on params")
@@ -182,9 +182,9 @@ class RigLCallback(TrainerCallback):
         # For now, the logs are very robust to ensure pruning occurs as expected.
         logs = dict({
             "rigl/target_pruned_on_params": prune_fraction,
-            "rigl/actual_pruned_on_params": actual_pruned / mask_sparsity0,
-            "rigl/target_pruned_total_params": prune_fraction * mask_sparsity0,
-            "rigl/actual_pruned_total_params": actual_pruned,
+            "rigl/actual_pruned_on_params": actual_pruned_on_params,
+            "rigl/target_pruned_all_params": prune_fraction * mask_sparsity0,
+            "rigl/actual_pruned_all_params": actual_pruned,
             "rigl/pre_prune_param_sparsity": param_sparsity0,
             "rigl/pre_prune_mask_sparsity": mask_sparsity0,
             "rigl/post_prune_param_sparsity": param_sparsity1,

--- a/projects/transformers/callbacks/sparsity.py
+++ b/projects/transformers/callbacks/sparsity.py
@@ -21,18 +21,36 @@
 
 import logging
 
+import matplotlib.pyplot as plt
+import seaborn as sns
+import torch
 import wandb
+from pandas import DataFrame
 from transformers import TrainerCallback
 
-from nupic.research.frameworks.pytorch.model_utils import count_nonzero_params
-from nupic.torch.modules import rezero_weights
+from nupic.research.frameworks.dynamic_sparse import (
+    CosineDecayPruneScheduler,
+    global_add_by_grad,
+    global_prune_by_weight,
+)
+from nupic.research.frameworks.pytorch.model_utils import (
+    count_nonzero_params,
+    filter_modules,
+)
+from nupic.torch.modules.sparse_weights import SparseWeightsBase, rezero_weights
 
 __all__ = [
     "RezeroWeightsCallback",
+    "RigLCallback",
+    "PlotDensitiesCallback"
 ]
 
 
 class RezeroWeightsCallback(TrainerCallback):
+    """
+    This rezeros the weights of a sparse model after each iteration and logs the
+    sparsity of the BERT model and its encoder.
+    """
 
     def on_init_end(self, args, state, control, model, **kwargs):
         """Log sparsity of the model and the sparsity of just the encoder."""
@@ -75,3 +93,266 @@ class RezeroWeightsCallback(TrainerCallback):
             )
 
             wandb.log(logs, step=state.global_step)
+
+
+class RigLCallback(TrainerCallback):
+    """
+    Perform `RigL`_ dynamic sparsity every N steps on the sparse modules within the
+    network. Weights are pruned according to their ranks absolute values and regrowing
+    (adding weights) occurs by ranking their absolute gradients. As per the original
+    paper, the pruning decreases over time according to a cosine decay.
+
+    .. _RigL: https://arxiv.org/abs/1911.11134
+
+    :param prune_fraction: initial fraction of weights to prune
+    :param prune_freq: how often, in iterations, to prune and regrow weights
+    :param warmup_steps: defaults to prune_freq; e.g. prune_freq of 100 will allow 100
+                         steps before pruning for the first time
+    """
+
+    def __init__(
+        self,
+        prune_fraction=0.3,
+        prune_freq=100,
+        warmup_steps=None
+    ):
+        self.prune_fraction = prune_fraction
+        self.prune_freq = prune_freq
+        self.prune_scheduler = None
+        self.warmup_steps = warmup_steps
+
+    def on_init_end(self, args, state, control, model, optimizer=None, **kwargs):
+        """Save a list of the sparse modules and initialize the pruning schedule"""
+
+        warmup_steps = self.warmup_steps or self.prune_freq
+        self.prune_scheduler = CosineDecayPruneScheduler(
+            total_steps=args.max_steps,
+            prune_fraction=self.prune_fraction,
+            warmup_steps=warmup_steps - 1
+        )
+        self.sparse_modules = filter_modules(
+            model, include_modules=[SparseWeightsBase]
+        ).values()
+
+    def on_step_end(
+        self, args, state, control, model=None,
+        train_dataloader=None, optimizer=None, **kwargs
+    ):
+        """Prune and regrow weights every 'prune_freq' iterations."""
+
+        if state.global_step % self.prune_freq != 0:
+            self.prune_scheduler.step()
+            return
+
+        # Pre-prune sparsities.
+        param_sparsity0, mask_sparsity0 = calc_cumulative_sparsity(self.sparse_modules)
+
+        # Prune weights.
+        model.apply(rezero_weights)
+        prune_fraction = self.prune_scheduler.get_prune_fraction()
+        num_removed = global_prune_by_weight(self.sparse_modules, prune_fraction)
+        model.apply(rezero_weights)
+
+        # Post-prune sparsities.
+        param_sparsity1, mask_sparsity1 = calc_cumulative_sparsity(self.sparse_modules)
+
+        # Train for one step.
+        optimizer.zero_grad()
+        train_batch = next(iter(train_dataloader))
+        inputs_to_device(train_batch, device=args.device)
+        output = model(**train_batch)
+        output.loss.backward()
+
+        # Regrow weights
+        num_add = self.prune_scheduler.get_num_add(num_removed)
+        global_add_by_grad(self.sparse_modules, num_add)
+        self.prune_scheduler.step()
+
+        # Post-grow sparsities.
+        param_sparsity2, mask_sparsity2 = calc_cumulative_sparsity(self.sparse_modules)
+
+        # Log pruning stats.
+        actual_pruned = param_sparsity1 - param_sparsity0
+        actual_pruned_on_params = actual_pruned / mask_sparsity0
+
+        logging.info(f"RigLCallback:")
+        logging.info(f"Target: remove {prune_fraction} frac of on params")
+        logging.info(f"Actual: removed {actual_pruned_on_params} fraction of on params")
+
+        # For now, the logs are very robust to ensure pruning occurs as expected.
+        logs = dict({
+            "rigl/target_pruned_on_params": prune_fraction,
+            "rigl/actual_pruned_on_params": actual_pruned / mask_sparsity0,
+            "rigl/target_pruned_total_params": prune_fraction * mask_sparsity0,
+            "rigl/actual_pruned_total_params": actual_pruned,
+            "rigl/pre_prune_param_sparsity": param_sparsity0,
+            "rigl/pre_prune_mask_sparsity": mask_sparsity0,
+            "rigl/post_prune_param_sparsity": param_sparsity1,
+            "rigl/post_prune_mask_sparsity": mask_sparsity1,
+            "rigl/pre_grow_param_sparsity": param_sparsity2,
+            "rigl/post_grow_mask_sparsity": mask_sparsity2,
+        })
+
+        wandb.log(logs, step=state.global_step)
+
+
+class PlotDensitiesCallback(TrainerCallback):
+    """
+    Callback to plot the densities of each layer as well as well as the deltas in the
+    numbers of their on-parameters. This is particularly useful for training dynamic
+    sparse networks where the densities of each layer may change over time.
+
+    :param plot_freq: how often to generate the plots
+    """
+
+    def __init__(self, plot_freq=1000):
+        self.plot_freq = plot_freq
+        self.initial_on_params = dict()  # used to calculate the delta in on-params
+        self.sparse_modules = None
+
+    def on_init_end(self, args, state, control, model=None, **kwargs):
+        """
+        Save a list of all the sparse modules and a dict of their initial densities.
+        """
+        self.sparse_modules = filter_modules(model, include_modules=[SparseWeightsBase])
+        for name, module in self.sparse_modules.items():
+            self.initial_on_params[name] = (module.zero_mask.bool() == 0).sum().item()
+        initial_sparsity = getattr(args, "config_kwargs", {}).get("sparsity", 0)
+        self.initial_density = 1 - initial_sparsity
+
+    def on_step_end(self, args, state, control, model=None, **kwargs):
+        """
+        Plot the densities of each layer and plot the change in on-params of each layer.
+        """
+
+        if state.global_step % self.plot_freq != 0:
+            return
+
+        # Plot densities for each layer.
+        df_dendity_by_layer = get_density_by_layer(self.sparse_modules)
+        fig, ax = plt.subplots(figsize=(8, 5), constrained_layout=True)
+        sns.stripplot(
+            data=df_dendity_by_layer,
+            y="density",
+            x="layer",
+            hue=None,
+            color="firebrick",
+            ax=ax,
+        )
+        ax.axhline(self.initial_density, label="Initial Density")
+        ax.legend(loc="lower center", bbox_to_anchor=(0.2, 0), ncol=2)
+        ax.set_title("Density Per Layer")
+        ax.set_ylim(0, 1)
+        ax.set_xticklabels(
+            ax.get_xticklabels(),
+            rotation=-45,
+            ha="left",
+            rotation_mode="anchor"
+        )
+        plot = wandb.Image(ax)
+        wandb.log({"density_per_layer": plot}, step=state.global_step)
+
+        # Plot plot change in on params for each layer.
+        df_delta_on_params = get_delta_on_params(
+            self.sparse_modules,
+            self.initial_on_params
+        )
+        fig, ax = plt.subplots(figsize=(8, 5), constrained_layout=True)
+        sns.stripplot(
+            data=df_delta_on_params,
+            y="delta_on_params",
+            x="layer",
+            hue=None,
+            color="firebrick",
+            ax=ax,
+        )
+        ax.axhline(0)
+        ax.set_title("Change in On-Params Per Layer")
+        ax.set_ylabel("delta on-params")
+        ax.set_xticklabels(
+            ax.get_xticklabels(),
+            rotation=-45,
+            ha="left",
+            rotation_mode="anchor",
+        )
+        plot = wandb.Image(ax)
+        wandb.log({"delta_on_params": plot}, step=state.global_step)
+
+
+# -------------
+# Utilities
+# -------------
+
+def inputs_to_device(inputs, device):
+    """
+    Prep inputs dict by transferring all inputs to the device.
+    """
+    for k, v in inputs.items():
+        if isinstance(v, torch.Tensor):
+            inputs[k] = v.to(device)
+
+
+def calc_sparsity(tensor):
+    """Calculate the sparsity of a given tensor."""
+    num_zero = (tensor == 0).sum().item()
+    return num_zero / tensor.numel()
+
+
+def calc_model_sparsity(model):
+    """Calculate the sparsity of a given model."""
+    tot, nz = count_nonzero_params(model)
+    sparsity = 1 - nz / tot
+    return sparsity
+
+
+def calc_cumulative_sparsity(sparse_modules):
+    """
+    Calculate the sparsities across a list of sparse modules. Both the weight sparsity
+    and the zero mask sparsity is calculated.
+    """
+    total_off = 0
+    total_zero = 0
+    total_params = 0
+    for m in sparse_modules:
+        total_off += (m.zero_mask != 0).sum().item()
+        total_zero += (m.weight == 0).sum().item()
+        total_params += m.weight.numel()
+
+    mask_sparsity = total_off / total_params
+    param_sparsity = total_zero / total_params
+    return param_sparsity, mask_sparsity
+
+
+def get_density_by_layer(sparse_modules):
+    """
+    This creates a dataframe with entries (layer name, density of layer).
+    """
+    df = DataFrame(columns=["layer", "density"])
+    for n, m in sparse_modules.items():
+
+        subname = ".".join(n.split(".")[3:])
+        layer_name = f"{subname} {tuple(m.weight.shape)}"
+        density = 1 - calc_sparsity(m.weight)
+        df.loc[len(df.index)] = (layer_name, density)
+
+    return df
+
+
+def get_delta_on_params(sparse_modules, initial_on_params):
+    """
+    This creates a dataframe with entries (layer name, change in num on params).
+
+    The initial_on_params is dict that maps the layer name to their initial number of
+    on parameters.
+    """
+    df = DataFrame(columns=["layer", "delta_on_params"])
+    for n, m in sparse_modules.items():
+
+        subname = ".".join(n.split(".")[3:])
+        layer_name = f"{subname} {tuple(m.weight.shape)}"
+
+        on_params = (m.zero_mask.bool() == 0).sum().item()
+        delta = on_params - initial_on_params[n]
+        df.loc[len(df.index)] = (layer_name, delta)
+
+    return df

--- a/projects/transformers/callbacks/sparsity.py
+++ b/projects/transformers/callbacks/sparsity.py
@@ -180,6 +180,7 @@ class RigLCallback(TrainerCallback):
         logging.info(f"Actual: removed {actual_pruned_on_params} fraction of on params")
 
         # For now, the logs are very robust to ensure pruning occurs as expected.
+        # TODO: Remove non-essential logging.
         logs = dict({
             "rigl/target_pruned_on_params": prune_fraction,
             "rigl/actual_pruned_on_params": actual_pruned_on_params,
@@ -192,8 +193,8 @@ class RigLCallback(TrainerCallback):
             "rigl/pre_grow_param_sparsity": param_sparsity2,
             "rigl/post_grow_mask_sparsity": mask_sparsity2,
         })
-
-        wandb.log(logs, step=state.global_step)
+        if wandb.run is not None:
+            wandb.log(logs, step=state.global_step)
 
 
 class PlotDensitiesCallback(TrainerCallback):
@@ -226,6 +227,9 @@ class PlotDensitiesCallback(TrainerCallback):
         """
 
         if state.global_step % self.plot_freq != 0:
+            return
+
+        if wandb.run is None:
             return
 
         # Plot densities for each layer.

--- a/projects/transformers/callbacks/sparsity.py
+++ b/projects/transformers/callbacks/sparsity.py
@@ -30,8 +30,8 @@ from transformers import TrainerCallback
 
 from nupic.research.frameworks.dynamic_sparse import (
     CosineDecayPruneScheduler,
-    global_add_by_grad,
-    global_prune_by_weight,
+    global_add_by_abs_grad,
+    global_prune_by_abs_weight,
 )
 from nupic.research.frameworks.pytorch.model_utils import (
     count_nonzero_params,
@@ -150,7 +150,7 @@ class RigLCallback(TrainerCallback):
         # Prune weights.
         model.apply(rezero_weights)
         prune_fraction = self.prune_scheduler.get_prune_fraction()
-        num_removed = global_prune_by_weight(self.sparse_modules, prune_fraction)
+        num_removed = global_prune_by_abs_weight(self.sparse_modules, prune_fraction)
         model.apply(rezero_weights)
 
         # Post-prune sparsities.
@@ -165,7 +165,7 @@ class RigLCallback(TrainerCallback):
 
         # Regrow weights
         num_add = self.prune_scheduler.get_num_add(num_removed)
-        global_add_by_grad(self.sparse_modules, num_add)
+        global_add_by_abs_grad(self.sparse_modules, num_add)
         self.prune_scheduler.step()
 
         # Post-grow sparsities.

--- a/projects/transformers/callbacks/sparsity.py
+++ b/projects/transformers/callbacks/sparsity.py
@@ -156,7 +156,7 @@ class RigLCallback(TrainerCallback):
         # Post-prune sparsities.
         param_sparsity1, mask_sparsity1 = calc_cumulative_sparsity(self.sparse_modules)
 
-        # Train for one step.
+        # Accumulate gradients over one batch.
         optimizer.zero_grad()
         train_batch = next(iter(train_dataloader))
         inputs_to_device(train_batch, device=args.device)

--- a/projects/transformers/experiments/__init__.py
+++ b/projects/transformers/experiments/__init__.py
@@ -27,8 +27,8 @@ from .base import CONFIGS as BASE
 from .bert_replication import CONFIGS as BERT_REPLICATION
 from .bertitos import CONFIGS as BERTITOS
 from .finetuning import CONFIGS as FINETUNING
+from .rigl_bert import CONFIGS as RIGL_BERT
 from .sparse_bert import CONFIGS as SPARSE_BERT
-from .finetuning import CONFIGS as FINETUNING
 from .distillation import CONFIGS as DISTILLATION
 
 """
@@ -42,6 +42,7 @@ CONFIGS.update(BASE)
 CONFIGS.update(BERT_REPLICATION)
 CONFIGS.update(BERTITOS)
 CONFIGS.update(FINETUNING)
+CONFIGS.update(RIGL_BERT)
 CONFIGS.update(SPARSE_BERT)
 CONFIGS.update(FINETUNING)
 CONFIGS.update(DISTILLATION)

--- a/projects/transformers/experiments/__init__.py
+++ b/projects/transformers/experiments/__init__.py
@@ -26,10 +26,11 @@ import models
 from .base import CONFIGS as BASE
 from .bert_replication import CONFIGS as BERT_REPLICATION
 from .bertitos import CONFIGS as BERTITOS
+from .distillation import CONFIGS as DISTILLATION
 from .finetuning import CONFIGS as FINETUNING
+from .one_cycle_lr import CONFIGS as ONE_CYCLE_LR
 from .rigl_bert import CONFIGS as RIGL_BERT
 from .sparse_bert import CONFIGS as SPARSE_BERT
-from .distillation import CONFIGS as DISTILLATION
 
 """
 Import and collect all experiment configurations into one CONFIG
@@ -41,8 +42,8 @@ CONFIGS = dict()
 CONFIGS.update(BASE)
 CONFIGS.update(BERT_REPLICATION)
 CONFIGS.update(BERTITOS)
+CONFIGS.update(DISTILLATION)
 CONFIGS.update(FINETUNING)
+CONFIGS.update(ONE_CYCLE_LR)
 CONFIGS.update(RIGL_BERT)
 CONFIGS.update(SPARSE_BERT)
-CONFIGS.update(FINETUNING)
-CONFIGS.update(DISTILLATION)

--- a/projects/transformers/experiments/one_cycle_lr.py
+++ b/projects/transformers/experiments/one_cycle_lr.py
@@ -1,0 +1,141 @@
+# ----------------------------------------------------------------------
+# Numenta Platform for Intelligent Computing (NuPIC)
+# Copyright (C) 2021, Numenta, Inc.  Unless you have an agreement
+# with Numenta, Inc., for a separate license for this software code, the
+# following terms and conditions apply:
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# See the GNU Affero Public License for more details.
+#
+# You should have received a copy of the GNU Affero Public License
+# along with this program.  If not, see http://www.gnu.org/licenses.
+#
+# http://numenta.org/licenses/
+# ----------------------------------------------------------------------
+
+
+from copy import deepcopy
+
+from transformers import Trainer
+
+from trainer_mixins import LRRangeTestMixin, OneCycleLRMixin
+
+from .bertitos import tiny_bert_50k, tiny_bert_debug
+
+"""
+Experiment to train BERT models with OneCycle LR.
+
+Note: it seems easier to encounter exploding gradients when
+    * lr is large (order of magnitude 1.0)
+    * using fp16 at moderately high lr's (order of magnitude 0.1)
+"""
+
+# Results:
+# |------------------------------------------------------------------------|
+# | model                      | train loss  | eval loss      | perplexity |
+# |----------------------------|:-----------:|:--------------:|:----------:|
+# | tiny_bert_50k              | 5.990       | 5.800          | 330.234    |
+# | tiny_bert_one_cycle_lr_50k | 4.083       | 3.605          | 36.767     |
+# |------------------------------------------------------------------------|
+#
+
+
+class OneCycleLRTrainer(OneCycleLRMixin, Trainer):
+    pass
+
+
+class LRRangeTestTrainer(LRRangeTestMixin, Trainer):
+    pass
+
+
+# Just a debug config.
+tiny_bert_one_cycle_lr_debug = deepcopy(tiny_bert_debug)
+tiny_bert_one_cycle_lr_debug.update(
+    max_steps=10,
+    do_eval=False,
+
+    trainer_class=OneCycleLRTrainer,
+    model_type="bert",
+    logging_steps=1,
+    logging_first_step=True,
+
+    trainer_extra_kwargs=dict(
+        max_lr=1.0,
+        pct_start=0.3,
+        anneal_strategy="linear",
+        cycle_momentum=True,
+        base_momentum=0.85,
+        max_momentum=0.95,
+        div_factor=25,
+        final_div_factor=1e4,
+        last_epoch=-1,
+    ),
+    learning_rate=0.1,
+)
+
+
+# Train with one cycle based of the lr found in the range tests below.
+# Note, it seems easier to observe exploding gradients when
+#    * lr is large (order of magnitude 1.0)
+#    * using fp16 at moderately high lr's (order of magnitude 0.1)
+tiny_bert_one_cycle_lr_50k = deepcopy(tiny_bert_50k)
+tiny_bert_one_cycle_lr_50k.update(
+
+    trainer_class=OneCycleLRTrainer,
+    trainer_extra_kwargs=dict(
+        max_lr=0.01,
+        pct_start=0.3,
+        anneal_strategy="linear",
+        cycle_momentum=True,
+        base_momentum=0.85,
+        max_momentum=0.95,
+        div_factor=25,
+        final_div_factor=1e4,
+        last_epoch=-1,
+    ),
+    overwrite_output_dir=True,
+)
+
+
+# --------------
+# LR Range Test
+# --------------
+
+
+# lr range test with linear ramp up
+tiny_bert_linear_lr_range_test = deepcopy(tiny_bert_50k)
+tiny_bert_linear_lr_range_test.update(
+
+    max_steps=100,
+    overwrite_output_dir=True,
+    do_eval=False,
+    trainer_class=LRRangeTestTrainer,
+    trainer_extra_kwargs=dict(
+        min_lr=1e-5,
+        max_lr=0.5,
+        test_mode="linear"
+    ),
+)
+
+
+# lr range test with exponential ramp up
+tiny_bert_exponential_lr_range_test = deepcopy(tiny_bert_linear_lr_range_test)
+tiny_bert_exponential_lr_range_test["trainer_extra_kwargs"].update(
+    test_mode="exponential"
+)
+
+
+CONFIGS = dict(
+    tiny_bert_one_cycle_lr_debug=tiny_bert_one_cycle_lr_debug,
+    tiny_bert_one_cycle_lr_50k=tiny_bert_one_cycle_lr_50k,
+
+    # LR Range Tests
+    tiny_bert_linear_lr_range_test=tiny_bert_linear_lr_range_test,
+    tiny_bert_exponential_lr_range_test=tiny_bert_exponential_lr_range_test,
+)

--- a/projects/transformers/experiments/rigl_bert.py
+++ b/projects/transformers/experiments/rigl_bert.py
@@ -1,0 +1,126 @@
+# ----------------------------------------------------------------------
+# Numenta Platform for Intelligent Computing (NuPIC)
+# Copyright (C) 2021, Numenta, Inc.  Unless you have an agreement
+# with Numenta, Inc., for a separate license for this software code, the
+# following terms and conditions apply:
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# See the GNU Affero Public License for more details.
+#
+# You should have received a copy of the GNU Affero Public License
+# along with this program.  If not, see http://www.gnu.org/licenses.
+#
+# http://numenta.org/licenses/
+# ----------------------------------------------------------------------
+
+from copy import deepcopy
+
+from callbacks import PlotDensitiesCallback, RezeroWeightsCallback, RigLCallback
+
+from .bertitos import tiny_bert_100k, tiny_bert_debug
+
+# Just a debug config.
+tiny_bert_rigl_debug = deepcopy(tiny_bert_debug)
+tiny_bert_rigl_debug.update(
+    max_steps=10,
+    do_eval=True,
+    # evaluation_strategy="steps",
+    # eval_steps=2,
+    model_type="fully_static_sparse_bert",
+    trainer_callbacks=[
+        RezeroWeightsCallback(),
+        # RigLCallback(prune_freq=5),
+        PlotDensitiesCallback(plot_freq=5),
+    ],
+)
+tiny_bert_rigl_debug["config_kwargs"].update(
+    sparsity=0.8,
+)
+
+
+# Sparse bert encoding (sparse encoding and sparse embeddings) with RigL
+tiny_bert_rigl_100k = deepcopy(tiny_bert_100k)
+tiny_bert_rigl_100k.update(
+    model_type="static_sparse_encoder_bert",
+    trainer_callbacks=[
+        RezeroWeightsCallback(),
+        RigLCallback(prune_fraction=0.2, prune_freq=1000)
+    ],
+)
+tiny_bert_rigl_100k["config_kwargs"].update(
+    sparsity=0.5,
+)
+
+
+# Fully static sparse bert (sparse encoding and sparse embeddings).
+tiny_bert_static_full_sparse_100k = deepcopy(tiny_bert_100k)
+tiny_bert_static_full_sparse_100k.update(
+    model_type="fully_static_sparse_bert",
+    trainer_callbacks=[
+        RezeroWeightsCallback(),
+    ],
+    fp16=True,
+    overwrite_output_dir=True,
+)
+tiny_bert_static_full_sparse_100k["config_kwargs"].update(
+    sparsity=0.8,
+)
+
+
+tiny_bert_static_full_sparse_200k = deepcopy(tiny_bert_static_full_sparse_100k)
+tiny_bert_static_full_sparse_200k.update(
+    max_steps=200000,
+    evaluation_strategy="steps",
+    eval_steps=100000,
+)
+
+
+# Fully sparse bert with RigL (dynamic sparse encoding and embeddings)
+tiny_bert_full_sparse_rigl_100k = deepcopy(tiny_bert_100k)
+tiny_bert_full_sparse_rigl_100k.update(
+    model_type="fully_static_sparse_bert",
+    trainer_callbacks=[
+        RezeroWeightsCallback(),
+        RigLCallback(prune_fraction=0.2, prune_freq=1000),
+        PlotDensitiesCallback(plot_freq=1000),
+    ],
+    fp16=True,
+)
+tiny_bert_full_sparse_rigl_100k["config_kwargs"].update(
+    sparsity=0.8,
+)
+
+
+# This config replicates the RigL paper more closely.
+tiny_bert_full_sparse_rigl_200k_prune_perc_30 = deepcopy(tiny_bert_100k)
+tiny_bert_full_sparse_rigl_200k_prune_perc_30.update(
+    model_type="fully_static_sparse_bert",
+    trainer_callbacks=[
+        RezeroWeightsCallback(),
+        RigLCallback(prune_fraction=0.3, prune_freq=100),
+        PlotDensitiesCallback(plot_freq=100),
+    ],
+    fp16=True,
+    overwrite_output_dir=True,
+    evaluation_strategy="steps",
+    eval_steps=100000,
+)
+tiny_bert_full_sparse_rigl_200k_prune_perc_30["config_kwargs"].update(
+    sparsity=0.8,
+)
+
+
+CONFIGS = dict(
+    tiny_bert_rigl_debug=tiny_bert_rigl_debug,
+    tiny_bert_rigl_100k=tiny_bert_rigl_100k,
+    tiny_bert_static_full_sparse_100k=tiny_bert_static_full_sparse_100k,
+    tiny_bert_static_full_sparse_200k=tiny_bert_static_full_sparse_200k,
+    tiny_bert_full_sparse_rigl_100k=tiny_bert_full_sparse_rigl_100k,
+    tiny_bert_full_sparse_rigl_200k_prune_perc_30=tiny_bert_full_sparse_rigl_200k_prune_perc_30,  # noqa E501
+)

--- a/projects/transformers/experiments/rigl_bert.py
+++ b/projects/transformers/experiments/rigl_bert.py
@@ -23,7 +23,16 @@ from copy import deepcopy
 
 from callbacks import PlotDensitiesCallback, RezeroWeightsCallback, RigLCallback
 
-from .bertitos import tiny_bert_100k, tiny_bert_debug
+from .bertitos import small_bert_100k, tiny_bert_100k, tiny_bert_debug
+
+# Results:
+# |--------------------------------------------------------------------------|
+# | model                        | train loss  | eval loss      | perplexity |
+# |------------------------------|:-----------:|:--------------:|:----------:|
+# | tiny_bert_static_sparse_300k | 4.537       | 3.997          | 54.432     |
+# | tiny_bert_rigl_sparse_300k   | 5.963       | 5.774          | 321.95     |
+# |--------------------------------------------------------------------------|
+#
 
 # Just a debug config.
 tiny_bert_rigl_debug = deepcopy(tiny_bert_debug)
@@ -73,9 +82,9 @@ tiny_bert_static_full_sparse_100k["config_kwargs"].update(
 )
 
 
-tiny_bert_static_full_sparse_200k = deepcopy(tiny_bert_static_full_sparse_100k)
-tiny_bert_static_full_sparse_200k.update(
-    max_steps=200000,
+tiny_bert_static_full_sparse_300k = deepcopy(tiny_bert_static_full_sparse_100k)
+tiny_bert_static_full_sparse_300k.update(
+    max_steps=300000,
     evaluation_strategy="steps",
     eval_steps=100000,
 )
@@ -98,21 +107,49 @@ tiny_bert_full_sparse_rigl_100k["config_kwargs"].update(
 
 
 # This config replicates the RigL paper more closely.
-tiny_bert_full_sparse_rigl_200k_prune_perc_30 = deepcopy(tiny_bert_100k)
-tiny_bert_full_sparse_rigl_200k_prune_perc_30.update(
+tiny_bert_full_sparse_rigl_300k_prune_perc_30 = deepcopy(tiny_bert_100k)
+tiny_bert_full_sparse_rigl_300k_prune_perc_30.update(
+    max_steps=300000,
     model_type="fully_static_sparse_bert",
     trainer_callbacks=[
         RezeroWeightsCallback(),
         RigLCallback(prune_fraction=0.3, prune_freq=100),
-        PlotDensitiesCallback(plot_freq=100),
+        PlotDensitiesCallback(plot_freq=1000),
     ],
     fp16=True,
     overwrite_output_dir=True,
     evaluation_strategy="steps",
     eval_steps=100000,
 )
-tiny_bert_full_sparse_rigl_200k_prune_perc_30["config_kwargs"].update(
+tiny_bert_full_sparse_rigl_300k_prune_perc_30["config_kwargs"].update(
     sparsity=0.8,
+)
+
+
+# ----------
+# Small BERT
+# ----------
+
+small_bert_sparse_100k = deepcopy(small_bert_100k)
+small_bert_sparse_100k.update(
+    model_type="fully_static_sparse_bert",
+    trainer_callbacks=[
+        RezeroWeightsCallback(),
+    ],
+    fp16=True,
+    overwrite_output_dir=True,
+)
+
+small_bert_rigl_100k = deepcopy(small_bert_100k)
+small_bert_rigl_100k.update(
+    model_type="fully_static_sparse_bert",
+    trainer_callbacks=[
+        RezeroWeightsCallback(),
+        RigLCallback(prune_fraction=0.3, prune_freq=100),
+        PlotDensitiesCallback(plot_freq=1000),
+    ],
+    fp16=True,
+    overwrite_output_dir=True,
 )
 
 
@@ -120,7 +157,10 @@ CONFIGS = dict(
     tiny_bert_rigl_debug=tiny_bert_rigl_debug,
     tiny_bert_rigl_100k=tiny_bert_rigl_100k,
     tiny_bert_static_full_sparse_100k=tiny_bert_static_full_sparse_100k,
-    tiny_bert_static_full_sparse_200k=tiny_bert_static_full_sparse_200k,
+    tiny_bert_static_full_sparse_300k=tiny_bert_static_full_sparse_300k,
     tiny_bert_full_sparse_rigl_100k=tiny_bert_full_sparse_rigl_100k,
-    tiny_bert_full_sparse_rigl_200k_prune_perc_30=tiny_bert_full_sparse_rigl_200k_prune_perc_30,  # noqa E501
+    tiny_bert_full_sparse_rigl_300k_prune_perc_30=tiny_bert_full_sparse_rigl_300k_prune_perc_30,  # noqa E501
+
+    small_bert_sparse_100k=small_bert_sparse_100k,
+    small_bert_rigl_100k=small_bert_rigl_100k,
 )

--- a/projects/transformers/integrations.py
+++ b/projects/transformers/integrations.py
@@ -142,11 +142,17 @@ class CustomWandbCallback(WandbCallback):
         perplexity = math.exp(eval_loss)
         run = wandb.run
         if run is not None:
-            run.summary["eval/perplexity"] = perplexity
-            run.summary["eval/loss"] = eval_loss
+            summary = run.summary
+            eval_results = {
+                "eval/perplexity": perplexity,
+                "eval/loss": eval_loss,
+            }
+            run.summary.update(eval_results)
+            wandb.log(eval_results, step=state.global_step)
 
-            runtime = run.summary["train/train_runtime"]
-            run.summary["train/train_runtime (hrs)"] = runtime / 3600
+            if "train/train_runtime" in summary.keys():
+                runtime = summary["train/train_runtime"]
+                summary["train/train_runtime (hrs)"] = runtime / 3600
 
 
 # Update the integrations. By updating this dict, any custom integration

--- a/projects/transformers/models/register_bert_model.py
+++ b/projects/transformers/models/register_bert_model.py
@@ -97,6 +97,11 @@ def register_bert_model(bert_cls):
     masked_lm_cls = create_masked_lm_class(bert_cls, name_prefix)
     seq_classification_cls = create_sequence_classification_class(bert_cls, name_prefix)
 
+    # Specify the correct config class
+    bert_cls.config_class = config_cls
+    masked_lm_cls.config_class = config_cls
+    seq_classification_cls.config_class = config_cls
+
     # Update Transformers mappings to auto-load these new models.
     CONFIG_MAPPING.update({
         config_cls.model_type: config_cls

--- a/projects/transformers/tests/global_pruning_test.py
+++ b/projects/transformers/tests/global_pruning_test.py
@@ -28,8 +28,8 @@ import torch
 from transformers import CONFIG_MAPPING, AdamW, AutoModelForMaskedLM
 
 from nupic.research.frameworks.dynamic_sparse import (
-    global_add_by_grad,
-    global_prune_by_weight,
+    global_add_by_abs_grad,
+    global_prune_by_abs_weight,
 )
 from nupic.research.frameworks.pytorch.model_utils import (
     count_nonzero_params,
@@ -115,7 +115,7 @@ class GlobalPruningTest(unittest.TestCase):
         # Prune weights
         # --------------
 
-        num_removed = global_prune_by_weight(sparse_modules, prune_fraction=1 / 3)
+        num_removed = global_prune_by_abs_weight(sparse_modules, prune_fraction=1 / 3)
 
         self.model.apply(rezero_weights)
         total_off_mask = np.sum([m.zero_mask.bool().sum() for m in sparse_modules])
@@ -146,7 +146,7 @@ class GlobalPruningTest(unittest.TestCase):
         loss.backward()
 
         # Add weights according to the largest gradients of the model.
-        global_add_by_grad(sparse_modules, num_add=num_removed)
+        global_add_by_abs_grad(sparse_modules, num_add=num_removed)
 
         # The new weights are initialized to zero.
         self.model.apply(rezero_weights)

--- a/projects/transformers/tests/global_pruning_test.py
+++ b/projects/transformers/tests/global_pruning_test.py
@@ -1,0 +1,173 @@
+# ----------------------------------------------------------------------
+# Numenta Platform for Intelligent Computing (NuPIC)
+# Copyright (C) 2021, Numenta, Inc.  Unless you have an agreement
+# with Numenta, Inc., for a separate license for this software code, the
+# following terms and conditions apply:
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# See the GNU Affero Public License for more details.
+#
+# You should have received a copy of the GNU Affero Public License
+# along with this program.  If not, see http://www.gnu.org/licenses.
+#
+# http://numenta.org/licenses/
+# ----------------------------------------------------------------------
+
+import sys
+import unittest
+from os.path import expanduser
+
+import numpy as np
+import torch
+from transformers import CONFIG_MAPPING, AdamW, AutoModelForMaskedLM
+
+from nupic.research.frameworks.dynamic_sparse import (
+    global_add_by_grad,
+    global_prune_by_weight,
+)
+from nupic.research.frameworks.pytorch.model_utils import (
+    count_nonzero_params,
+    filter_modules,
+)
+from nupic.torch.modules.sparse_weights import SparseWeightsBase, rezero_weights
+
+sys.path.insert(0, expanduser("~/nta/nupic.research/projects/transformers"))
+import models  # noqa F401
+
+
+def simple_sparse_transformer():
+    config = CONFIG_MAPPING["fully_static_sparse_bert"](
+        num_attention_heads=1,
+        num_hidden_layers=1,
+        hidden_size=4,
+        intermediate_size=8,
+        max_position_embeddings=10,
+        vocab_size=10,
+        sparsity=0.75,
+    )
+    model = AutoModelForMaskedLM.from_config(config)
+    return config, model
+
+
+def calc_sparsity(model):
+    tot, nz = count_nonzero_params(model)
+    sparsity = 1 - nz / tot
+    return sparsity
+
+
+def init_all_zero_params(model):
+    """
+    Adjust params so that none are zero. This helps control sparsity levels in case some
+    params are randomly zero.
+    """
+    for p in model.parameters():
+        zero_mask = p == 0
+        num_zero = zero_mask.sum()
+        rand_vals = torch.randn(num_zero) + 1e-5
+        p.data[zero_mask] = rand_vals
+
+
+class GlobalPruningTest(unittest.TestCase):
+    def setUp(self):
+        self.config, self.model = simple_sparse_transformer()
+        self.optimizer = AdamW(self.model.parameters(), lr=1e-5)
+
+    def test_global_rigl(self):
+        """
+        Test for globally pruning all sparse modules by their weights and adding back by
+        gradients.
+        """
+
+        # -----------
+        # Init model
+        # -----------
+
+        # Make sure there are no random zeros in model params.
+        init_all_zero_params(self.model)
+        sparsity = calc_sparsity(self.model)
+        self.assertEqual(sparsity, 0)
+
+        # Validate initial sparsity after rezeroing the weights.
+        self.model.apply(rezero_weights)
+        sparsity = calc_sparsity(self.model.bert)
+        self.assertTrue(np.isclose(sparsity, 0.4701, atol=1e-4))
+
+        # Get all the SparseWeightsBase modules. These will be pruned.
+        sparse_modules = filter_modules(self.model, include_modules=[SparseWeightsBase])
+        sparse_modules = sparse_modules.values()
+        self.assertEqual(len(sparse_modules), 7)
+
+        # Validate initial number of off params with sparse modules..
+        total_sparse_params = np.sum([m.weight.numel() for m in sparse_modules])
+        total_off_mask = np.sum([m.zero_mask.bool().sum() for m in sparse_modules])
+        total_off_params = np.sum([(m.weight == 0).sum() for m in sparse_modules])
+        self.assertEqual(total_sparse_params, 168)
+        self.assertEqual(total_off_params, 126)
+        self.assertEqual(total_off_mask, 126)
+
+        # --------------
+        # Prune weights
+        # --------------
+
+        num_removed = global_prune_by_weight(sparse_modules, prune_fraction=1 / 3)
+
+        self.model.apply(rezero_weights)
+        total_off_mask = np.sum([m.zero_mask.bool().sum() for m in sparse_modules])
+        total_off_params = np.sum([(m.weight == 0).sum() for m in sparse_modules])
+
+        self.assertEqual(total_off_mask, 140)
+        self.assertEqual(total_off_params, 140)
+
+        # ---------------
+        # Regrow weights
+        # ---------------
+
+        # Pseudo forward pass to accumulate gradients.
+        batch_size = 2
+        num_ebeddings = self.config.max_position_embeddings
+        attention_mask = torch.ones(batch_size, num_ebeddings).float()
+        input_ids = torch.ones(batch_size, num_ebeddings).long()
+        token_type_ids = torch.ones(batch_size, num_ebeddings).long()
+        labels = torch.ones(batch_size * num_ebeddings).long()
+
+        outputs = self.model(
+            attention_mask=attention_mask,
+            input_ids=input_ids,
+            labels=labels,
+            token_type_ids=token_type_ids,
+        )
+        loss = outputs.loss
+        loss.backward()
+
+        # Add weights according to the largest gradients of the model.
+        global_add_by_grad(sparse_modules, num_add=num_removed)
+
+        # The new weights are initialized to zero.
+        self.model.apply(rezero_weights)
+        total_off_mask = np.sum([m.zero_mask.bool().sum() for m in sparse_modules])
+        total_off_params = np.sum([(m.weight == 0).sum() for m in sparse_modules])
+
+        # Validate number of off params after regrowing the weights.
+        self.assertEqual(total_off_mask, 126)
+        self.assertEqual(total_off_params, 140)
+
+        # Psuedo training step where learning happens on the new zero weights.
+        init_all_zero_params(self.model)
+        self.model.apply(rezero_weights)
+
+        # Validate number of off params after learning has occurred on new weights.
+        total_off_mask = np.sum([m.zero_mask.bool().sum() for m in sparse_modules])
+        total_off_params = np.sum([(m.weight == 0).sum() for m in sparse_modules])
+
+        self.assertEqual(total_off_mask, 126)
+        self.assertEqual(total_off_params, 126)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/projects/transformers/trainer_mixins/__init__.py
+++ b/projects/transformers/trainer_mixins/__init__.py
@@ -18,4 +18,7 @@
 #
 # http://numenta.org/licenses/
 # ----------------------------------------------------------------------
+
 from .distillation import DistillationTrainerMixin
+from .lr_range_test import LRRangeTestMixin
+from .one_cycle_lr import OneCycleLRMixin

--- a/projects/transformers/trainer_mixins/lr_range_test.py
+++ b/projects/transformers/trainer_mixins/lr_range_test.py
@@ -1,0 +1,97 @@
+# ----------------------------------------------------------------------
+# Numenta Platform for Intelligent Computing (NuPIC)
+# Copyright (C) 2021, Numenta, Inc.  Unless you have an agreement
+# with Numenta, Inc., for a separate license for this software code, the
+# following terms and conditions apply:
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# See the GNU Affero Public License for more details.
+#
+# You should have received a copy of the GNU Affero Public License
+# along with this program.  If not, see http://www.gnu.org/licenses.
+#
+# http://numenta.org/licenses/
+# ----------------------------------------------------------------------
+
+from torch.optim.lr_scheduler import LambdaLR
+
+
+class LRRangeTestMixin:
+    """
+    Mixin for the LR-range test defined in section 4.1 of "A Disciplined Approach to
+    Neural Network Hyper-Parameters"
+        - https://arxiv.org/pdf/1803.09820.pdf
+
+    Herein, a min_lr and max_lr are set, and training proceeds for a small number of
+    epochs (1-3) while the learning rate is linearly or exponentially increased.
+    Generally, the point at which the training loss begins to curve upwards, is
+    considered to be a reasonable choice for your max_lr in a cyclical lr-schedule. For
+    an exponential ramp-up, the ideal max_lr is roughly one order of magnitude below the
+    point in which the loss begins to increase. The same author recommends using 10-20
+    times lower this amount for your min_lr. Of course, in practice these heuristics may
+    vary.
+
+    :param min_lr: starting lr
+    :param max_lr: ending lr; presumed to be larger than min_lr
+    :param test_mode: either linear or exponential
+    """
+    def __init__(
+        self,
+        min_lr=None,
+        max_lr=None,
+        test_mode="linear",
+        **kwargs,
+    ):
+
+        # The LambdaLR will multiply this base lr of 1 times the one at the given step.
+        kwargs["args"].learning_rate = 1
+
+        # Log so that the lr is recorder every step.
+        kwargs["args"].logging_steps = 1
+
+        # Turn off eval since it's satisfactory to just look at the training loss.
+        kwargs["args"].do_eval = False
+
+        super().__init__(**kwargs)
+        assert isinstance(min_lr, float)
+        assert isinstance(max_lr, float)
+        assert test_mode in ["linear", "exponential"]
+        self.min_lr = min_lr
+        self.max_lr = max_lr
+        self.test_mode = test_mode
+
+    def create_optimizer_and_scheduler(self, num_training_steps: int):
+        """
+        Create a linearly or exponentially increasing lr schedule. This overrides super
+        in a way that just customizes the lr scheduler while the optimizer remains the
+        default.
+        """
+
+        # Set lr scheduler to dummy variable so it's not created in the call to super.
+        self.lr_scheduler = ...
+
+        # Create just the optimizer.
+        super().create_optimizer_and_scheduler(num_training_steps)
+
+        # Create a lr scheduler that ramps up either linearly or exponentially.
+        total_steps = num_training_steps
+        min_lr = self.min_lr
+        max_lr = self.max_lr
+
+        # Linearly increase lr
+        if self.test_mode == "linear":
+            def lr_lambda(step: int):
+                return (max_lr - min_lr) / (total_steps - 1) * step + min_lr
+
+        # Exponentially increase lr
+        elif self.test_mode == "exponential":
+            def lr_lambda(step):
+                return (max_lr / min_lr) ** (step / (total_steps - 1)) * min_lr
+
+        self.lr_scheduler = LambdaLR(self.optimizer, lr_lambda)

--- a/projects/transformers/trainer_mixins/lr_range_test.py
+++ b/projects/transformers/trainer_mixins/lr_range_test.py
@@ -28,14 +28,15 @@ class LRRangeTestMixin:
     Neural Network Hyper-Parameters"
         - https://arxiv.org/pdf/1803.09820.pdf
 
-    Herein, a min_lr and max_lr are set, and training proceeds for a small number of
-    epochs (1-3) while the learning rate is linearly or exponentially increased.
-    Generally, the point at which the training loss begins to curve upwards, is
-    considered to be a reasonable choice for your max_lr in a cyclical lr-schedule. For
-    an exponential ramp-up, the ideal max_lr is roughly one order of magnitude below the
-    point in which the loss begins to increase. The same author recommends using 10-20
-    times lower this amount for your min_lr. Of course, in practice these heuristics may
-    vary.
+    To use this mixin, define min_lr and max_lr through the config and then run a small
+    number of steps of training (e.g. 100 steps). Throughout training the lr will be
+    gradually increased either linearly or exponentially. Next, review the plotted
+    training loss. This mixin won't calculate the max_lr you should use for training
+    with a OneCycle schedule. You must inspect the loss yourself and observe when the
+    loss begins to increase. This inflection point is where you should set your max_lr.
+    Note, sometimes the ideal max_lr turns out an order of magnitude lower; you know
+    this is the case if your training loss increases at all during training. For your
+    min_lr, the author recommends using 10-20 times lower than the max_lr.
 
     :param min_lr: starting lr
     :param max_lr: ending lr; presumed to be larger than min_lr

--- a/projects/transformers/trainer_mixins/one_cycle_lr.py
+++ b/projects/transformers/trainer_mixins/one_cycle_lr.py
@@ -1,0 +1,85 @@
+# ----------------------------------------------------------------------
+# Numenta Platform for Intelligent Computing (NuPIC)
+# Copyright (C) 2021, Numenta, Inc.  Unless you have an agreement
+# with Numenta, Inc., for a separate license for this software code, the
+# following terms and conditions apply:
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# See the GNU Affero Public License for more details.
+#
+# You should have received a copy of the GNU Affero Public License
+# along with this program.  If not, see http://www.gnu.org/licenses.
+#
+# http://numenta.org/licenses/
+# ----------------------------------------------------------------------
+
+from torch.optim.lr_scheduler import OneCycleLR
+
+
+class OneCycleLRMixin:
+    """
+    Mixin to HF Trainer for using the `OneCycleLR`_. See documentation for argument
+    details.
+
+    .. _OneCycleLR:
+        https://pytorch.org/docs/stable/optim.html#torch.optim.lr_scheduler.OneCycleLR
+    """
+
+    def __init__(
+        self,
+        max_lr=1e-2,
+        pct_start=0.3,
+        anneal_strategy="linear",
+        cycle_momentum=True,
+        base_momentum=0.85,
+        max_momentum=0.95,
+        div_factor=25,
+        final_div_factor=1e4,
+        last_epoch=-1,
+        **kwargs,
+    ):
+        super().__init__(**kwargs)
+
+        self.max_lr = max_lr
+        self.pct_start = pct_start
+        self.anneal_strategy = anneal_strategy
+        self.cycle_momentum = cycle_momentum
+        self.base_momentum = base_momentum
+        self.max_momentum = max_momentum
+        self.div_factor = div_factor
+        self.final_div_factor = final_div_factor
+        self.last_epoch = last_epoch
+
+    def create_optimizer_and_scheduler(self, num_training_steps: int):
+        """
+        Setup the optimizer and the learning rate scheduler. This overrides super
+        in a way that just customizes the lr scheduler while the optimizer remains the
+        default.
+        """
+
+        # Set lr scheduler to dummy variable so it's not created in the call to super.
+        self.lr_scheduler = ...
+
+        # Create just the optimizer.
+        super().create_optimizer_and_scheduler(num_training_steps)
+
+        # Now define the lr scheduler, given the optimizer.
+        self.lr_scheduler = OneCycleLR(
+            self.optimizer,
+            total_steps=num_training_steps,
+            max_lr=self.max_lr,
+            pct_start=self.pct_start,
+            anneal_strategy=self.anneal_strategy,
+            cycle_momentum=self.cycle_momentum,
+            base_momentum=self.base_momentum,
+            max_momentum=self.max_momentum,
+            div_factor=self.div_factor,
+            final_div_factor=self.final_div_factor,
+            last_epoch=self.last_epoch,
+        )

--- a/tests/unit/frameworks/dynamic_sparse/global_pruning_test.py
+++ b/tests/unit/frameworks/dynamic_sparse/global_pruning_test.py
@@ -1,0 +1,250 @@
+# ----------------------------------------------------------------------
+# Numenta Platform for Intelligent Computing (NuPIC)
+# Copyright (C) 2021, Numenta, Inc.  Unless you have an agreement
+# with Numenta, Inc., for a separate license for this software code, the
+# following terms and conditions apply:
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# See the GNU Affero Public License for more details.
+#
+# You should have received a copy of the GNU Affero Public License
+# along with this program.  If not, see http://www.gnu.org/licenses.
+#
+# http://numenta.org/licenses/
+# ----------------------------------------------------------------------
+
+import unittest
+
+import numpy as np
+import torch
+from torch.nn.utils import parameters_to_vector
+
+from nupic.research.frameworks.dynamic_sparse import (
+    global_add_by_grad,
+    global_prune_by_weight,
+)
+from nupic.torch.modules import SparseWeights, rezero_weights
+
+# Chosen so that all linear transformations can be of shape 4 x 4
+INPUT_SHAPE = (4,)
+
+
+class SimpleSparseMLP(torch.nn.Module):
+    def __init__(self, input_shape=INPUT_SHAPE, hidden_size=4, output_size=4):
+        super().__init__()
+
+        input_size = np.prod(input_shape)
+        self.flatten = torch.nn.Flatten()
+        self.lin1 = SparseWeights(
+            torch.nn.Linear(input_size, hidden_size, bias=None), sparsity=0.5
+        )
+        self.lin2 = SparseWeights(
+            torch.nn.Linear(hidden_size, hidden_size, bias=None), sparsity=0.5
+        )
+        self.lin3 = SparseWeights(
+            torch.nn.Linear(hidden_size, output_size, bias=None), sparsity=0.5
+        )
+
+    def forward(self, x):
+        y = self.flatten(x)
+        y = self.lin1(y)
+        y = self.lin2(y)
+        y = self.lin3(y)
+        return y
+
+
+def all_equal(tensor1, tensor2):
+    return (tensor1 == tensor2).all()
+
+
+def all_close(tensor1, tensor2, atol=1e-4):
+    return torch.allclose(tensor1, tensor2, atol=atol)
+
+
+class GlobalPruningTest(unittest.TestCase):
+    def setUp(self):
+        """
+        Initialize model weights and mask.
+        """
+        model = SimpleSparseMLP()
+
+        model.lin1.module.weight.data[:] = torch.tensor(
+            [
+                [0.00, 0.34, 0.00, -0.45],
+                [-0.37, 0.00, 0.00, -0.45],
+                [-0.31, 0.02, 0.00, 0.00],
+                [0.42, -0.15, 0.00, 0.00],
+            ],
+            requires_grad=True,
+        )
+        self.initial_lin1_mask = torch.tensor(
+            [
+                [1.0, 0.0, 1.0, 0.0],
+                [0.0, 1.0, 1.0, 0.0],
+                [0.0, 0.0, 1.0, 1.0],
+                [0.0, 0.0, 1.0, 1.0],
+            ]
+        ).half()
+        model.lin1.zero_mask[:] = self.initial_lin1_mask
+
+        model.lin2.module.weight.data[:] = torch.tensor(
+            [
+                [-0.09, 0.22, 0.00, 0.00],
+                [0.13, 0.28, 0.00, 0.00],
+                [0.00, 0.24, 0.00, -0.16],
+                [0.00, 0.00, 0.01, 0.02],
+            ],
+            requires_grad=True,
+        )
+        self.initial_lin2_mask = torch.tensor(
+            [
+                [0.0, 0.0, 1.0, 1.0],
+                [0.0, 0.0, 1.0, 1.0],
+                [1.0, 0.0, 1.0, 0.0],
+                [1.0, 1.0, 0.0, 0.0],
+            ]
+        ).half()
+        model.lin2.zero_mask[:] = self.initial_lin2_mask
+
+        model.lin3.module.weight.data[:] = torch.tensor(
+            [
+                [-0.14, 0.00, 0.00, -0.08],
+                [0.00, -0.36, 0.00, -0.43],
+                [0.00, 0.33, 0.00, -0.50],
+                [0.22, 0.00, 0.41, 0.00],
+            ],
+            requires_grad=True,
+        )
+        self.initial_lin3_mask = torch.tensor(
+            [
+                [0.0, 1.0, 1.0, 0.0],
+                [1.0, 0.0, 1.0, 0.0],
+                [1.0, 0.0, 1.0, 0.0],
+                [0.0, 1.0, 0.0, 1.0],
+            ]
+        ).half()
+        model.lin3.zero_mask[:] = self.initial_lin3_mask
+
+        self.model = model
+        self.model.apply(rezero_weights)
+
+    def test_global_pruning_and_regrowing(self):
+
+        # ----------
+        # Prune
+        # ----------
+
+        sparse_modules = [self.model.lin1, self.model.lin2, self.model.lin3]
+        global_prune_by_weight(sparse_modules, prune_fraction=0.5)
+        self.model.apply(rezero_weights)
+
+        # Validate pruned weights
+        expected_w1 = torch.tensor(
+            [
+                [0.0000, 0.3400, 0.0000, -0.4500],
+                [-0.3700, 0.0000, 0.0000, -0.4500],
+                [-0.3100, 0.0000, 0.0000, 0.0000],
+                [0.4200, 0.0000, 0.0000, 0.0000],
+            ]
+        )
+        self.assertTrue(all_equal(self.model.lin1.weight, expected_w1))
+
+        expected_w2 = torch.tensor(
+            [
+                [0.0000, 0.0000, 0.0000, 0.0000],
+                [0.0000, 0.2800, 0.0000, 0.0000],
+                [0.0000, 0.0000, 0.0000, 0.0000],
+                [0.0000, 0.0000, 0.0000, 0.0000],
+            ]
+        )
+        self.assertTrue(all_equal(self.model.lin2.weight, expected_w2))
+
+        expected_w3 = torch.tensor(
+            [
+                [0.0000, 0.0000, 0.0000, 0.0000],
+                [0.0000, -0.3600, 0.0000, -0.4300],
+                [0.0000, 0.3300, 0.0000, -0.5000],
+                [0.0000, 0.0000, 0.4100, 0.0000],
+            ]
+        )
+        self.assertTrue(all_equal(self.model.lin3.weight, expected_w3))
+
+        # Validate pruned mask is a subset of the original mask.
+        pruned_lin1_mask = self.model.lin1.zero_mask
+        pruned_lin2_mask = self.model.lin2.zero_mask
+        pruned_lin3_mask = self.model.lin3.zero_mask
+        self.assertTrue((pruned_lin1_mask >= self.initial_lin1_mask).all())
+        self.assertTrue((pruned_lin2_mask >= self.initial_lin2_mask).all())
+        self.assertTrue((pruned_lin3_mask >= self.initial_lin3_mask).all())
+
+        # Validate number of off weights.
+        zero_masks = parameters_to_vector(self.model.buffers())
+        weights = parameters_to_vector(self.model.parameters())
+        self.assertEqual((weights == 0).sum(), 36)
+        self.assertEqual(zero_masks.sum(), 36)
+
+        # ----------
+        # Regrow
+        # ----------
+
+        # Pseudo forward pass to accumulate gradients.
+        x = torch.tensor(
+            [[0.35, 0.94, 0.10, 0.31], [0.05, 0.16, 0.46, 0.11]], requires_grad=True
+        )
+        self.model(x).sum().backward()
+
+        # Regrow weights per the largest abs gradients.
+        global_add_by_grad(sparse_modules, num_add=12)
+        self.model.apply(rezero_weights)
+
+        # Validate regrown weights
+        expected_w1 = torch.tensor(
+            [
+                [0.0000, 0.3400, 0.0000, -0.4500],
+                [-0.3700, 0.0000, 0.0000, -0.4500],
+                [-0.3100, 0.0000, 0.0000, 0.0000],
+                [0.4200, 0.0000, 0.0000, 0.0000],
+            ]
+        )
+        self.assertTrue(all_close(self.model.lin1.weight, expected_w1))
+
+        expected_w2 = torch.tensor(
+            [
+                [0.0000, 0.0000, 0.0000, 0.0000],
+                [0.0000, 0.2800, 0.0000, 0.0000],
+                [0.0000, 0.0000, 0.0000, 0.0000],
+                [0.0000, 0.0000, 0.0000, 0.0000],
+            ]
+        )
+        self.assertTrue(all_close(self.model.lin2.weight, expected_w2))
+
+        expected_w3 = torch.tensor(
+            [
+                [0.0000, 0.0000, 0.0000, 0.0000],
+                [0.0000, -0.3600, 0.0000, -0.4300],
+                [0.0000, 0.3300, 0.0000, -0.5000],
+                [0.0000, 0.0000, 0.4100, 0.0000],
+            ]
+        )
+        self.assertTrue(all_close(self.model.lin3.weight, expected_w3))
+
+        # Validate regrown mask is a subset of the pruned mask.
+        self.assertTrue((self.model.lin1.zero_mask <= pruned_lin1_mask).all())
+        self.assertTrue((self.model.lin2.zero_mask <= pruned_lin2_mask).all())
+        self.assertTrue((self.model.lin3.zero_mask <= pruned_lin3_mask).all())
+
+        # Validate number of off weights.
+        zero_masks = parameters_to_vector(self.model.buffers())
+        weights = parameters_to_vector(self.model.parameters())
+        self.assertEqual((weights == 0).sum(), 36)
+        self.assertEqual(zero_masks.sum(), 24)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/tests/unit/frameworks/dynamic_sparse/global_pruning_test.py
+++ b/tests/unit/frameworks/dynamic_sparse/global_pruning_test.py
@@ -26,8 +26,8 @@ import torch
 from torch.nn.utils import parameters_to_vector
 
 from nupic.research.frameworks.dynamic_sparse import (
-    global_add_by_grad,
-    global_prune_by_weight,
+    global_add_by_abs_grad,
+    global_prune_by_abs_weight,
 )
 from nupic.torch.modules import SparseWeights, rezero_weights
 
@@ -141,7 +141,7 @@ class GlobalPruningTest(unittest.TestCase):
         # ----------
 
         sparse_modules = [self.model.lin1, self.model.lin2, self.model.lin3]
-        global_prune_by_weight(sparse_modules, prune_fraction=0.5)
+        global_prune_by_abs_weight(sparse_modules, prune_fraction=0.5)
         self.model.apply(rezero_weights)
 
         # Validate pruned weights
@@ -200,7 +200,7 @@ class GlobalPruningTest(unittest.TestCase):
         self.model(x).sum().backward()
 
         # Regrow weights per the largest abs gradients.
-        global_add_by_grad(sparse_modules, num_add=12)
+        global_add_by_abs_grad(sparse_modules, num_add=12)
         self.model.apply(rezero_weights)
 
         # Validate regrown weights


### PR DESCRIPTION
### **RigL**
The PR includes utilities for global pruning by RigL:
* Methods to prune by weight and add by grad and associated tests 
* A `CosineDecayPruneScheduler` class for decaying the pruning rate throughout training
* HF Trainer `RigLCallback` to integrate these utilities and train SparseWeight models using RigL
* HF Trainer `PlotDensitiesCallback` to log the densities of each layer

Main Results:
| model                        | train loss  | eval loss      | perplexity |
|------------------------------|:-----------:|:--------------:|:----------:|
| tiny_bert_static_sparse_300k | 4.537       | 3.997          | 54.432     |
| tiny_bert_rigl_sparse_300k   | 5.963       | 5.774          | 321.95     |

^Note: These are sparse models.

### **OneCycleLR**
This PR also includes mixins for using the OneCycleLR scheduler and a LR Range Test mixin to help find good bounds for the max and min learning rates. The results are below. The max_lr was tuned tuned manually to be 0.01 while all the other params go by the default for the scheduler. 

| model                      | train loss  | eval loss      | perplexity |
|----------------------------|:-----------:|:--------------:|:----------:|
| tiny_bert_50k              | 5.990       | 5.800          | 330.234    |
| tiny_bert_one_cycle_lr_50k | 4.083       | 3.605          | 36.767     |

^Note: These are dense models.

TODO:
* Ideally, the `trainer_extra_kwargs` will be logged to wandb so that the lr params therein get logged. I'm currently looking into this and will add it in a future PR.