### PR TITLE
Small fix to enable training with the 80% trifecta model

### DIFF
--- a/projects/transformers/experiments/trifecta.py
+++ b/projects/transformers/experiments/trifecta.py
@@ -258,6 +258,7 @@ bert_sparse_trifecta_100k.update(
 verify_bert_sparse_trifecta_100k = deepcopy(bert_sparse_trifecta_100k)
 verify_bert_sparse_trifecta_100k.update(
     # Training arguments
+    model_name_or_path="/mnt/efs/results/pretrained-models/transformers-local/bert_sparse_80%_trifecta_100k",  # noqa: E501
     do_train=False,
     do_eval=True,
     overwrite_output_dir=False,

--- a/projects/transformers/models/static_sparse_bert.py
+++ b/projects/transformers/models/static_sparse_bert.py
@@ -154,7 +154,7 @@ class FullyStaticSparseBertModel(BertModel):
     class ConfigKWargs:
         """Keyword arguments to configure sparsity."""
         sparsity: Union[float, dict] = 0.5
-        sparsify_all_embeddings: bool = True
+        sparsify_all_embeddings: bool = False
 
     def __init__(self, config, add_pooling_layer=True):
         # Call the init one parent class up. Otherwise, the model will be defined twice.


### PR DESCRIPTION
The PR is for https://ntaresearch.atlassian.net/browse/RES-2309

The 80% sparse trifecta model was not overridden or lost. A small bug in the code simply prevented it from being loaded properly.