### PR TITLE
Migrate dendrites project files into Vernon

### DIFF
--- a/nupic/research/frameworks/dendrites/__init__.py
+++ b/nupic/research/frameworks/dendrites/__init__.py
@@ -19,6 +19,7 @@
 # http://numenta.org/licenses/
 # ----------------------------------------------------------------------
 
+from .model_utils import *
 from .modules import *
 from .metrics import *
 from .apply_dendrites_hook import *

--- a/nupic/research/frameworks/dendrites/dendrite_cl_experiment.py
+++ b/nupic/research/frameworks/dendrites/dendrite_cl_experiment.py
@@ -1,0 +1,96 @@
+# ----------------------------------------------------------------------
+# Numenta Platform for Intelligent Computing (NuPIC)
+# Copyright (C) 2021, Numenta, Inc.  Unless you have an agreement
+# with Numenta, Inc., for a separate license for this software code, the
+# following terms and conditions apply:
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# See the GNU Affero Public License for more details.
+#
+# You should have received a copy of the GNU Affero Public License
+# along with this program.  If not, see http://www.gnu.org/licenses.
+#
+# http://numenta.org/licenses/
+# ----------------------------------------------------------------------
+
+from nupic.research.frameworks.dendrites import (
+    evaluate_dendrite_model,
+    train_dendrite_model,
+)
+from nupic.research.frameworks.vernon import ContinualLearningExperiment
+
+__all__ = [
+    "DendriteContinualLearningExperiment",
+]
+
+
+class DendriteContinualLearningExperiment(ContinualLearningExperiment):
+
+    def setup_experiment(self, config):
+        super().setup_experiment(config)
+
+    def run_task(self):
+        """
+        Run the current task.
+        """
+        # configure the sampler to load only samples from current task
+        self.logger.info("Training task %d...", self.current_task)
+        self.train_loader.sampler.set_active_tasks(self.current_task)
+
+        # Run epochs, inner loop
+        # TODO: return the results from run_epoch
+        self.current_epoch = 0
+        for _ in range(self.epochs):
+            self.run_epoch()
+
+        # TODO: put back evaluation_metrics from cl_experiment
+        # TODO: add option to run validate on all tasks at end of training.
+        # TODO: add option to run validate on one task at a time during training
+        ret = {}
+        if self.current_task in self.tasks_to_validate:
+            self.val_loader.sampler.set_active_tasks(range(self.num_tasks))
+            ret = self.validate()
+            self.val_loader.sampler.set_active_tasks(self.current_task)
+
+        ret.update(
+            learning_rate=self.get_lr()[0],
+        )
+
+        self.current_task += 1
+
+        if self.reset_optimizer_after_task:
+            self.optimizer = self.create_optimizer(self.model)
+
+        print("run_task ret: ", ret)
+        return ret
+
+    def train_epoch(self):
+        train_dendrite_model(
+            model=self.model,
+            loader=self.train_loader,
+            optimizer=self.optimizer,
+            device=self.device,
+            criterion=self.error_loss,
+            share_labels=True,
+            num_labels=10,
+            post_batch_callback=self.post_batch_wrapper
+        )
+
+    def validate(self, loader=None):
+        """
+        Run validation on the currently active tasks.
+        """
+        if loader is None:
+            loader = self.val_loader
+
+        return evaluate_dendrite_model(model=self.model,
+                                       loader=loader,
+                                       device=self.device,
+                                       criterion=self.error_loss,
+                                       share_labels=True, num_labels=10)

--- a/nupic/research/frameworks/dendrites/dendrite_cl_experiment.py
+++ b/nupic/research/frameworks/dendrites/dendrite_cl_experiment.py
@@ -65,13 +65,13 @@ class DendriteContinualLearningExperiment(ContinualLearningExperiment):
         self.current_task += 1
 
         if self.reset_optimizer_after_task:
-            self.optimizer = self.create_optimizer(self.model)
+            self.optimizer = self.recreate_optimizer(self.model)
 
         print("run_task ret: ", ret)
         return ret
 
     def train_epoch(self):
-        # TODO: take out constants in the call below
+        # TODO: take out constants in the call below. How do we determine num_labels?
         train_dendrite_model(
             model=self.model,
             loader=self.train_loader,

--- a/nupic/research/frameworks/dendrites/dendrite_cl_experiment.py
+++ b/nupic/research/frameworks/dendrites/dendrite_cl_experiment.py
@@ -71,6 +71,7 @@ class DendriteContinualLearningExperiment(ContinualLearningExperiment):
         return ret
 
     def train_epoch(self):
+        # TODO: take out constants in the call below
         train_dendrite_model(
             model=self.model,
             loader=self.train_loader,
@@ -89,6 +90,7 @@ class DendriteContinualLearningExperiment(ContinualLearningExperiment):
         if loader is None:
             loader = self.val_loader
 
+        # TODO: take out constants in the call below
         return evaluate_dendrite_model(model=self.model,
                                        loader=loader,
                                        device=self.device,

--- a/nupic/research/frameworks/dendrites/model_utils.py
+++ b/nupic/research/frameworks/dendrites/model_utils.py
@@ -48,7 +48,7 @@ def train_dendrite_model(
     Train the given model by iterating through mini batches. An epoch ends
     after one pass through the training set.
 
-    For unused parameters, see `nupic.research.frameworks.pytorch.model_utils`
+    For unused parameters, see `nupic.research.frameworks.pytorch.model_utils`.
 
     :param model: Pytorch model to be trained
     :param loader: Train dataset loader
@@ -121,10 +121,12 @@ def evaluate_dendrite_model(
     Evaluate pre-trained model using given test dataset loader, and return a dict with
     computed "mean_accuracy", "mean_loss", "total_correct", and "total_tested".
 
+    For unused parameters, see `nupic.research.frameworks.pytorch.model_utils`.
+
     :param model: Pretrained pytorch model
-    :param loader: test dataset loader
-    :param device: device to use ('cpu' or 'cuda')
-    :param criterion: loss function to use
+    :param loader: Test dataset loader
+    :param device: Device to use ('cpu' or 'cuda')
+    :param criterion: Loss function to use
     :param share_labels: Whether or not to share labels between tasks, which is
                          accomplished by applying the modulo operator to target labels
     :param num_labels: The number of unique labels; only required if
@@ -132,8 +134,8 @@ def evaluate_dendrite_model(
     :param active_classes: List of indices of the heads that are active for a given
                            task; only relevant if this function is being used in a
                            continual learning scenario
-    :param batches_in_epoch: Max number of mini batches to test on
-    :param complexity_loss_fn: a regularization term for the loss function
+    :param batches_in_epoch: Unused
+    :param complexity_loss_fn: Unused
     :param progress: Unused
     :param post_batch_callback: Unused
     :param transform_to_device_fn: Unused

--- a/nupic/research/frameworks/dendrites/model_utils.py
+++ b/nupic/research/frameworks/dendrites/model_utils.py
@@ -1,0 +1,131 @@
+# ----------------------------------------------------------------------
+# Numenta Platform for Intelligent Computing (NuPIC)
+# Copyright (C) 2021, Numenta, Inc.  Unless you have an agreement
+# with Numenta, Inc., for a separate license for this software code, the
+# following terms and conditions apply:
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# See the GNU Affero Public License for more details.
+#
+# You should have received a copy of the GNU Affero Public License
+# along with this program.  If not, see http://www.gnu.org/licenses.
+#
+# http://numenta.org/licenses/
+# ----------------------------------------------------------------------
+
+import torch
+import torch.nn.functional as F
+
+__all__ = [
+    "evaluate_dendrite_model",
+    "train_dendrite_model",
+]
+
+
+def train_dendrite_model(
+    model,
+    loader,
+    optimizer,
+    device,
+    criterion=F.cross_entropy,
+    share_labels=False,
+    num_labels=None,
+    post_batch_callback=None,
+    complexity_loss_fn=None,
+    batches_in_epoch=None,
+    active_classes=None,
+    pre_batch_callback=None,
+    transform_to_device_fn=None,
+    progress_bar=None,
+):
+    """
+    TODO: add docstring
+    """
+    model.train()
+    for batch_idx, (data, target) in enumerate(loader):
+        # TODO: need to make this more generic to not require context
+        data, context = data
+        data = data.flatten(start_dim=1)
+
+        # Since there's only one output head, target values should be modified to be in
+        # the range [0, 1, ..., 9]
+        if share_labels:
+            target = target % num_labels
+
+        data = data.to(device)
+        context = context.to(device)
+        target = target.to(device)
+
+        optimizer.zero_grad()
+        output = model(data, context)
+
+        error_loss = criterion(output, target)
+        error_loss.backward()
+        optimizer.step()
+
+        # Rezero weights if necessary
+        if post_batch_callback is not None:
+            post_batch_callback(model=model, error_loss=error_loss.detach(),
+                                complexity_loss=None, batch_idx=batch_idx,
+                                num_images=0, time_string="")
+
+
+def evaluate_dendrite_model(
+    model,
+    loader,
+    device,
+    criterion=F.nll_loss,
+    share_labels=False,
+    num_labels=None,
+    batches_in_epoch=None,
+    complexity_loss_fn=None,
+    active_classes=None,
+    progress=None,
+    post_batch_callback=None,
+    transform_to_device_fn=None,
+):
+    """
+    TODO docstring
+    """
+    model.eval()
+    total = 0
+
+    loss = torch.tensor(0., device=device)
+    correct = torch.tensor(0, device=device)
+
+    with torch.no_grad():
+
+        for data, target in loader:
+            # TODO: need to make this more generic to not require context
+            data, context = data
+            data = data.flatten(start_dim=1)
+
+            # Since there's only one output head, target values should be modified to
+            # be in the range [0, 1, ..., 9]
+            if share_labels:
+                target = target % num_labels
+
+            data = data.to(device)
+            context = context.to(device)
+            target = target.to(device)
+
+            output = model(data, context)
+
+            loss += criterion(output, target, reduction="sum")
+            pred = output.max(1, keepdim=True)[1]
+            correct += pred.eq(target.view_as(pred)).sum()
+            total += len(data)
+
+    results = {
+        "total_correct": correct,
+        "total_tested": total,
+        "mean_loss": loss / total if total > 0 else 0,
+        "mean_accuracy": torch.true_divide(correct, total).item() if total > 0 else 0,
+    }
+    return results

--- a/nupic/research/frameworks/vernon/experiments/cl_experiment.py
+++ b/nupic/research/frameworks/vernon/experiments/cl_experiment.py
@@ -80,6 +80,9 @@ class ContinualLearningExperiment(
         self.train_model = config.get("train_model_func", train_model)
         self.train_model_args = config.get("train_model_args", None)
         self.evaluate_model = config.get("evaluate_model_func", evaluate_model)
+        self.tasks_to_validate = config.get("tasks_to_validate",
+                                            range(self.num_tasks - 3,
+                                                  self.num_tasks))
 
         # Whitelist evaluation metrics
         self.evaluation_metrics = config.get(
@@ -127,7 +130,7 @@ class ContinualLearningExperiment(
 
         self.current_task += 1
 
-        if reset_optimizer_after_task:
+        if self.reset_optimizer_after_task:
             self.optimizer = self.create_optimizer(self.model)
 
         return ret

--- a/nupic/research/frameworks/vernon/experiments/cl_experiment.py
+++ b/nupic/research/frameworks/vernon/experiments/cl_experiment.py
@@ -51,6 +51,9 @@ class ContinualLearningExperiment(
 
         self.current_task = 0
 
+        # TODO: General mechanism to handle all the cases and determine num_labels,
+        #       number of output units, error calculation, share labels, etc.
+
         # Defines how many classes should exist per task
         self.num_tasks = config.get("num_tasks", 1)
 

--- a/nupic/research/frameworks/vernon/experiments/supervised_experiment.py
+++ b/nupic/research/frameworks/vernon/experiments/supervised_experiment.py
@@ -154,7 +154,9 @@ class SupervisedExperiment(ExperimentBase):
         self.logger.debug(self.model)
 
         # Configure and create optimizer
-        self.optimizer = self.create_optimizer(config, self.model)
+        self.optimizer_class = config.get("optimizer_class", torch.optim.SGD)
+        self.optimizer_args = config.get("optimizer_args", {})
+        self.optimizer = self.create_optimizer(self.model)
 
         # Validate mixed precision requirements
         self.mixed_precision = config.get("mixed_precision", False)
@@ -240,18 +242,11 @@ class SupervisedExperiment(ExperimentBase):
             load_checkpoint_args=config.get("load_checkpoint_args", {}),
         )
 
-    @classmethod
-    def create_optimizer(cls, config, model):
+    def create_optimizer(self, model):
         """
-        Create optimizer from an experiment config.
-
-        :param optimizer_class: Callable or class to instantiate optimizer. Must return
-                                object inherited from "torch.optim.Optimizer"
-        :param optimizer_args: Arguments to pass to the optimizer.
+        Create optimizer from our experiment config.
         """
-        optimizer_class = config.get("optimizer_class", torch.optim.SGD)
-        optimizer_args = config.get("optimizer_args", {})
-        return optimizer_class(model.parameters(), **optimizer_args)
+        return self.optimizer_class(model.parameters(), **self.optimizer_args)
 
     @classmethod
     def create_lr_scheduler(cls, config, optimizer, total_batches):

--- a/nupic/research/frameworks/vernon/experiments/supervised_experiment.py
+++ b/nupic/research/frameworks/vernon/experiments/supervised_experiment.py
@@ -154,9 +154,7 @@ class SupervisedExperiment(ExperimentBase):
         self.logger.debug(self.model)
 
         # Configure and create optimizer
-        self.optimizer_class = config.get("optimizer_class", torch.optim.SGD)
-        self.optimizer_args = config.get("optimizer_args", {})
-        self.optimizer = self.create_optimizer(self.model)
+        self.optimizer = self.create_optimizer(config, self.model)
 
         # Validate mixed precision requirements
         self.mixed_precision = config.get("mixed_precision", False)
@@ -242,11 +240,18 @@ class SupervisedExperiment(ExperimentBase):
             load_checkpoint_args=config.get("load_checkpoint_args", {}),
         )
 
-    def create_optimizer(self, model):
+    @classmethod
+    def create_optimizer(cls, config, model):
         """
-        Create optimizer from our experiment config.
+        Create optimizer from an experiment config.
+
+        :param optimizer_class: Callable or class to instantiate optimizer. Must return
+                                object inherited from "torch.optim.Optimizer"
+        :param optimizer_args: Arguments to pass to the optimizer.
         """
-        return self.optimizer_class(model.parameters(), **self.optimizer_args)
+        optimizer_class = config.get("optimizer_class", torch.optim.SGD)
+        optimizer_args = config.get("optimizer_args", {})
+        return optimizer_class(model.parameters(), **optimizer_args)
 
     @classmethod
     def create_lr_scheduler(cls, config, optimizer, total_batches):

--- a/projects/dendrites/permutedMNIST/experiments/__init__.py
+++ b/projects/dendrites/permutedMNIST/experiments/__init__.py
@@ -20,6 +20,7 @@
 # ----------------------------------------------------------------------
 
 from .base import CONFIGS as BASE
+from .standard_mlp import CONFIGS as STANDARD
 
 """
 Import and collect all experiment configurations into one CONFIG
@@ -29,3 +30,4 @@ __all__ = ["CONFIGS"]
 # Collect all configurations
 CONFIGS = dict()
 CONFIGS.update(BASE)
+CONFIGS.update(STANDARD)

--- a/projects/dendrites/permutedMNIST/experiments/__init__.py
+++ b/projects/dendrites/permutedMNIST/experiments/__init__.py
@@ -21,7 +21,6 @@
 
 from .base import CONFIGS as BASE
 
-
 """
 Import and collect all experiment configurations into one CONFIG
 """

--- a/projects/dendrites/permutedMNIST/experiments/base.py
+++ b/projects/dendrites/permutedMNIST/experiments/base.py
@@ -22,20 +22,22 @@
 Base Experiment configuration.
 """
 
-from copy import deepcopy
 import os
+from copy import deepcopy
 
-import numpy as np
-import torch
+    import torch
 import torch.nn.functional as F
 
 from nupic.research.frameworks.dendrites import DendriticMLP
+from nupic.research.frameworks.dendrites.dendrite_cl_experiment import (
+    DendriteContinualLearningExperiment,
+)
 from nupic.research.frameworks.pytorch.datasets import ContextDependentPermutedMNIST
-from nupic.research.frameworks.vernon import ContinualLearningExperiment, mixins
+from nupic.research.frameworks.vernon import mixins
 
 
 class PermutedMNISTExperiment(mixins.RezeroWeights,
-                              ContinualLearningExperiment):
+                              DendriteContinualLearningExperiment):
     pass
 
 
@@ -71,9 +73,8 @@ DEFAULT_BASE = dict(
     batch_size=256,
     val_batch_size=512,
     epochs=1,
-    epochs_to_validate=(4, 9, 24, 49),  # Note: `epochs_to_validate` is treated as
-    # the set of task ids after which to
-    # evaluate the model on all seen tasks
+    tasks_to_validate=(0, 1, 2),  # Tasks on which to run validate
+    epochs_to_validate=[],
     num_tasks=NUM_TASKS,
     num_classes=10 * NUM_TASKS,
     distributed=False,

--- a/projects/dendrites/permutedMNIST/experiments/base.py
+++ b/projects/dendrites/permutedMNIST/experiments/base.py
@@ -47,7 +47,7 @@ DEFAULT_BASE = dict(
     dataset_args=dict(
         num_tasks=NUM_TASKS,
         dim_context=1024,
-        seed=np.random.randint(0, 1000),
+        seed=42,
         download=True,  # Change to True if running for the first time
     ),
 
@@ -72,7 +72,7 @@ DEFAULT_BASE = dict(
     num_tasks=NUM_TASKS,
     num_classes=10 * NUM_TASKS,
     distributed=False,
-    seed=np.random.randint(0, 10000),
+    seed=42,
 
     loss_function=F.cross_entropy,
     optimizer_class=torch.optim.Adam,

--- a/projects/dendrites/permutedMNIST/experiments/base.py
+++ b/projects/dendrites/permutedMNIST/experiments/base.py
@@ -25,7 +25,7 @@ Base Experiment configuration.
 import os
 from copy import deepcopy
 
-    import torch
+import torch
 import torch.nn.functional as F
 
 from nupic.research.frameworks.dendrites import DendriticMLP

--- a/projects/dendrites/permutedMNIST/experiments/base.py
+++ b/projects/dendrites/permutedMNIST/experiments/base.py
@@ -25,6 +25,7 @@ Base Experiment configuration.
 import os
 from copy import deepcopy
 
+import ray.tune as tune
 import torch
 import torch.nn.functional as F
 
@@ -88,10 +89,7 @@ DEFAULT_BASE = dict(
 # Temporary, just for testing
 BASE2 = deepcopy(DEFAULT_BASE)
 BASE2.update(
-    batch_size=64,
-    epochs=2,
-    optimizer_class=torch.optim.SGD,
-    optimizer_args=dict(lr=0.001),
+    epochs=tune.grid_search([1, 2, 3]),
 )
 
 # Export configurations in this file

--- a/projects/dendrites/permutedMNIST/experiments/base.py
+++ b/projects/dendrites/permutedMNIST/experiments/base.py
@@ -23,6 +23,7 @@ Base Experiment configuration.
 """
 
 from copy import deepcopy
+import os
 
 import numpy as np
 import torch
@@ -43,9 +44,13 @@ NUM_TASKS = 2
 DEFAULT_BASE = dict(
     experiment_class=PermutedMNISTExperiment,
 
+    # Results path
+    local_dir=os.path.expanduser("~/nta/results/experiments/dendrites"),
+
     dataset_class=ContextDependentPermutedMNIST,
     dataset_args=dict(
         num_tasks=NUM_TASKS,
+        root="~/nta/data/dendrites",
         dim_context=1024,
         seed=42,
         download=True,  # Change to True if running for the first time

--- a/projects/dendrites/permutedMNIST/experiments/base.py
+++ b/projects/dendrites/permutedMNIST/experiments/base.py
@@ -74,7 +74,7 @@ DEFAULT_BASE = dict(
     distributed=False,
     seed=np.random.randint(0, 10000),
 
-    loss_function=F.nll_loss,
+    loss_function=F.cross_entropy,
     optimizer_class=torch.optim.Adam,
     optimizer_args=dict(lr=0.001),
 )

--- a/projects/dendrites/permutedMNIST/experiments/standard_mlp.py
+++ b/projects/dendrites/permutedMNIST/experiments/standard_mlp.py
@@ -30,18 +30,10 @@ import torch
 import torch.nn.functional as F
 from torchvision import datasets, transforms
 
-from nupic.research.frameworks.dendrites.dendrite_cl_experiment import (
-    DendriteContinualLearningExperiment,
-)
 from nupic.research.frameworks.pytorch.models import StandardMLP
-from nupic.research.frameworks.vernon import SupervisedExperiment, mixins
+from nupic.research.frameworks.vernon import SupervisedExperiment
 
 """Regular MNIST """
-
-
-class PermutedMNISTExperiment(mixins.RezeroWeights,
-                              DendriteContinualLearningExperiment):
-    pass
 
 
 NUM_TASKS = 2

--- a/projects/dendrites/permutedMNIST/experiments/standard_mlp.py
+++ b/projects/dendrites/permutedMNIST/experiments/standard_mlp.py
@@ -23,18 +23,20 @@ Base Experiment configuration.
 """
 
 import os
-from copy import deepcopy
 
+import numpy as np
 import ray.tune as tune
 import torch
 import torch.nn.functional as F
+from torchvision import datasets, transforms
 
-from nupic.research.frameworks.dendrites import DendriticMLP
 from nupic.research.frameworks.dendrites.dendrite_cl_experiment import (
     DendriteContinualLearningExperiment,
 )
-from nupic.research.frameworks.pytorch.datasets import ContextDependentPermutedMNIST
-from nupic.research.frameworks.vernon import mixins
+from nupic.research.frameworks.pytorch.models import StandardMLP
+from nupic.research.frameworks.vernon import SupervisedExperiment, mixins
+
+"""Regular MNIST """
 
 
 class PermutedMNISTExperiment(mixins.RezeroWeights,
@@ -44,56 +46,54 @@ class PermutedMNISTExperiment(mixins.RezeroWeights,
 
 NUM_TASKS = 2
 
-DEFAULT_BASE = dict(
-    experiment_class=PermutedMNISTExperiment,
+# Gets about 98% accuracy
+DENSE_MLP = dict(
+    experiment_class=SupervisedExperiment,
 
     # Results path
     local_dir=os.path.expanduser("~/nta/results/experiments/dendrites"),
 
-    dataset_class=ContextDependentPermutedMNIST,
+    dataset_class=datasets.MNIST,
     dataset_args=dict(
-        num_tasks=NUM_TASKS,
-        root="~/nta/data/dendrites",  # Consistent location outside of git repo
-        dim_context=1024,
-        seed=42,
+        root="~/nta/data/",  # Consistent location outside of git repo
         download=False,  # Change to True if running for the first time
+        transform=transforms.Compose([
+            transforms.ToTensor(),
+            transforms.Normalize((0.13062755,), (0.30810780,)),
+        ])
     ),
 
-    model_class=DendriticMLP,
+    model_class=StandardMLP,
     model_args=dict(
         input_size=784,
-        output_size=10,
-        hidden_sizes=[64, 64],
-        num_segments=NUM_TASKS,
-        dim_context=1024,  # Note: with the Gaussian dataset, `dim_context` was
-        # 2048, but this shouldn't effect results
-        kw=True,
-        # dendrite_sparsity=0.0,
+        num_classes=10,
+        hidden_sizes=[2048, 2048],
     ),
 
-    batch_size=256,
+    batch_size=32,
     val_batch_size=512,
-    epochs=1,
-    tasks_to_validate=(0, 1, 2),  # Tasks on which to run validate
-    epochs_to_validate=[],
-    num_tasks=NUM_TASKS,
-    num_classes=10 * NUM_TASKS,
+    epochs=13,
+    epochs_to_validate=range(30),
+    num_classes=10,
     distributed=False,
-    seed=42,
+    seed=tune.sample_from(lambda spec: np.random.randint(2, 10000)),
+    num_samples=1,  # Increase to run multiple experiments in parallel
 
     loss_function=F.cross_entropy,
-    optimizer_class=torch.optim.Adam,
-    optimizer_args=dict(lr=0.001),
-)
+    optimizer_class=torch.optim.SGD,
+    optimizer_args=dict(
+        lr=0.01,
+    ),
 
-# Temporary, just for testing
-BASE2 = deepcopy(DEFAULT_BASE)
-BASE2.update(
-    epochs=tune.grid_search([1, 2, 3]),
+    # Learning rate scheduler class and args. Must inherit from "_LRScheduler"
+    lr_scheduler_class=torch.optim.lr_scheduler.StepLR,
+    lr_scheduler_args=dict(
+        gamma=0.1,
+        step_size=10,
+    ),
 )
 
 # Export configurations in this file
 CONFIGS = dict(
-    default_base=DEFAULT_BASE,
-    base2=BASE2,
+    dense_mlp=DENSE_MLP,
 )

--- a/projects/dendrites/permutedMNIST/run_dendritic_network.py
+++ b/projects/dendrites/permutedMNIST/run_dendritic_network.py
@@ -161,7 +161,7 @@ def run_experiment(config):
 
 if __name__ == "__main__":
 
-    num_tasks = 50
+    num_tasks = 2
 
     config = dict(
         experiment_class=PermutedMNISTExperiment,
@@ -171,18 +171,19 @@ if __name__ == "__main__":
             num_tasks=num_tasks,
             dim_context=1024,
             seed=np.random.randint(0, 1000),
+            download=True,
         ),
 
         model_class=DendriticMLP,
         model_args=dict(
             input_size=784,
             output_size=10,
-            hidden_size=2048,
+            hidden_sizes=[64, 64],
             num_segments=num_tasks,
             dim_context=1024,  # Note: with the Gaussian dataset, `dim_context` was
                                # 2048, but this shouldn't effect results
             kw=True,
-            dendrite_sparsity=0.0,
+            # dendrite_sparsity=0.0,
         ),
 
         batch_size=256,

--- a/projects/dendrites/permutedMNIST/run_dendritic_network.py
+++ b/projects/dendrites/permutedMNIST/run_dendritic_network.py
@@ -29,7 +29,6 @@ This setup is very similar to that of context-dependent gating model from the pa
 stabilization' (Masse et al., 2018).
 """
 
-import numpy as np
 import torch
 import torch.nn.functional as F
 

--- a/projects/dendrites/permutedMNIST/run_dendritic_network.py
+++ b/projects/dendrites/permutedMNIST/run_dendritic_network.py
@@ -61,7 +61,6 @@ def train_model(exp):
         exp.optimizer.zero_grad()
         output = exp.model(data, context)
 
-        output = F.log_softmax(output)
         error_loss = exp.error_loss(output, target)
         error_loss.backward()
         exp.optimizer.step()
@@ -170,7 +169,7 @@ if __name__ == "__main__":
         dataset_args=dict(
             num_tasks=num_tasks,
             dim_context=1024,
-            seed=np.random.randint(0, 1000),
+            seed=42,
             download=True,
         ),
 
@@ -195,9 +194,9 @@ if __name__ == "__main__":
         num_tasks=num_tasks,
         num_classes=10 * num_tasks,
         distributed=False,
-        seed=np.random.randint(0, 10000),
+        seed=42,
 
-        loss_function=F.nll_loss,
+        loss_function=F.cross_entropy,
         optimizer_class=torch.optim.Adam,
         optimizer_args=dict(lr=0.001),
     )


### PR DESCRIPTION
The `projects/dendrites/permutedMNIST/` had custom code that didn't rely on Vernon to run experiments. Now, it will use Vernon, and a lot of redundancy has been eliminated. The major changes are:

1. A `DendriteContinualLearningExperiment ` experiment class, similar to `CLExperiment`, but with few changes (such as the parameters assumed by the train & eval methods). It's not yet clear if this experiment class will be needed in the long run, but it's here for now.
2. `train_dendrite_model` and `evaluate_dendrite_model` functions in a new dendrite model utils file. As the original model utils is now pretty crowded, dendrites could use their own train & eval functions.
3. `create_optimizer` in `SupervisedExperiment` is no longer a class method. There are mixins that assume it's still a class method, so that will need to be updated. For now, a bunch of TODOs have been used as placeholders.

The changes here are preliminary and possibly not complete, but it's better to start with this than submit an even larger PR with more moving parts.