### PR TITLE
permutedMNIST

### DIFF
--- a/nupic/research/frameworks/pytorch/datasets/__init__.py
+++ b/nupic/research/frameworks/pytorch/datasets/__init__.py
@@ -20,5 +20,6 @@
 # ----------------------------------------------------------------------
 
 from .gsc_factory import download_gsc_data, preprocessed_gsc
-from .torchvision_factory import torchvisiondataset, omniglot
 from .imagenet_factory import imagenet
+from .permuted_mnist import ContextDependentPermutedMNIST, PermutedMNIST
+from .torchvision_factory import omniglot, torchvisiondataset

--- a/nupic/research/frameworks/pytorch/datasets/permuted_mnist.py
+++ b/nupic/research/frameworks/pytorch/datasets/permuted_mnist.py
@@ -109,11 +109,11 @@ class ContextDependentPermutedMNIST(PermutedMNIST):
 
     def __getitem__(self, index):
         """
-        Returns an (image, context, target) triplet.
+        Returns an ((image, context), target) tuple.
         """
         img, target = super().__getitem__(index)
         task_id = self.get_task_id(index)
-        return img, self.contexts[task_id, :], target
+        return (img, self.contexts[task_id, :]), target
 
     def init_contexts(self, seed):
         percent_on = 0.05

--- a/nupic/research/frameworks/pytorch/datasets/permuted_mnist.py
+++ b/nupic/research/frameworks/pytorch/datasets/permuted_mnist.py
@@ -1,0 +1,145 @@
+# ----------------------------------------------------------------------
+# Numenta Platform for Intelligent Computing (NuPIC)
+# Copyright (C) 2021, Numenta, Inc.  Unless you have an agreement
+# with Numenta, Inc., for a separate license for this software code, the
+# following terms and conditions apply:
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# See the GNU Affero Public License for more details.
+#
+# You should have received a copy of the GNU Affero Public License
+# along with this program.  If not, see http://www.gnu.org/licenses.
+#
+# http://numenta.org/licenses/
+# ----------------------------------------------------------------------
+
+import os
+
+import torch
+from torchvision import transforms
+from torchvision.datasets import MNIST
+
+from nupic.research.frameworks.dendrites.routing import generate_context_vectors
+
+
+class PermutedMNIST(MNIST):
+    """
+    The permutedMNIST dataset contains MNIST images where the same random permutation
+    of pixel values is applied to each image. More specifically, the dataset can be
+    broken down into 'tasks', where each such task is the set of all MNIST images, but
+    with a unique pixel-wise permutation applied to all images. `num_tasks` gives the
+    number of 10-way classification tasks (each corresponding to a unique pixel-wise
+    permutation) that a continual learner will try to learn in sequence.
+    """
+
+    # Permutations should be the same whether this class is instantiated for training
+    # or testing
+    permutations = None
+
+    def __init__(self, num_tasks, train, root=".", target_transform=None,
+                 download=False):
+
+        data_transform = transforms.Compose([
+            transforms.ToTensor(),
+            transforms.Normalize((0.13062755,), (0.30810780,)),
+        ])
+        super().__init__(root=root, train=train, transform=data_transform,
+                         target_transform=target_transform, download=download)
+
+        self.num_tasks = num_tasks
+
+        # Generate num_tasks random permutations - the first one is the identity
+        # permutation (i.e., regular MNIST), represented below as `None`
+        if PermutedMNIST.permutations is None:
+            PermutedMNIST.permutations = [
+                torch.randperm(784) for task_id in range(1, num_tasks)
+            ]
+            PermutedMNIST.permutations.insert(0, None)
+
+        self.permutations = PermutedMNIST.permutations
+
+    def __getitem__(self, index):
+        """
+        Returns an (image, target) pair.
+
+        In particular, this method retrieves an MNIST image, and based on the value of
+        `index`, determines which pixel-wise permutation to apply. Target values are
+        also scaled to be unique to each permutation.
+        """
+        img, target = super().__getitem__(index % len(self.data))
+
+        # Determine which task `index` corresponds to
+        task_id = index // len(self.data)
+
+        # Apply permutation to `img`
+        img = permute(img, self.permutations[task_id])
+
+        # Since target values are not shared between tasks, `target` should be in the
+        # range [0 + 10 * task_id, 9 + 10 * task_id]
+        target += 10 * task_id
+
+        # Since image size is not relevant for an MLP, `img` can be flattened
+        return img.flatten(), target
+
+    def __len__(self):
+        return self.num_tasks * len(self.data)
+
+    @property
+    def processed_folder(self):
+        return os.path.join(self.root, "MNIST", "processed")
+
+
+class ContextDependentPermutedMNIST(PermutedMNIST):
+    """
+    A variant of permutedMNIST where each permutation (i.e., 'task') is associated with
+    a context: a binary sparse vector. The `__getitem__` method returns the context
+    vector along with the data sample and target.
+    """
+
+    # Context vectors should be the same whether this class is instantiated for
+    # training or testing
+    contexts = None
+
+    def __init__(self, num_tasks, dim_context, train, root=".", target_transform=None,
+                 download=False):
+
+        super().__init__(num_tasks, train, root, target_transform, download)
+
+        # Generate context vectors if `contexts` isn't already defined
+        if ContextDependentPermutedMNIST.contexts is None:
+            ContextDependentPermutedMNIST.contexts = generate_context_vectors(
+                num_contexts=num_tasks, n_dim=dim_context, percent_on=0.05
+            )
+
+        self.contexts = ContextDependentPermutedMNIST.contexts
+
+    def __getitem__(self, index):
+        """
+        Returns an (image, context, target) triplet.
+        """
+        img, target = super().__getitem__(index)
+        task_id = index // len(self.data)
+        return img, self.contexts[task_id, :], target
+
+
+def permute(x, permutation):
+    """
+    Applies the permutation specified by `permutation` to `x` and returns the resulting
+    tensor.
+    """
+
+    # Assume x has shape (1, height, width)
+    if permutation is None:
+        return x
+
+    _, height, width = x.size()
+    x = x.view(-1, 1)
+    x = x[permutation, :]
+    x = x.view(1, height, width)
+    return x

--- a/nupic/research/frameworks/pytorch/datasets/permuted_mnist.py
+++ b/nupic/research/frameworks/pytorch/datasets/permuted_mnist.py
@@ -75,7 +75,7 @@ class PermutedMNIST(MNIST):
         img, target = super().__getitem__(index % len(self.data))
 
         # Determine which task `index` corresponds to
-        task_id = index // len(self.data)
+        task_id = self.get_task_id(index)
 
         # Apply permutation to `img`
         img = permute(img, self.permutations[task_id])
@@ -83,9 +83,7 @@ class PermutedMNIST(MNIST):
         # Since target values are not shared between tasks, `target` should be in the
         # range [0 + 10 * task_id, 9 + 10 * task_id]
         target += 10 * task_id
-
-        # Since image size is not relevant for an MLP, `img` can be flattened
-        return img.flatten(), target
+        return img, target
 
     def __len__(self):
         return self.num_tasks * len(self.data)
@@ -93,6 +91,9 @@ class PermutedMNIST(MNIST):
     @property
     def processed_folder(self):
         return os.path.join(self.root, "MNIST", "processed")
+
+    def get_task_id(self, index):
+        return index // len(self.data)
 
 
 class ContextDependentPermutedMNIST(PermutedMNIST):
@@ -124,7 +125,7 @@ class ContextDependentPermutedMNIST(PermutedMNIST):
         Returns an (image, context, target) triplet.
         """
         img, target = super().__getitem__(index)
-        task_id = index // len(self.data)
+        task_id = self.get_task_id(index)
         return img, self.contexts[task_id, :], target
 
 

--- a/nupic/research/frameworks/vernon/experiments/cl_experiment.py
+++ b/nupic/research/frameworks/vernon/experiments/cl_experiment.py
@@ -138,8 +138,7 @@ class ContinualLearningExperiment(
     def compute_task_indices(cls, config, dataset):
         # Assume dataloaders are already created
         class_indices = defaultdict(list)
-        for idx, batch_item in enumerate(dataset):
-            target = batch_item[-1]
+        for idx, (_, target) in enumerate(dataset):
             class_indices[target].append(idx)
 
         # Defines how many classes should exist per task

--- a/nupic/research/frameworks/vernon/experiments/cl_experiment.py
+++ b/nupic/research/frameworks/vernon/experiments/cl_experiment.py
@@ -138,7 +138,8 @@ class ContinualLearningExperiment(
     def compute_task_indices(cls, config, dataset):
         # Assume dataloaders are already created
         class_indices = defaultdict(list)
-        for idx, (_, target) in enumerate(dataset):
+        for idx, batch_item in enumerate(dataset):
+            target = batch_item[-1]
             class_indices[target].append(idx)
 
         # Defines how many classes should exist per task

--- a/projects/dendrites/gaussian_classification/run_dendritic_network.py
+++ b/projects/dendrites/gaussian_classification/run_dendritic_network.py
@@ -31,10 +31,8 @@ Usage: adjust the config parameters `kw`, `dendrite_sparsity`, `weight_init`,
 `dendrite_init`, and `freeze_dendrites` (all in `model_args`).
 """
 
-import math
 import pprint
 import time
-from collections import defaultdict
 
 import torch
 import torch.nn.functional as F
@@ -59,25 +57,6 @@ class DendritesExperiment(mixins.RezeroWeights,
             self.model.hardcode_dendritic_weights(
                 context_vectors=self.train_loader.dataset._contexts, init="overlapping"
             )
-
-    @classmethod
-    def compute_task_indices(cls, config, dataset):
-        # Assume dataloaders are already created
-        class_indices = defaultdict(list)
-        for idx, (_, _, target) in enumerate(dataset):
-            class_indices[target].append(idx)
-
-        # Defines how many classes should exist per task
-        num_tasks = config.get("num_tasks", 1)
-        num_classes = config.get("num_classes", None)
-        assert num_classes is not None, "num_classes should be defined"
-        num_classes_per_task = math.floor(num_classes / num_tasks)
-
-        task_indices = defaultdict(list)
-        for i in range(num_tasks):
-            for j in range(num_classes_per_task):
-                task_indices[i].extend(class_indices[j + (i * num_classes_per_task)])
-        return task_indices
 
 
 # ------ Training & evaluation function

--- a/projects/dendrites/permutedMNIST/run_dendritic_network.py
+++ b/projects/dendrites/permutedMNIST/run_dendritic_network.py
@@ -172,6 +172,7 @@ if __name__ == "__main__":
         dataset_args=dict(
             num_tasks=num_tasks,
             dim_context=1024,
+            seed=np.random.randint(0, 1000),
         ),
 
         model_class=DendriticMLP,

--- a/projects/dendrites/permutedMNIST/run_dendritic_network.py
+++ b/projects/dendrites/permutedMNIST/run_dendritic_network.py
@@ -29,9 +29,6 @@ This setup is very similar to that of context-dependent gating model from the pa
 stabilization' (Masse et al., 2018).
 """
 
-import math
-from collections import defaultdict
-
 import numpy as np
 import torch
 import torch.nn.functional as F
@@ -44,25 +41,7 @@ from nupic.research.frameworks.vernon import ContinualLearningExperiment, mixins
 # ------ Experiment class
 class PermutedMNISTExperiment(mixins.RezeroWeights,
                               ContinualLearningExperiment):
-
-    @classmethod
-    def compute_task_indices(cls, config, dataset):
-        # Assume dataloaders are already created
-        class_indices = defaultdict(list)
-        for idx, (_, _, target) in enumerate(dataset):
-            class_indices[target].append(idx)
-
-        # Defines how many classes should exist per task
-        num_tasks = config.get("num_tasks", 1)
-        num_classes = config.get("num_classes", None)
-        assert num_classes is not None, "num_classes should be defined"
-        num_classes_per_task = math.floor(num_classes / num_tasks)
-
-        task_indices = defaultdict(list)
-        for i in range(num_tasks):
-            for j in range(num_classes_per_task):
-                task_indices[i].extend(class_indices[j + (i * num_classes_per_task)])
-        return task_indices
+    pass
 
 
 # ------ Training & evaluation functions

--- a/projects/dendrites/permutedMNIST/run_dendritic_network.py
+++ b/projects/dendrites/permutedMNIST/run_dendritic_network.py
@@ -1,0 +1,231 @@
+# ----------------------------------------------------------------------
+# Numenta Platform for Intelligent Computing (NuPIC)
+# Copyright (C) 2021, Numenta, Inc.  Unless you have an agreement
+# with Numenta, Inc., for a separate license for this software code, the
+# following terms and conditions apply:
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# See the GNU Affero Public License for more details.
+#
+# You should have received a copy of the GNU Affero Public License
+# along with this program.  If not, see http://www.gnu.org/licenses.
+#
+# http://numenta.org/licenses/
+# ----------------------------------------------------------------------
+
+"""
+This module trains & evaluates a dendritic network in a continual learning setting on
+permutedMNIST for a specified number of tasks/permutations. A context vector is
+provided to the dendritic network, so task information need not be inferred.
+
+This setup is very similar to that of context-dependent gating model from the paper
+'Alleviating catastrophic forgetting using contextdependent gating and synaptic
+stabilization' (Masse et al., 2018).
+"""
+
+import math
+from collections import defaultdict
+
+import numpy as np
+import torch
+import torch.nn.functional as F
+
+from nupic.research.frameworks.dendrites import DendriticMLP
+from nupic.research.frameworks.pytorch.datasets import ContextDependentPermutedMNIST
+from nupic.research.frameworks.vernon import ContinualLearningExperiment, mixins
+
+
+# ------ Experiment class
+class PermutedMNISTExperiment(mixins.RezeroWeights,
+                              ContinualLearningExperiment):
+
+    def setup_experiment(self, config):
+        # Store optimizer args, since optimizer is reset at the beginning of each task
+        self.optimizer_class = config.get("optimizer_class", torch.optim.SGD)
+        self.optimizer_args = config.get("optimizer_args", {})
+
+        super().setup_experiment(config)
+
+    @classmethod
+    def compute_task_indices(cls, config, dataset):
+        # Assume dataloaders are already created
+        class_indices = defaultdict(list)
+        for idx, (_, _, target) in enumerate(dataset):
+            class_indices[target].append(idx)
+
+        # Defines how many classes should exist per task
+        num_tasks = config.get("num_tasks", 1)
+        num_classes = config.get("num_classes", None)
+        assert num_classes is not None, "num_classes should be defined"
+        num_classes_per_task = math.floor(num_classes / num_tasks)
+
+        task_indices = defaultdict(list)
+        for i in range(num_tasks):
+            for j in range(num_classes_per_task):
+                task_indices[i].extend(class_indices[j + (i * num_classes_per_task)])
+        return task_indices
+
+    def run_iteration(self):
+        # Reset optimizer before training on a new task, just as context-dependent
+        # gating does
+        del self.optimizer
+
+        self.optimizer = self.optimizer_class(self.model.parameters(),
+                                              **self.optimizer_args)
+        return super().run_iteration()
+
+
+# ------ Training & evaluation functions
+def train_model(exp):
+    # Assume `loader` yields 3-item tuples of the form (data, context, target)
+    exp.model.train()
+    for data, context, target in exp.train_loader:
+
+        # Since there's only one output head, target values should be modified to be in
+        # the range [0, 1, ..., 9]
+        target = target % exp.num_classes_per_task
+
+        data = data.to(exp.device)
+        context = context.to(exp.device)
+        target = target.to(exp.device)
+
+        exp.optimizer.zero_grad()
+        output = exp.model(data, context)
+
+        output = F.log_softmax(output)
+        error_loss = exp.error_loss(output, target)
+        error_loss.backward()
+        exp.optimizer.step()
+
+        # Rezero weights if necessary
+        exp.post_optimizer_step(exp.model)
+
+
+def evaluate_model(exp):
+    # Assume `loader` yields 3-item tuples of the form (data, context, target)
+    exp.model.eval()
+    total = 0
+
+    loss = torch.tensor(0., device=exp.device)
+    correct = torch.tensor(0, device=exp.device)
+
+    with torch.no_grad():
+
+        for data, context, target in exp.val_loader:
+
+            # Since there's only one output head, target values should be modified to
+            # be in the range [0, 1, ..., 9]
+            target = target % exp.num_classes_per_task
+
+            data = data.to(exp.device)
+            context = context.to(exp.device)
+            target = target.to(exp.device)
+
+            output = exp.model(data, context)
+
+            # All output units are used to compute loss / accuracy
+            loss += exp.error_loss(output, target, reduction="sum")
+            pred = output.max(1, keepdim=True)[1]
+            correct += pred.eq(target.view_as(pred)).sum()
+            total += len(data)
+
+    mean_acc = torch.true_divide(correct, total).item() if total > 0 else 0,
+    return mean_acc
+
+
+def run_experiment(config):
+    exp_class = config["experiment_class"]
+    exp = exp_class()
+    exp.setup_experiment(config)
+
+    exp.model = exp.model.to(exp.device)
+
+    # --------------------------- CONTINUAL LEARNING PHASE -------------------------- #
+
+    for task_id in range(num_tasks):
+
+        # Train model on current task
+        exp.train_loader.sampler.set_active_tasks(task_id)
+        for _epoch_id in range(exp.epochs):
+            train_model(exp)
+
+        if task_id in config["epochs_to_validate"]:
+
+            print("")
+            print(f"=== AFTER TASK {task_id} ===")
+            print("")
+
+            # Evaluate model accuracy on each task separately
+            for eval_task_id in range(task_id + 1):
+
+                exp.val_loader.sampler.set_active_tasks(eval_task_id)
+                acc_task = evaluate_model(exp)
+                if isinstance(acc_task, tuple):
+                    acc_task = acc_task[0]
+
+                print(f"task {eval_task_id} accuracy: {acc_task}")
+            print("")
+
+        else:
+            print(f"--Completed task {task_id}--")
+
+    # ------------------------------------------------------------------------------- #
+
+    # Report final aggregate accuracy
+    exp.val_loader.sampler.set_active_tasks(range(num_tasks))
+    acc_task = evaluate_model(exp)
+    if isinstance(acc_task, tuple):
+        acc_task = acc_task[0]
+
+    print(f"Final test accuracy: {acc_task}")
+    print("")
+
+
+if __name__ == "__main__":
+
+    num_tasks = 50
+
+    config = dict(
+        experiment_class=PermutedMNISTExperiment,
+
+        dataset_class=ContextDependentPermutedMNIST,
+        dataset_args=dict(
+            num_tasks=num_tasks,
+            dim_context=1024,
+        ),
+
+        model_class=DendriticMLP,
+        model_args=dict(
+            input_size=784,
+            output_size=10,
+            hidden_size=2048,
+            num_segments=num_tasks,
+            dim_context=1024,  # Note: with the Gaussian dataset, `dim_context` was
+                               # 2048, but this shouldn't effect results
+            kw=True,
+            dendrite_sparsity=0.0,
+        ),
+
+        batch_size=256,
+        val_batch_size=512,
+        epochs=1,
+        epochs_to_validate=(4, 9, 24, 49),  # Note: `epochs_to_validate` is treated as
+                                            # the set of task ids after which to
+                                            # evaluate the model on all seen tasks
+        num_tasks=num_tasks,
+        num_classes=10 * num_tasks,
+        distributed=False,
+        seed=np.random.randint(0, 10000),
+
+        loss_function=F.nll_loss,
+        optimizer_class=torch.optim.Adam,
+        optimizer_args=dict(lr=0.001),
+    )
+
+    run_experiment(config)

--- a/projects/dendrites/permutedMNIST/run_dendritic_network.py
+++ b/projects/dendrites/permutedMNIST/run_dendritic_network.py
@@ -46,9 +46,8 @@ class PermutedMNISTExperiment(mixins.RezeroWeights,
 
 # ------ Training & evaluation functions
 def train_model(exp):
-    # Assume `loader` yields 3-item tuples of the form (data, context, target)
     exp.model.train()
-    for data, context, target in exp.train_loader:
+    for (data, context), target in exp.train_loader:
         data = data.flatten(start_dim=1)
 
         # Since there's only one output head, target values should be modified to be in
@@ -72,7 +71,6 @@ def train_model(exp):
 
 
 def evaluate_model(exp):
-    # Assume `loader` yields 3-item tuples of the form (data, context, target)
     exp.model.eval()
     total = 0
 
@@ -81,7 +79,7 @@ def evaluate_model(exp):
 
     with torch.no_grad():
 
-        for data, context, target in exp.val_loader:
+        for (data, context), target in exp.val_loader:
             data = data.flatten(start_dim=1)
 
             # Since there's only one output head, target values should be modified to

--- a/projects/transformers/run.py
+++ b/projects/transformers/run.py
@@ -30,7 +30,7 @@ github.com/huggingface/transformers/blob/master/examples/text-classification/run
 """
 
 # FIXME: The experiments import Ray, but it must be imported before Pickle # noqa I001
-from ray import tune # noqa F401
+import ray  # noqa: F401, I001
 import argparse
 import logging
 import os
@@ -42,6 +42,7 @@ from pprint import pformat
 
 import torch.distributed
 import transformers
+from integrations import CustomWandbCallback
 from transformers import (
     MODEL_FOR_MASKED_LM_MAPPING,
     DataCollatorWithPadding,
@@ -53,7 +54,6 @@ from transformers.integrations import is_wandb_available
 from transformers.trainer_utils import get_last_checkpoint, is_main_process
 
 from experiments import CONFIGS
-from integrations import CustomWandbCallback
 from run_args import CustomTrainingArguments, DataTrainingArguments, ModelArguments
 from run_utils import (
     TaskResults,


### PR DESCRIPTION
This PR mainly concerns the addition of the permutedMNIST dataset for continual learning. For memory efficiency, the MNIST images are not duplicated, and instead the different permutations are held in memory and applied to each image when being loaded.

Other notable changes:

1. In addition to `PermutedMNIST`, there's also a `ContextDependentPermutedMNIST` dataset class which augments the former by additionally returning a binary sparse context vector. This is useful in the case of dendritic networks when task id is provided and not inferred.
2. `compute_task_indices` in the CL experiment class has been slightly modified so that train/test loaders need not yield 2-item tuples (as was previously assumed), but now can yield any number of batch items as long as the target label is the last one.
3. `DendriticMLP` has been augmented with the `dendrite_sparsity` parameter, so users may specify the level of sparsity in dendritic weights. This is useful because in many experiments, forgetting is only avoided when dendrites are fully dense. This change to `DendriticMLP` has been propagated throughout nupic.research.
4. The new project file in the permutedMNIST project folder runs a dendritic MLP on permutedMNIST (with context provided) in an identical setup to the [XdG model](https://www.pnas.org/content/pnas/115/44/E10467.full.pdf).