### PR TITLE
Remove use of `trainer_extra_kwargs`

### DIFF
--- a/projects/transformers/experiments/distillation.py
+++ b/projects/transformers/experiments/distillation.py
@@ -113,9 +113,6 @@ tiny_bert_100k_kd.update(
 # 2.25 steps/sec
 tiny_bert_50k_kd = deepcopy(tiny_bert_100k_kd)
 tiny_bert_50k_kd.update(
-    teacher_models_name_or_path=[
-        "/mnt/efs/results/pretrained-models/transformers-local/bert_1mi",
-    ],
     overwrite_output_dir=True,
 
     # Training Arguments
@@ -128,6 +125,16 @@ tiny_bert_50k_kd.update(
     warmup_steps=1000,
     max_steps=50000,
     lr_scheduler_type="linear",
+
+    mixin_args=dict(
+        teacher_model_names_or_paths=[
+            "/mnt/efs/results/pretrained-models/transformers-local/bert_1mi"
+        ],
+        kd_factor_init=1.0,
+        kd_factor_end=1.0,
+        kd_temperature_init=1.0,
+        kd_temperature_end=1.0,
+    ),
 )
 
 

--- a/projects/transformers/experiments/distillation.py
+++ b/projects/transformers/experiments/distillation.py
@@ -53,7 +53,7 @@ debug_bert_kd.update(
     # Distillation Arguments
     trainer_class=DistillationTrainer,
 
-    mixin_args=dict(
+    trainer_mixin_args=dict(
         # kd_ensemble_weights=None,
         teacher_model_names_or_paths=["bert-large-cased"],
         teacher_model_cache_dir="/mnt/efs/results/pretrained-models/huggingface",
@@ -90,7 +90,7 @@ tiny_bert_100k_kd.update(
 
     # Distillation Arguments
     trainer_class=DistillationTrainer,
-    mixin_args=dict(
+    trainer_mixin_args=dict(
         # kd_ensemble_weights=None,
         teacher_model_names_or_paths=[
             "bert-base-cased"
@@ -126,7 +126,7 @@ tiny_bert_50k_kd.update(
     max_steps=50000,
     lr_scheduler_type="linear",
 
-    mixin_args=dict(
+    trainer_mixin_args=dict(
         teacher_model_names_or_paths=[
             "/mnt/efs/results/pretrained-models/transformers-local/bert_1mi"
         ],

--- a/projects/transformers/experiments/distillation.py
+++ b/projects/transformers/experiments/distillation.py
@@ -52,12 +52,11 @@ debug_bert_kd.update(
 
     # Distillation Arguments
     trainer_class=DistillationTrainer,
-    teacher_models_name_or_path=[
-        "bert-large-cased",
-        # "roberta-large"
-    ],
-    trainer_extra_kwargs=dict(
+
+    mixin_args=dict(
         # kd_ensemble_weights=None,
+        teacher_model_names_or_paths=["bert-large-cased"],
+        teacher_model_cache_dir="/mnt/efs/results/pretrained-models/huggingface",
         kd_factor_init=1.0,
         kd_factor_end=1.0,
         kd_temperature_init=1.0,
@@ -91,13 +90,14 @@ tiny_bert_100k_kd.update(
 
     # Distillation Arguments
     trainer_class=DistillationTrainer,
-    teacher_models_name_or_path=[
-        "bert-base-cased"
-        # "prajjwal1/bert-tiny",
-        # "roberta-large"
-    ],
-    trainer_extra_kwargs=dict(
+    mixin_args=dict(
         # kd_ensemble_weights=None,
+        teacher_model_names_or_paths=[
+            "bert-base-cased"
+            # "prajjwal1/bert-tiny",
+            # "roberta-large"
+        ],
+        teacher_model_cache_dir="/mnt/efs/results/pretrained-models/huggingface",
         kd_factor_init=1.0,
         kd_factor_end=1.0,
         kd_temperature_init=1.0,

--- a/projects/transformers/experiments/one_cycle_lr.py
+++ b/projects/transformers/experiments/one_cycle_lr.py
@@ -65,7 +65,7 @@ tiny_bert_one_cycle_lr_debug.update(
     logging_steps=1,
     logging_first_step=True,
 
-    trainer_extra_kwargs=dict(
+    mixin_args=dict(
         max_lr=1.0,
         pct_start=0.3,
         anneal_strategy="linear",
@@ -88,7 +88,7 @@ tiny_bert_one_cycle_lr_50k = deepcopy(tiny_bert_50k)
 tiny_bert_one_cycle_lr_50k.update(
 
     trainer_class=OneCycleLRTrainer,
-    trainer_extra_kwargs=dict(
+    mixin_args=dict(
         max_lr=0.01,
         pct_start=0.3,
         anneal_strategy="linear",
@@ -116,7 +116,7 @@ tiny_bert_linear_lr_range_test.update(
     overwrite_output_dir=True,
     do_eval=False,
     trainer_class=LRRangeTestTrainer,
-    trainer_extra_kwargs=dict(
+    mixin_args=dict(
         min_lr=1e-5,
         max_lr=0.5,
         test_mode="linear"
@@ -126,7 +126,7 @@ tiny_bert_linear_lr_range_test.update(
 
 # lr range test with exponential ramp up
 tiny_bert_exponential_lr_range_test = deepcopy(tiny_bert_linear_lr_range_test)
-tiny_bert_exponential_lr_range_test["trainer_extra_kwargs"].update(
+tiny_bert_exponential_lr_range_test["mixin_args"].update(
     test_mode="exponential"
 )
 

--- a/projects/transformers/experiments/one_cycle_lr.py
+++ b/projects/transformers/experiments/one_cycle_lr.py
@@ -65,7 +65,7 @@ tiny_bert_one_cycle_lr_debug.update(
     logging_steps=1,
     logging_first_step=True,
 
-    mixin_args=dict(
+    trainer_mixin_args=dict(
         max_lr=1.0,
         pct_start=0.3,
         anneal_strategy="linear",
@@ -88,7 +88,7 @@ tiny_bert_one_cycle_lr_50k = deepcopy(tiny_bert_50k)
 tiny_bert_one_cycle_lr_50k.update(
 
     trainer_class=OneCycleLRTrainer,
-    mixin_args=dict(
+    trainer_mixin_args=dict(
         max_lr=0.01,
         pct_start=0.3,
         anneal_strategy="linear",
@@ -116,7 +116,7 @@ tiny_bert_linear_lr_range_test.update(
     overwrite_output_dir=True,
     do_eval=False,
     trainer_class=LRRangeTestTrainer,
-    mixin_args=dict(
+    trainer_mixin_args=dict(
         min_lr=1e-5,
         max_lr=0.5,
         test_mode="linear"
@@ -126,7 +126,7 @@ tiny_bert_linear_lr_range_test.update(
 
 # lr range test with exponential ramp up
 tiny_bert_exponential_lr_range_test = deepcopy(tiny_bert_linear_lr_range_test)
-tiny_bert_exponential_lr_range_test["mixin_args"].update(
+tiny_bert_exponential_lr_range_test["trainer_mixin_args"].update(
     test_mode="exponential"
 )
 

--- a/projects/transformers/run.py
+++ b/projects/transformers/run.py
@@ -62,7 +62,6 @@ from run_utils import (
     init_datasets_mlm,
     init_datasets_task,
     init_model,
-    init_teacher_models,
     init_tokenizer,
     init_trainer,
     preprocess_datasets_mlm,
@@ -222,12 +221,6 @@ def run_pretraining(
         tokenizer=tokenizer, mlm_probability=data_args.mlm_probability
     )
 
-    # Initialize distillation models
-    if model_args.teacher_models_name_or_path:
-        model_args.trainer_extra_kwargs["teacher_models"] = init_teacher_models(
-            model_args, tokenizer
-        )
-
     # Run hp search or regular training
     if model_args.hp_num_trials >= 1:
         run_hyperparameter_search(
@@ -248,7 +241,6 @@ def run_pretraining(
             eval_dataset=eval_dataset if training_args.do_eval else None,
             model=init_model(model_args, config, tokenizer),
             trainer_class=model_args.trainer_class,
-            trainer_extra_kwargs=model_args.trainer_extra_kwargs,
             trainer_callbacks=model_args.trainer_callbacks or None,
         )
         if training_args.do_train:

--- a/projects/transformers/run_args.py
+++ b/projects/transformers/run_args.py
@@ -40,7 +40,7 @@ class CustomTrainingArguments(TrainingArguments):
             "help": "How many runs per task. Currently only used for finetuning."
         },
     )
-    mixin_args: Dict = field(
+    trainer_mixin_args: Dict = field(
         default_factory=dict,
         metadata={
             "help": "Extra arguments to be passed to Trainer. Can be accessed "

--- a/projects/transformers/run_args.py
+++ b/projects/transformers/run_args.py
@@ -40,6 +40,13 @@ class CustomTrainingArguments(TrainingArguments):
             "help": "How many runs per task. Currently only used for finetuning."
         },
     )
+    mixin_args: Dict = field(
+        default_factory=dict,
+        metadata={
+            "help": "Extra arguments to be passed to Trainer. Can be accessed "
+                    "for addition arguments when trainer mixins are used."
+        }
+    )
 
 
 @dataclass
@@ -132,20 +139,6 @@ class ModelArguments:
         default=Trainer,
         metadata={
             "help": "Trainer class"
-        }
-    )
-    teacher_models_name_or_path: List[str] = field(
-        default_factory=list,
-        metadata={
-            "help": "List of models names or paths for the teachers. If argument is "
-                    "provided, assumes distillation is being used"
-        }
-    )
-    trainer_extra_kwargs: Dict = field(
-        default_factory=dict,
-        metadata={
-            "help": "Extra keyword arguments to be passed to Trainer. Can be passed "
-                    "to pass extra arguments when trainer mixins are used."
         }
     )
     hp_space: Callable = field(

--- a/projects/transformers/trainer_mixins/distillation.py
+++ b/projects/transformers/trainer_mixins/distillation.py
@@ -44,7 +44,8 @@ class DistillationTrainerMixin:
 
     def __init__(self, *args, **kwargs):
         """
-        Add following variables under 'mixin_args' through the training arguments.
+        Add following variables under 'trainer_mixin_args' through the training
+        arguments.
 
         :param teacher_model_names_or_paths: List of pretrained model names or paths to
                                              use as teachers in knowledge distillation.
@@ -81,7 +82,7 @@ class DistillationTrainerMixin:
 
         super().__init__(*args, **kwargs)
 
-        mixin_args = self.args.mixin_args
+        mixin_args = self.args.trainer_mixin_args
 
         teacher_names_or_paths = mixin_args.get("teacher_model_names_or_paths", None)
         teacher_models_cache_dir = mixin_args.get("teacher_models_cache_dir", None)

--- a/projects/transformers/trainer_mixins/distillation.py
+++ b/projects/transformers/trainer_mixins/distillation.py
@@ -48,8 +48,8 @@ class DistillationTrainerMixin:
 
         :param teacher_model_names_or_paths: List of pretrained model names or paths to
                                              use as teachers in knowledge distillation.
-        :param teacher_model_cache_dir: (optional) directory to load and save
-                                        pre-trained teacher models
+        :param teacher_models_cache_dir: (optional) directory to load and save
+                                         pre-trained teacher models
         :param kd_ensemble_weights: List of weights to apply to each teacher model
                                 during distillation.
                                 If the total is > 1 the loss will be scaled out
@@ -84,7 +84,7 @@ class DistillationTrainerMixin:
         mixin_args = self.args.mixin_args
 
         teacher_names_or_paths = mixin_args.get("teacher_model_names_or_paths", None)
-        teacher_model_cache_dir = mixin_args.get("teacher_model_cache_dir", None)
+        teacher_models_cache_dir = mixin_args.get("teacher_models_cache_dir", None)
         kd_ensemble_weights = mixin_args.get("kd_ensemble_weights", None)
         kd_factor_init = mixin_args.get("kd_factor_init", 1.0)
         kd_factor_end = mixin_args.get("kd_factor_end", 1.0)
@@ -94,13 +94,13 @@ class DistillationTrainerMixin:
         # Validate teacher models
         assert (
             isinstance(teacher_names_or_paths, list) and len(teacher_names_or_paths) > 0
-        ), "When using KD mixin, teacher_models_name_or_path must be defined"
+        ), "When using KD mixin, teacher_model_names_or_paths must be defined"
 
         teacher_models = []
         for model_name_or_path in teacher_names_or_paths:
             teacher_model = AutoModelForMaskedLM.from_pretrained(
                 model_name_or_path,
-                cache_dir=teacher_model_cache_dir
+                cache_dir=teacher_models_cache_dir
             )
             teacher_model.resize_token_embeddings(len(self.tokenizer))
             teacher_models.append(teacher_model)

--- a/projects/transformers/trainer_mixins/lr_range_test.py
+++ b/projects/transformers/trainer_mixins/lr_range_test.py
@@ -38,7 +38,7 @@ class LRRangeTestMixin:
     this is the case if your training loss increases at all during training. For your
     min_lr, the author recommends using 10-20 times lower than the max_lr.
 
-    Params to add to 'mixin_args':
+    Params to add to 'trainer_mixin_args':
     :param min_lr: starting lr
     :param max_lr: ending lr; presumed to be larger than min_lr
     :param test_mode: either linear or exponential
@@ -56,9 +56,9 @@ class LRRangeTestMixin:
 
         super().__init__(*args, **kwargs)
 
-        self.min_lr = self.args.mixin_args.get("min_lr", None)
-        self.max_lr = self.args.mixin_args.get("max_lr", None)
-        self.test_mode = self.args.mixin_args.get("test_mode", "linear")
+        self.min_lr = self.args.trainer_mixin_args.get("min_lr", None)
+        self.max_lr = self.args.trainer_mixin_args.get("max_lr", None)
+        self.test_mode = self.args.trainer_mixin_args.get("test_mode", "linear")
 
         assert isinstance(self.min_lr, float)
         assert isinstance(self.max_lr, float)

--- a/projects/transformers/trainer_mixins/lr_range_test.py
+++ b/projects/transformers/trainer_mixins/lr_range_test.py
@@ -38,17 +38,12 @@ class LRRangeTestMixin:
     this is the case if your training loss increases at all during training. For your
     min_lr, the author recommends using 10-20 times lower than the max_lr.
 
+    Params to add to 'mixin_args':
     :param min_lr: starting lr
     :param max_lr: ending lr; presumed to be larger than min_lr
     :param test_mode: either linear or exponential
     """
-    def __init__(
-        self,
-        min_lr=None,
-        max_lr=None,
-        test_mode="linear",
-        **kwargs,
-    ):
+    def __init__(self, *args, **kwargs):
 
         # The LambdaLR will multiply this base lr of 1 times the one at the given step.
         kwargs["args"].learning_rate = 1
@@ -59,13 +54,15 @@ class LRRangeTestMixin:
         # Turn off eval since it's satisfactory to just look at the training loss.
         kwargs["args"].do_eval = False
 
-        super().__init__(**kwargs)
-        assert isinstance(min_lr, float)
-        assert isinstance(max_lr, float)
-        assert test_mode in ["linear", "exponential"]
-        self.min_lr = min_lr
-        self.max_lr = max_lr
-        self.test_mode = test_mode
+        super().__init__(*args, **kwargs)
+
+        self.min_lr = self.args.mixin_args.get("min_lr", None)
+        self.max_lr = self.args.mixin_args.get("max_lr", None)
+        self.test_mode = self.args.mixin_args.get("test_mode", "linear")
+
+        assert isinstance(self.min_lr, float)
+        assert isinstance(self.max_lr, float)
+        assert self.test_mode in ["linear", "exponential"]
 
     def create_optimizer_and_scheduler(self, num_training_steps: int):
         """

--- a/projects/transformers/trainer_mixins/one_cycle_lr.py
+++ b/projects/transformers/trainer_mixins/one_cycle_lr.py
@@ -25,36 +25,25 @@ from torch.optim.lr_scheduler import OneCycleLR
 class OneCycleLRMixin:
     """
     Mixin to HF Trainer for using the `OneCycleLR`_. See documentation for argument
-    details.
+    details. Arguments for the one-cycle lr schedule must be passed though 'mixin_args'.
 
     .. _OneCycleLR:
         https://pytorch.org/docs/stable/optim.html#torch.optim.lr_scheduler.OneCycleLR
     """
 
-    def __init__(
-        self,
-        max_lr=1e-2,
-        pct_start=0.3,
-        anneal_strategy="linear",
-        cycle_momentum=True,
-        base_momentum=0.85,
-        max_momentum=0.95,
-        div_factor=25,
-        final_div_factor=1e4,
-        last_epoch=-1,
-        **kwargs,
-    ):
-        super().__init__(**kwargs)
+    def __init__(self, *args, **kwargs):
 
-        self.max_lr = max_lr
-        self.pct_start = pct_start
-        self.anneal_strategy = anneal_strategy
-        self.cycle_momentum = cycle_momentum
-        self.base_momentum = base_momentum
-        self.max_momentum = max_momentum
-        self.div_factor = div_factor
-        self.final_div_factor = final_div_factor
-        self.last_epoch = last_epoch
+        super().__init__(*args, **kwargs)
+
+        self.max_lr = self.args.mixin_args.get("max_lr", 1e-2)
+        self.pct_start = self.args.mixin_args.get("pct_start", 0.3)
+        self.anneal_strategy = self.args.mixin_args.get("anneal_strategy", "linear")
+        self.cycle_momentum = self.args.mixin_args.get("cycle_momentum", True)
+        self.base_momentum = self.args.mixin_args.get("base_momentum", 0.85)
+        self.max_momentum = self.args.mixin_args.get("max_momentum", 0.95)
+        self.div_factor = self.args.mixin_args.get("div_factor", 25)
+        self.final_div_factor = self.args.mixin_args.get("final_div_factor", 1e4)
+        self.last_epoch = self.args.mixin_args.get("last_epoch", -1)
 
     def create_optimizer_and_scheduler(self, num_training_steps: int):
         """

--- a/projects/transformers/trainer_mixins/one_cycle_lr.py
+++ b/projects/transformers/trainer_mixins/one_cycle_lr.py
@@ -25,7 +25,8 @@ from torch.optim.lr_scheduler import OneCycleLR
 class OneCycleLRMixin:
     """
     Mixin to HF Trainer for using the `OneCycleLR`_. See documentation for argument
-    details. Arguments for the one-cycle lr schedule must be passed though 'mixin_args'.
+    details. Arguments for the one-cycle lr schedule must be passed though
+    'trainer_mixin_args'.
 
     .. _OneCycleLR:
         https://pytorch.org/docs/stable/optim.html#torch.optim.lr_scheduler.OneCycleLR
@@ -35,15 +36,17 @@ class OneCycleLRMixin:
 
         super().__init__(*args, **kwargs)
 
-        self.max_lr = self.args.mixin_args.get("max_lr", 1e-2)
-        self.pct_start = self.args.mixin_args.get("pct_start", 0.3)
-        self.anneal_strategy = self.args.mixin_args.get("anneal_strategy", "linear")
-        self.cycle_momentum = self.args.mixin_args.get("cycle_momentum", True)
-        self.base_momentum = self.args.mixin_args.get("base_momentum", 0.85)
-        self.max_momentum = self.args.mixin_args.get("max_momentum", 0.95)
-        self.div_factor = self.args.mixin_args.get("div_factor", 25)
-        self.final_div_factor = self.args.mixin_args.get("final_div_factor", 1e4)
-        self.last_epoch = self.args.mixin_args.get("last_epoch", -1)
+        mixin_args = self.args.trainer_mixin_args
+
+        self.max_lr = mixin_args.get("max_lr", 1e-2)
+        self.pct_start = mixin_args.get("pct_start", 0.3)
+        self.anneal_strategy = mixin_args.get("anneal_strategy", "linear")
+        self.cycle_momentum = mixin_args.get("cycle_momentum", True)
+        self.base_momentum = mixin_args.get("base_momentum", 0.85)
+        self.max_momentum = mixin_args.get("max_momentum", 0.95)
+        self.div_factor = mixin_args.get("div_factor", 25)
+        self.final_div_factor = mixin_args.get("final_div_factor", 1e4)
+        self.last_epoch = mixin_args.get("last_epoch", -1)
 
     def create_optimizer_and_scheduler(self, num_training_steps: int):
         """


### PR DESCRIPTION
This is a refactoring PR that replaces `trainer_extra_kwargs`, originally passed through `model_args`, to `mixin_args` which is now passed through `training_args`. This has two benefits:
1. These args are now log-able to wandb (they will show up under the run's config).
2. We can run an hp search over mixin related arguments.

Before, 2. was not doable since the hp_space method was only for updating the trainers `self.args`. Now `mixin_args` are a subset of these and can be tuned as needed. As well, the code should be a bit cleaner and easier to use (hopefully).