### PR TITLE
Update to Transformers==4.5.1

### DIFF
--- a/projects/transformers/callbacks/sparsity.py
+++ b/projects/transformers/callbacks/sparsity.py
@@ -86,7 +86,7 @@ class RezeroWeightsCallback(TrainerCallback):
                 encoder_sparsity=encoder_sparsity
             )
 
-            wandb.log(logs, step=state.global_step)
+            wandb.log(logs, commit=False)
 
 
 class PlotDensitiesCallback(TrainerCallback):
@@ -147,7 +147,7 @@ class PlotDensitiesCallback(TrainerCallback):
             rotation_mode="anchor"
         )
         plot = wandb.Image(ax)
-        wandb.log({"density_per_layer": plot}, step=state.global_step)
+        wandb.log({"density_per_layer": plot}, commit=False)
 
         # Plot plot change in on params for each layer.
         df_delta_on_params = get_delta_on_params(
@@ -173,7 +173,7 @@ class PlotDensitiesCallback(TrainerCallback):
             rotation_mode="anchor",
         )
         plot = wandb.Image(ax)
-        wandb.log({"delta_on_params": plot}, step=state.global_step)
+        wandb.log({"delta_on_params": plot}, commit=False)
 
 
 # -------------

--- a/projects/transformers/experiments/__init__.py
+++ b/projects/transformers/experiments/__init__.py
@@ -31,6 +31,7 @@ from .distillation import CONFIGS as DISTILLATION
 from .finetuning import CONFIGS as FINETUNING
 from .hpsearch import CONFIGS as HPSEARCH
 from .one_cycle_lr import CONFIGS as ONE_CYCLE_LR
+from .regressions import CONFIGS as REGRESSIONS
 from .rigl_bert import CONFIGS as RIGL_BERT
 from .sparse_bert import CONFIGS as SPARSE_BERT
 from .sparse_bertitos import CONFIGS as SPARSE_BERTITOS
@@ -51,6 +52,7 @@ CONFIGS.update(DISTILLATION)
 CONFIGS.update(FINETUNING)
 CONFIGS.update(HPSEARCH)
 CONFIGS.update(ONE_CYCLE_LR)
+CONFIGS.update(REGRESSIONS)
 CONFIGS.update(RIGL_BERT)
 CONFIGS.update(SPARSE_BERT)
 CONFIGS.update(SPARSE_BERTITOS)

--- a/projects/transformers/experiments/one_cycle_lr.py
+++ b/projects/transformers/experiments/one_cycle_lr.py
@@ -135,7 +135,7 @@ tiny_bert_linear_lr_range_test.update(
 
     max_steps=100,
     overwrite_output_dir=True,
-    do_eval=False,
+    do_eval=True,
     trainer_class=LRRangeTestTrainer,
     trainer_mixin_args=dict(
         min_lr=1e-5,

--- a/projects/transformers/experiments/regressions.py
+++ b/projects/transformers/experiments/regressions.py
@@ -21,7 +21,7 @@
 
 from copy import deepcopy
 
-from trifecta import tiny_bert_trifecta_300k
+from .trifecta import tiny_bert_trifecta_300k
 
 """
 Regression tests configs: As the Transformers project is updated the results from

--- a/projects/transformers/experiments/regressions.py
+++ b/projects/transformers/experiments/regressions.py
@@ -1,0 +1,40 @@
+# ----------------------------------------------------------------------
+# Numenta Platform for Intelligent Computing (NuPIC)
+# Copyright (C) 2021, Numenta, Inc.  Unless you have an agreement
+# with Numenta, Inc., for a separate license for this software code, the
+# following terms and conditions apply:
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# See the GNU Affero Public License for more details.
+#
+# You should have received a copy of the GNU Affero Public License
+# along with this program.  If not, see http://www.gnu.org/licenses.
+#
+# http://numenta.org/licenses/
+# ----------------------------------------------------------------------
+
+from copy import deepcopy
+
+from trifecta import tiny_bert_trifecta_300k
+
+"""
+Regression tests configs: As the Transformers project is updated the results from
+these configs should be reproducible.
+"""
+
+
+tiny_bert_trifecta_50k = deepcopy(tiny_bert_trifecta_300k)
+tiny_bert_trifecta_50k.update(
+    max_steps=50000,
+)
+
+
+CONFIGS = dict(
+    tiny_bert_trifecta_50k=tiny_bert_trifecta_50k,
+)

--- a/projects/transformers/requirements.txt
+++ b/projects/transformers/requirements.txt
@@ -22,9 +22,9 @@
 # Run pip install -r requirements.txt to reproduce the currently tested environment
 # Last update: 3/29/2021
 
-transformers>=4.4.2,<4.5.0
-datasets>=1.5.0,<=1.6.0
+transformers>=4.5.1,<4.6.0
+datasets>=1.6.1,<1.7.0
 torch>=1.8.1
-wandb>=0.10.23
+wandb>=0.10.27
 cloudpickle>=1.6.0
 pickle5>=0.0.11

--- a/projects/transformers/trainer_mixins/lr_range_test.py
+++ b/projects/transformers/trainer_mixins/lr_range_test.py
@@ -80,20 +80,11 @@ class LRRangeTestMixin:
         assert isinstance(self.max_lr, float)
         assert self.test_mode in ["linear", "exponential"]
 
-    def create_optimizer_and_scheduler(self, num_training_steps: int):
+    def create_scheduler(self, num_training_steps: int):
         """
-        Create a linearly or exponentially increasing lr schedule. This overrides super
-        in a way that just customizes the lr scheduler while the optimizer remains the
-        default.
+        Create a lr scheduler that ramps up either linearly or exponentially.
         """
 
-        # Set lr scheduler to dummy variable so it's not created in the call to super.
-        self.lr_scheduler = ...
-
-        # Create just the optimizer.
-        super().create_optimizer_and_scheduler(num_training_steps)
-
-        # Create a lr scheduler that ramps up either linearly or exponentially.
         total_steps = num_training_steps
         min_lr = self.min_lr
         max_lr = self.max_lr

--- a/projects/transformers/trainer_mixins/one_cycle_lr.py
+++ b/projects/transformers/trainer_mixins/one_cycle_lr.py
@@ -32,7 +32,7 @@ class OneCycleLRMixin:
         https://pytorch.org/docs/stable/optim.html#torch.optim.lr_scheduler.OneCycleLR
     """
 
-    def create_optimizer_and_scheduler(self, num_training_steps: int):
+    def create_scheduler(self, num_training_steps: int):
         """
         Setup the optimizer and the learning rate scheduler. This overrides super
         in a way that just customizes the lr scheduler while the optimizer remains the
@@ -51,12 +51,6 @@ class OneCycleLRMixin:
         div_factor = mixin_args.get("div_factor", 25)
         final_div_factor = mixin_args.get("final_div_factor", 1e4)
         last_epoch = mixin_args.get("last_epoch", -1)
-
-        # Set lr scheduler to dummy variable so it's not created in the call to super.
-        self.lr_scheduler = ...
-
-        # Create just the optimizer.
-        super().create_optimizer_and_scheduler(num_training_steps)
 
         # Now define the lr scheduler, given the optimizer.
         self.lr_scheduler = OneCycleLR(

--- a/projects/transformers/trainer_mixins/rigl.py
+++ b/projects/transformers/trainer_mixins/rigl.py
@@ -142,7 +142,7 @@ class RigLMixin:
             })
 
         if wandb.run is not None:
-            wandb.log(logs, step=self.state.global_step)
+            wandb.log(logs, commit=False)
 
         return train_loss
 


### PR DESCRIPTION
This PR updates our `requirements.py` to `transformers==4.5.1`. No major changes were required for this update. The biggest is that our mixins now override `create_scheduler` instead of `create_scheduler_and_optimizer` where appropriate. 

As well, there were some code changes needed for our wandb callback. Huggingface has slightly updated the way they do logging. Before, all of our plots (such that for train/loss) were with respect to `step`. Now, they will be with respect to `train/global_step`. This will be done automatically and there's nothing you need to do differently to view the logs on wandb. However, comparing new runs to old runs may not be straightforward. If you view two runs, one old and one new, and look at `train/loss` vs `step`, that `step` may have a different meaning for the two plots. In particular, `step` now tallies how many times a training *or eval step* occurs whereas before it just tallied the training steps. Now it's the role of `train/global_step` to tally the just training steps. Thus, if you call evaluate multiple times during training, be careful in how you compare that run to some other run prior to this PR. 

Overall, regression tests on `tiny_bert_trifecta_50k` passed just fine and no changes in training were observed. You can view these results [here](https://wandb.ai/numenta/huggingface/reports/Regression-Test-4-30-2021--Vmlldzo2NTA3MTI) if you'd like.
