### PR TITLE
Mixin for plotting context vectors

### DIFF
--- a/nupic/research/frameworks/dendrites/metrics/__init__.py
+++ b/nupic/research/frameworks/dendrites/metrics/__init__.py
@@ -20,6 +20,7 @@
 # ----------------------------------------------------------------------
 
 from .metrics import (
+    contexts_by_class,
     dendrite_activations_by_unit,
     dendrite_duty_cycle,
     dendrite_overlap,
@@ -34,6 +35,7 @@ from .metrics import (
     winning_segment_indices,
 )
 from .plotting import (
+    plot_contexts_by_class,
     plot_dendrite_activations,
     plot_dendrite_activations_by_unit,
     plot_dendrite_overlap_matrix,

--- a/nupic/research/frameworks/dendrites/metrics/metrics.py
+++ b/nupic/research/frameworks/dendrites/metrics/metrics.py
@@ -222,8 +222,9 @@ def contexts_by_class(contexts, targets):
         num_categories = 1 + targets.max().item()
         _, dim_context = contexts.size()
 
-        _contexts_by_class = torch.zeros((0, dim_context))
-        _contexts_by_class = _contexts_by_class.to(device)
+        # 'cbc' is an abbreviation for 'contexts by class'
+        cbc = torch.zeros((0, dim_context))
+        cbc = cbc.to(device)
 
         for t in range(num_categories):
             inds_t = torch.nonzero((targets == t).float(), as_tuple=True)
@@ -236,9 +237,9 @@ def contexts_by_class(contexts, targets):
             contexts_t = contexts_t.mean(dim=0)
             contexts_t = contexts_t.unsqueeze(0)
 
-            _contexts_by_class = torch.cat((_contexts_by_class, contexts_t))
+            cbc = torch.cat((cbc, contexts_t))
 
-        return _contexts_by_class
+        return cbc
 
 
 def dendrite_overlap_matrix(winning_mask, targets):

--- a/nupic/research/frameworks/dendrites/metrics/plotting.py
+++ b/nupic/research/frameworks/dendrites/metrics/plotting.py
@@ -25,6 +25,7 @@ import seaborn as sns
 import torch
 
 from .metrics import (
+    contexts_by_class,
     dendrite_activations_by_unit,
     dendrite_duty_cycle,
     dendrite_overlap,
@@ -300,6 +301,39 @@ def plot_hidden_activations_by_unit(activations, targets, category_names=None,
     ax.imshow(activations, cmap="PiYG", vmin=-max_val, vmax=max_val)
 
     ax.set_xlabel("hidden unit")
+    ax.set_ylabel("category")
+
+    plt.tight_layout()
+    figure = plt.gcf()
+    return figure
+
+
+def plot_contexts_by_class(contexts, targets, dims_to_plot=64):
+    """
+    Returns a heatmap with shape (num_categories, dim_context) where cell c, k gives
+    the fraction of instances of category c for which feature/dimension k of the
+    context signal generated for an input of said class was non-zero. All values are in
+    the range [0, 1].
+
+    :param contexts: 2D torch tensor with shape (batch_size, dim_context) where row b
+                     gives the context signal for the bth input
+    :param targets: 1D torch tensor with shape (batch_size,) where entry b gives the
+                    target label for example b
+    :param dims_to_plot: an integer which gives how many columns/features to show, for
+                         ease of visualization; only the first dims_to_plot units are
+                         shown
+    """
+    contexts = contexts_by_class(contexts, targets)
+
+    if dims_to_plot is not None:
+        contexts = contexts[:, :dims_to_plot]
+    contexts = contexts.detach().cpu().numpy()
+
+    plt.cla()
+    fig, ax = plt.subplots()
+    ax.imshow(contexts, cmap="binary", vmin=0)
+
+    ax.set_xlabel("context feature")
     ax.set_ylabel("category")
 
     plt.tight_layout()

--- a/nupic/research/frameworks/vernon/mixins/__init__.py
+++ b/nupic/research/frameworks/vernon/mixins/__init__.py
@@ -22,6 +22,7 @@
 from .composite_loss import CompositeLoss
 from .configure_optimizer_param_groups import ConfigureOptimizerParamGroups
 from .constrain_parameters import ConstrainParameters
+from .context_signal import *
 from .cutmix import CutMix, CutMixKnowledgeDistillation
 from .delay_load_checkpoint import *
 from .dendrite_metrics import *
@@ -48,6 +49,7 @@ from .prune_low_snr import PruneLowSNR
 from .quantization_aware import QuantizationAware
 from .reduce_lr_after_task import ReduceLRAfterTask
 from .regularize_loss import RegularizeLoss
+from .report_max_accuracy import ReportMaxAccuracy
 from .representation_overlap import *
 from .rezero_weights import RezeroWeights
 from .save_final_checkpoint import SaveFinalCheckpoint
@@ -56,4 +58,3 @@ from .track_representation_sparsity import *
 from .update_boost_strength import UpdateBoostStrength
 from .update_dendrite_boost_strength import UpdateDendriteBoostStrength
 from .vary_batch_size import VaryBatchSize
-from .report_max_accuracy import ReportMaxAccuracy

--- a/nupic/research/frameworks/vernon/mixins/context_signal.py
+++ b/nupic/research/frameworks/vernon/mixins/context_signal.py
@@ -1,0 +1,166 @@
+# ----------------------------------------------------------------------
+# Numenta Platform for Intelligent Computing (NuPIC)
+# Copyright (C) 2021, Numenta, Inc.  Unless you have an agreement
+# with Numenta, Inc., for a separate license for this software code, the
+# following terms and conditions apply:
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# See the GNU Affero Public License for more details.
+#
+# You should have received a copy of the GNU Affero Public License
+# along with this program.  If not, see http://www.gnu.org/licenses.
+#
+# http://numenta.org/licenses/
+# ----------------------------------------------------------------------
+
+import abc
+from copy import deepcopy
+from pprint import pformat
+
+import torch
+
+from nupic.research.frameworks.dendrites import plot_contexts_by_class
+from nupic.research.frameworks.pytorch.hooks import (
+    ModelHookManager,
+    TrackHiddenActivationsHook,
+)
+from nupic.research.frameworks.pytorch.model_utils import filter_modules
+
+__all__ = [
+    "PlotContextSignal"
+]
+
+
+class PlotContextSignal(metaclass=abc.ABCMeta):
+    """
+    Mixin for creating plots of the context vectors used to modulate dendritic
+    networks.
+
+    :param config: a dict containing the following
+
+        - plot_context_args: a dict containing the following
+
+            - include_modules: (optional) a list of module types to track
+            - include_names: (optional) a list of module names to track e.g.
+                             "features.stem"
+            - include_patterns: (optional) a list of regex patterns to compare to the
+                                names; for instance, all feature parameters in ResNet
+                                can be included through "features.*"
+            - plot_freq: (optional) how often to create the plot, measured in training
+                         iterations; defaults to 1
+            - max_samples_to_plot: (optional) how many of samples to use for plotting;
+                                   only the newest will be used; defaults to 5000
+
+    Example config:
+    ```
+    config=dict(
+        plot_context_args=dict(
+            include_names=["context_net"],
+            plot_freq=1,
+            max_samples_to_plot=2000
+        ),
+    )
+    ```
+    where `context_net` is assumed to refer to the module whose outputs are context
+    vectors used to modulate a dendritic network.
+    """
+
+    def setup_experiment(self, config):
+        super().setup_experiment(config)
+
+        # Process config args
+        context_args = config.get("plot_context_args", {})
+        context_plot_freq, filter_args, max_samples = process_context_args(context_args)
+
+        self.context_plot_freq = context_plot_freq
+        self.context_max_samples = max_samples
+
+        # Register hook for tracking context vectors
+        named_modules = filter_modules(self.model, **filter_args)
+        hook_args = dict(max_samples_to_track=self.context_max_samples)
+        self.context_hook = ModelHookManager(named_modules,
+                                             TrackHiddenActivationsHook,
+                                             hook_args=hook_args)
+
+        # Log the names of the modules being tracked
+        tracked_names = pformat(list(named_modules.keys()))
+        self.logger.info(f"Tracking context signals output from: {tracked_names}")
+
+        # The targets will be collected in `self.error_loss` in a 1:1 fashion
+        # to the tensors being collected by the hooks.
+        self.context_targets = torch.tensor([]).long()
+
+    def run_epoch(self):
+        """
+        This runs the epoch with the hooks in tracking mode. The resulting context
+        vectors collected by the `TrackHiddenActivationsHook` object are plotted by
+        calling a plotting function.
+        """
+
+        # Run the epoch with tracking enabled.
+        with self.context_hook:
+            results = super().run_epoch()
+
+        # The epoch was iterated in `run_epoch` so epoch 0 is really epoch 1 here.
+        iteration = self.current_epoch + 1
+
+        # Create visualization, and update results dict.
+        if iteration % self.context_plot_freq == 0:
+
+            for name, _, contexts in self.context_hook.get_statistics():
+
+                visual = plot_contexts_by_class(contexts, self.context_targets)
+                results.update({f"contexts/{name}": visual})
+
+        return results
+
+    def error_loss(self, output, target, reduction="mean"):
+        """
+        This computes the loss and then saves the targets computed on this loss. This
+        mixin assumes these targets correspond, in a 1:1 fashion, to the samples seen
+        in the forward pass.
+        """
+        loss = super().error_loss(output, target, reduction=reduction)
+        if self.context_hook.tracking:
+
+            # Targets were initialized on the cpu which could differ from the
+            # targets collected during the forward pass.
+            self.context_targets = self.context_targets.to(target.device)
+
+            # Concatenate and discard the older targets.
+            self.context_targets = torch.cat([target, self.context_targets], dim=0)
+            self.context_targets = self.context_targets[:self.context_max_samples]
+
+        return loss
+
+
+def process_context_args(context_args):
+
+    context_args = deepcopy(context_args)
+
+    # Collect information about which modules to apply hooks to
+    include_names = context_args.pop("include_names", [])
+    include_modules = context_args.pop("include_modules", [])
+    include_patterns = context_args.pop("include_patterns", [])
+    filter_args = dict(
+        include_names=include_names,
+        include_modules=include_modules,
+        include_patterns=include_patterns,
+    )
+
+    # Others args
+    plot_freq = context_args.get("plot_freq", 1)
+    max_samples = context_args.get("max_samples_to_plot", 1000)
+
+    assert isinstance(plot_freq, int)
+    assert isinstance(max_samples, int)
+    assert plot_freq > 0
+    assert max_samples > 0
+
+    return plot_freq, filter_args, max_samples


### PR DESCRIPTION
This new mixin is similar to `PlotHiddenActivations`, but plots context vectors (generated by a dendritic network directly from the input) instead. [Here](https://drive.google.com/file/d/10oHOqLZWsRYO5PYdZcdA_WNEqDCaoAnP/view?usp=sharing) is the resulting plot, where cell c, k gives the fraction of instances of category c for which feature k in the context vector was 'on'. It requires a new plotting function for visualization.

The easiest use case is to set `include_names` or `include_modules` in the config to refer to the modules that output the context vector, then a hook is registered that tracks its outputs.

In the future, we'll have to address how to unify all these mixins, since
- many of them have related functions, and we can probably reduce the amount of code that achieves the same goal, and
- the memory costs grow with the number of such mixins used in an experiment (e.g., each such mixin tracks target variables (`context_targets` in this case), which are all just duplicates of each other,

but I wouldn't worry about this for now.