### PR TITLE
Make Dendritic MLP more general

### DIFF
--- a/nupic/research/frameworks/dendrites/modules/dendritic_layers.py
+++ b/nupic/research/frameworks/dendrites/modules/dendritic_layers.py
@@ -169,7 +169,9 @@ class OneSegmentDendriticLayer(SparseWeights):
         self.segments = None
 
         allow_extremes = module_sparsity == 1.0 or module_sparsity == 0.0
-        super().__init__(module, sparsity=module_sparsity, allow_extremes=allow_extremes)
+        super().__init__(module,
+                         sparsity=module_sparsity,
+                         allow_extremes=allow_extremes)
 
         allow_extremes = dendrite_sparsity == 1.0 or dendrite_sparsity == 0.0
         self.segments = SparseWeights(

--- a/nupic/research/frameworks/dendrites/modules/dendritic_layers.py
+++ b/nupic/research/frameworks/dendrites/modules/dendritic_layers.py
@@ -66,7 +66,11 @@ class DendriticLayerBase(SparseWeights, metaclass=abc.ABCMeta):
         self.dim_context = dim_context
         self.segments = None
         allow_extremes = module_sparsity == 0.0 or module_sparsity == 1.0
-        super().__init__(module, sparsity=module_sparsity, allow_extremes=allow_extremes)
+        super().__init__(
+            module,
+            sparsity=module_sparsity,
+            allow_extremes=allow_extremes
+        )
 
         self.segments = DendriteSegments(
             num_units=module.weight.shape[0],
@@ -99,8 +103,8 @@ class DendriticLayerBase(SparseWeights, metaclass=abc.ABCMeta):
     def weights(self):
         return self.segments.weights
 
-class BiasingDendriticLayer(DendriticLayerBase):
 
+class BiasingDendriticLayer(DendriticLayerBase):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.dendritic_bias = DendriticBias1d()
@@ -165,7 +169,7 @@ class OneSegmentDendriticLayer(SparseWeights):
         self.segments = None
         super().__init__(module, sparsity=module_sparsity)
 
-        allow_extremes = dendrite_sparsity==1.0 or dendrite_sparsity==0.0
+        allow_extremes = dendrite_sparsity == 1.0 or dendrite_sparsity == 0.0
         self.segments = SparseWeights(
             torch.nn.Linear(dim_context,
                             module.weight.shape[0],

--- a/nupic/research/frameworks/dendrites/modules/dendritic_layers.py
+++ b/nupic/research/frameworks/dendrites/modules/dendritic_layers.py
@@ -167,7 +167,9 @@ class OneSegmentDendriticLayer(SparseWeights):
 
         self.dim_context = dim_context
         self.segments = None
-        super().__init__(module, sparsity=module_sparsity)
+
+        allow_extremes = module_sparsity == 1.0 or module_sparsity == 0.0
+        super().__init__(module, sparsity=module_sparsity, allow_extremes=allow_extremes)
 
         allow_extremes = dendrite_sparsity == 1.0 or dendrite_sparsity == 0.0
         self.segments = SparseWeights(

--- a/nupic/research/frameworks/dendrites/modules/dendritic_layers.py
+++ b/nupic/research/frameworks/dendrites/modules/dendritic_layers.py
@@ -65,11 +65,10 @@ class DendriticLayerBase(SparseWeights, metaclass=abc.ABCMeta):
         """
         self.dim_context = dim_context
         self.segments = None
-        allow_extremes = module_sparsity == 0.0 or module_sparsity == 1.0
         super().__init__(
             module,
             sparsity=module_sparsity,
-            allow_extremes=allow_extremes
+            allow_extremes=True
         )
 
         self.segments = DendriteSegments(
@@ -100,7 +99,7 @@ class DendriticLayerBase(SparseWeights, metaclass=abc.ABCMeta):
         return self.apply_dendrites(y, dendrite_activations)
 
     @property
-    def weights(self):
+    def segment_weights(self):
         return self.segments.weights
 
 
@@ -168,18 +167,16 @@ class OneSegmentDendriticLayer(SparseWeights):
         self.dim_context = dim_context
         self.segments = None
 
-        allow_extremes = module_sparsity == 1.0 or module_sparsity == 0.0
         super().__init__(module,
                          sparsity=module_sparsity,
-                         allow_extremes=allow_extremes)
+                         allow_extremes=True)
 
-        allow_extremes = dendrite_sparsity == 1.0 or dendrite_sparsity == 0.0
         self.segments = SparseWeights(
             torch.nn.Linear(dim_context,
                             module.weight.shape[0],
                             bias=dendrite_bias),
             sparsity=dendrite_sparsity,
-            allow_extremes=allow_extremes
+            allow_extremes=True
         )
 
         self.rezero_weights()
@@ -201,7 +198,7 @@ class OneSegmentDendriticLayer(SparseWeights):
         return y * torch.sigmoid(dendrite_activations)
 
     @property
-    def weights(self):
+    def segment_weights(self):
         return self.segments.module.weight
 
 

--- a/nupic/research/frameworks/dendrites/modules/dendritic_mlp.py
+++ b/nupic/research/frameworks/dendrites/modules/dendritic_mlp.py
@@ -25,7 +25,9 @@ from torch import nn
 
 from nupic.torch.modules import KWinners, SparseWeights, rezero_weights
 
-from .dendritic_layers import AbsoluteMaxGatingDendriticLayer
+from nupic.research.frameworks.dendrites.modules.dendritic_layers import\
+    AbsoluteMaxGatingDendriticLayer, \
+    OneSegmentDendriticLayer
 
 
 class DendriticMLP(nn.Module):
@@ -37,12 +39,13 @@ class DendriticMLP(nn.Module):
 
     :param input_size: size of the input to the network
     :param output_size: the number of units in the output layer
-    :param hidden_size: the number of units in each of the two hidden layers
+    :param hidden_sizes: the number of units in each hidden layer
     :param num_segments: the number of dendritic segments that each hidden unit has
     :param dim_context: the size of the context input to the network
-    :param kw: whether to apply k-Winners (with 5% winners) to the outputs of each
-               hidden layer
-    :param dendrite_sparsity: the sparsity level of dendritic weights (default 0.95)
+    :param kw: whether to apply k-Winners to the outputs of each hidden layer
+    :param kw_percent_on: percent of hidden units activated by K-winners.
+    :param context_percent_on: percent of non-zero units in the context input.
+    :param weight_sparsity: the sparsity level of dendritic weights (default 0.95)
     :param weight_init: the initialization applied to feed-forward weights; must be
                         either "kaiming" (for Kaiming Uniform) of "modified" (for
                         sparse Kaiming Uniform)
@@ -51,6 +54,8 @@ class DendriticMLP(nn.Module):
     :param freeze_dendrites: whether to set `requires_grad=False` for all dendritic
                              weights so they don't train
     :param dendritic_layer_class: dendritic layer class to use for each hidden layer
+    :param output_nonlinearity: nonlinearity to apply to output. 'None' of no
+                                nonlinearity.
 
                     _____
                    |_____|    # classifier layer, no dendrite input
@@ -67,83 +72,96 @@ class DendriticMLP(nn.Module):
                     input
     """
 
-    def __init__(self, input_size, output_size, hidden_size, num_segments, dim_context,
-                 kw=True, dendrite_sparsity=0.95, weight_init="modified",
+    def __init__(self, input_size, output_size, hidden_sizes, num_segments, dim_context,
+                 kw, kw_percent_on=0.05, context_percent_on=1.0, weight_sparsity=0.95, weight_init="modified",
                  dendrite_init="modified", freeze_dendrites=False,
-                 dendritic_layer_class=AbsoluteMaxGatingDendriticLayer):
+                 dendritic_layer_class=AbsoluteMaxGatingDendriticLayer, output_nonlinearity=None):
 
         # Forward & dendritic weight initialization must be either "kaiming" or
         # "modified"
         assert weight_init in ("kaiming", "modified")
         assert dendrite_init in ("kaiming", "modified")
+        assert kw_percent_on >= 0.0
+        assert context_percent_on >= 0.0
 
         super().__init__()
 
+        if num_segments == 1:
+            # use optimized 1 segment class
+            dendritic_layer_class=OneSegmentDendriticLayer
+
         self.num_segments = num_segments
         self.input_size = input_size
-        self.hidden_size = hidden_size
+        self.hidden_sizes = hidden_sizes
         self.output_size = output_size
         self.dim_context = dim_context
         self.kw = kw
-        self.dendrite_sparsity = dendrite_sparsity
-        self.freeze_dendrites = freeze_dendrites
+        self.kw_percent_on = kw_percent_on
+        self.weight_sparsity = weight_sparsity
+        self.output_nonlinearity = output_nonlinearity
+        self.hardcode_dendrites = (dendrite_init == "hardcoded")
 
-        # Forward layers & k-winners
-        self.dend1 = dendritic_layer_class(
-            module=nn.Linear(input_size, hidden_size, bias=True),
-            num_segments=num_segments,
-            dim_context=dim_context,
-            module_sparsity=0.95,
-            dendrite_sparsity=dendrite_sparsity,
-        )
-        self.dend2 = dendritic_layer_class(
-            module=nn.Linear(hidden_size, hidden_size, bias=True),
-            num_segments=num_segments,
-            dim_context=dim_context,
-            module_sparsity=0.95,
-            dendrite_sparsity=dendrite_sparsity,
-        )
-        self.classifier = SparseWeights(module=nn.Linear(hidden_size, output_size),
-                                        sparsity=0.95)
+        self._layers = nn.ModuleList()
+        self._activations = nn.ModuleList()
 
-        if kw:
+        for i in range(len(self.hidden_sizes)):
+            curr_dend = dendritic_layer_class(
+                module=nn.Linear(input_size, self.hidden_sizes[i], bias=True),
+                num_segments=num_segments,
+                dim_context=dim_context,
+                module_sparsity=self.weight_sparsity,
+                dendrite_sparsity=0.0 if self.hardcode_dendrites else self.weight_sparsity,
+            )
 
-            print(f"Using k-Winners: 0.05 'on'")
-            self.kw1 = KWinners(n=hidden_size, percent_on=0.05, k_inference_factor=1.0,
-                                boost_strength=0.0, boost_strength_factor=0.0)
-            self.kw2 = KWinners(n=hidden_size, percent_on=0.05, k_inference_factor=1.0,
-                                boost_strength=0.0, boost_strength_factor=0.0)
+            if weight_init == "modified":
+                # Scale weights to be sampled from the new initialization U(-h, h) where
+                # h = sqrt(1 / (weight_density * previous_layer_percent_on))
+                if i == 0:
+                    # first hidden layer can't have kw input
+                    self._init_sparse_weights(curr_dend, 0.0)
+                else:
+                    self._init_sparse_weights(curr_dend, 1 - kw_percent_on if kw else 0.0)
 
+            if dendrite_init == "modified":
+                self._init_sparse_dendrites(curr_dend, 1 - context_percent_on)
+
+            if freeze_dendrites:
+                # Dendritic weights will not be updated during backward pass
+                for name, param in curr_dend.named_parameters():
+                    if "segments" in name:
+                        param.requires_grad = False
+
+            if self.kw:
+                curr_activation = KWinners(n=hidden_sizes[i],
+                                           percent_on=kw_percent_on,
+                                           k_inference_factor=1.0,
+                                           boost_strength=0.0,
+                                           boost_strength_factor=0.0)
+            else:
+                curr_activation = nn.ReLU()
+
+            self._layers.append(curr_dend)
+            self._activations.append(curr_activation)
+
+            input_size = self.hidden_sizes[i]
+
+        self._output_layer = nn.Sequential()
+        output_linear = SparseWeights(module=nn.Linear(input_size, output_size),
+                                      sparsity=weight_sparsity, allow_extremes=True)
         if weight_init == "modified":
+            self._init_sparse_weights(output_linear, 1 - kw_percent_on if kw else 0.0)
+        self._output_layer.add_module("output_linear", output_linear)
 
-            # Scale weights to be sampled from the new inititialization U(-h, h) where
-            # h = sqrt(1 / (weight_density * previous_layer_percent_on))
-            self._init_sparse_weights(self.dend1, 0.0)
-            self._init_sparse_weights(self.dend2, 0.95 if kw else 0.0)
-            self._init_sparse_weights(self.classifier, 0.95 if kw else 0.0)
-
-        if dendrite_init == "modified":
-            self._init_sparse_dendrites(self.dend1, 0.95)
-            self._init_sparse_dendrites(self.dend2, 0.95)
-
-        if freeze_dendrites:
-
-            # Dendritic weights will not be updated during backward pass
-            for name, param in self.named_parameters():
-                if "segments" in name:
-                    param.requires_grad = False
+        if self.output_nonlinearity:
+            self._output_layer.add_module("non_linearity", output_nonlinearity)
 
     def forward(self, x, context):
-        output = self.dend1(x, context=context)
-        output = self.kw1(output) if self.kw else output
+        for layer, activation in zip(self._layers, self._activations):
+            x = activation(layer(x, context))
 
-        output = self.dend2(output, context=context)
-        output = self.kw2(output) if self.kw else output
+        return self._output_layer(x)
 
-        output = self.classifier(output)
-        return output
-
-    # ------ Weight initialization functions
+    # ------ Weight initialization functions ------
     @staticmethod
     def _init_sparse_weights(m, input_sparsity):
         """
@@ -166,9 +184,9 @@ class DendriticMLP(nn.Module):
         # Assume `m` is an instance of `DendriticLayerBase`
         input_density = 1.0 - input_sparsity
         weight_density = 1.0 - m.segments.sparsity
-        fan_in = m.segments.dim_context
+        fan_in = m.dim_context
         bound = 1.0 / np.sqrt(input_density * weight_density * fan_in)
-        nn.init.uniform_(m.segments.weights, -bound, bound)
+        nn.init.uniform_(m.weights, -bound, bound)
         m.apply(rezero_weights)
 
     def hardcode_dendritic_weights(self, context_vectors, init):
@@ -193,12 +211,19 @@ class DendriticMLP(nn.Module):
         :param context_vectors:
         :param init: a string "overlapping" or "non_overlapping"
         """
-        self._hardcode_dendritic_weights(self.dend1.segments, context_vectors, init)
-        self._hardcode_dendritic_weights(self.dend2.segments, context_vectors, init)
+        for dendrite in self._layers:
+            self._hardcode_dendritic_weights(dendrite.weights, context_vectors, init)
 
     @staticmethod
-    def _hardcode_dendritic_weights(dendrite_segments, context_vectors, init):
-        num_units, num_segments, dim_context = dendrite_segments.weights.size()
+    def _hardcode_dendritic_weights(dendrite_weights, context_vectors, init):
+        squeeze = False
+        if len(dendrite_weights.shape) == 2:
+            # 1 segment dendrite, so add in a segment dimension
+            squeeze = True
+            original_weights = dendrite_weights
+            dendrite_weights = dendrite_weights.unsqueeze(dim=1)
+
+        num_units, num_segments, dim_context = dendrite_weights.size()
         num_contexts, _ = context_vectors.size()
 
         if init == "overlapping":
@@ -241,4 +266,19 @@ class DendriticMLP(nn.Module):
         else:
             raise Exception("Invalid dendritic weight hardcode choice")
 
-        dendrite_segments.weights.data = new_dendritic_weights
+        dendrite_weights.data = new_dendritic_weights
+
+        if squeeze:
+            dendrite_weights = dendrite_weights.squeeze(dim=1)
+            # dendrite weights doesn't point to the dendrite weights tensor,
+            # so expicitly assign the new values
+            original_weights.data = dendrite_weights
+
+
+
+
+if __name__ == '__main__':
+    d = DendriticMLP(10, 5, (32, 32), num_segments=1, dim_context=10, context_percent_on=1.0, kw=True)
+    contexts = torch.eye(10)
+    d.hardcode_dendritic_weights(contexts, init="overlapping")
+    d(torch.rand(1, 10), torch.rand(1, 10))

--- a/nupic/research/frameworks/dendrites/modules/dendritic_mlp.py
+++ b/nupic/research/frameworks/dendrites/modules/dendritic_mlp.py
@@ -278,3 +278,11 @@ class DendriticMLP(nn.Module):
             # dendrite weights doesn't point to the dendrite weights tensor,
             # so expicitly assign the new values
             original_weights.data = dendrite_weights
+
+
+
+if __name__ == '__main__':
+    d = DendriticMLP(10, 5, (32, 32), num_segments=1, dim_context=10, context_percent_on=1.0, kw=True)
+    contexts = torch.eye(10)
+    d.hardcode_dendritic_weights(contexts, init="non_overlapping")
+    d(torch.rand(1, 10), torch.rand(1, 10))

--- a/nupic/research/frameworks/dendrites/modules/dendritic_mlp.py
+++ b/nupic/research/frameworks/dendrites/modules/dendritic_mlp.py
@@ -46,7 +46,7 @@ class DendriticMLP(nn.Module):
     :param kw_percent_on: percent of hidden units activated by K-winners.
     :param context_percent_on: percent of non-zero units in the context input.
     :param dendrite_weight_sparsity: the sparsity level of dendritic weights.
-    :param ff_weight_sparsity: the sparsity level of feed-forward weights.
+    :param weight_sparsity: the sparsity level of feed-forward weights.
     :param weight_init: the initialization applied to feed-forward weights; must be
                         either "kaiming" (for Kaiming Uniform) of "modified" (for
                         sparse Kaiming Uniform)
@@ -75,7 +75,7 @@ class DendriticMLP(nn.Module):
     def __init__(
         self, input_size, output_size, hidden_sizes, num_segments, dim_context,
         kw, kw_percent_on=0.05, context_percent_on=1.0, dendrite_weight_sparsity=0.95,
-        ff_weight_sparsity=0.95, weight_init="modified", dendrite_init="modified",
+        weight_sparsity=0.95, weight_init="modified", dendrite_init="modified",
         freeze_dendrites=False, output_nonlinearity=None,
         dendritic_layer_class=AbsoluteMaxGatingDendriticLayer,
     ):
@@ -100,7 +100,7 @@ class DendriticMLP(nn.Module):
         self.dim_context = dim_context
         self.kw = kw
         self.kw_percent_on = kw_percent_on
-        self.ff_weight_sparsity = ff_weight_sparsity
+        self.weight_sparsity = weight_sparsity
         self.dendrite_weight_sparsity = dendrite_weight_sparsity
         self.output_nonlinearity = output_nonlinearity
         self.hardcode_dendrites = (dendrite_init == "hardcoded")
@@ -117,7 +117,7 @@ class DendriticMLP(nn.Module):
                 module=nn.Linear(input_size, self.hidden_sizes[i], bias=True),
                 num_segments=num_segments,
                 dim_context=dim_context,
-                module_sparsity=self.ff_weight_sparsity,
+                module_sparsity=self.weight_sparsity,
                 dendrite_sparsity=dendrite_sparsity,
             )
 
@@ -158,7 +158,7 @@ class DendriticMLP(nn.Module):
 
         self._output_layer = nn.Sequential()
         output_linear = SparseWeights(module=nn.Linear(input_size, output_size),
-                                      sparsity=ff_weight_sparsity, allow_extremes=True)
+                                      sparsity=weight_sparsity, allow_extremes=True)
         if weight_init == "modified":
             self._init_sparse_weights(output_linear, 1 - kw_percent_on if kw else 0.0)
         self._output_layer.add_module("output_linear", output_linear)

--- a/nupic/research/frameworks/dendrites/modules/dendritic_mlp.py
+++ b/nupic/research/frameworks/dendrites/modules/dendritic_mlp.py
@@ -278,11 +278,3 @@ class DendriticMLP(nn.Module):
             # dendrite weights doesn't point to the dendrite weights tensor,
             # so expicitly assign the new values
             original_weights.data = dendrite_weights
-
-
-
-if __name__ == '__main__':
-    d = DendriticMLP(10, 5, (32, 32), num_segments=1, dim_context=10, context_percent_on=1.0, kw=True)
-    contexts = torch.eye(10)
-    d.hardcode_dendritic_weights(contexts, init="non_overlapping")
-    d(torch.rand(1, 10), torch.rand(1, 10))

--- a/projects/transformers/run.py
+++ b/projects/transformers/run.py
@@ -29,8 +29,6 @@ github.com/huggingface/transformers/blob/master/examples/language-modeling/run_m
 github.com/huggingface/transformers/blob/master/examples/text-classification/run_glue.py
 """
 
-# FIXME: The experiments import Ray, but it must be imported before Pickle # noqa I001
-import ray  # noqa: F401, I001
 import argparse
 import logging
 import os
@@ -40,9 +38,10 @@ import sys
 from copy import deepcopy
 from pprint import pformat
 
+# FIXME: The experiments import Ray, but it must be imported before Pickle # noqa I001
+import ray  # noqa: F401, I001
 import torch.distributed
 import transformers
-from integrations import CustomWandbCallback
 from transformers import (
     MODEL_FOR_MASKED_LM_MAPPING,
     DataCollatorWithPadding,
@@ -54,6 +53,7 @@ from transformers.integrations import is_wandb_available
 from transformers.trainer_utils import get_last_checkpoint, is_main_process
 
 from experiments import CONFIGS
+from integrations import CustomWandbCallback
 from run_args import CustomTrainingArguments, DataTrainingArguments, ModelArguments
 from run_utils import (
     TaskResults,


### PR DESCRIPTION
Allows users to specify # hidden layers, hidden layer dimensions, sparsity levels. 
Integrates the optimized 1 layer dendritic segment into the dendritic mlp. 