### PR TITLE
pythorch-lightning 1.3 breaks python path 

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -56,4 +56,4 @@ wandb>=0.9.4
 # of colorama or urllib3 compatible with awscli
 colorama==0.4.3
 urllib3==1.25.11
-pytorch-lightning
+pytorch-lightning==1.2.9


### PR DESCRIPTION
pythorch-lightning 1.3 breaks python path by installing the integration tests and other unwanted files directly into the site-package directory confusing isort