### PR TITLE
Configs for 100 tasks + Minor updates to SI mixin

### DIFF
--- a/projects/dendrites/permutedMNIST/experiments/centroid.py
+++ b/projects/dendrites/permutedMNIST/experiments/centroid.py
@@ -149,10 +149,21 @@ FIGURE_1B.update(
     ),
 )
 
+CENTROID_100 = deepcopy(CENTROID_10)
+CENTROID_100["dataset_args"].update(num_tasks=100)
+CENTROID_100["model_args"].update(num_segments=100)
+CENTROID_100.update(
+    num_samples=8,
+    num_tasks=100,
+    num_classes=10 * 100,
+    optimizer_args=dict(lr=1e-4),
+)
+
 # Export configurations in this file
 CONFIGS = dict(
     centroid_2=CENTROID_2,
     centroid_10=CENTROID_10,
     centroid_50=CENTROID_50,
+    centroid_100=CENTROID_100,
     figure_1b=FIGURE_1B,
 )

--- a/projects/dendrites/permutedMNIST/experiments/si_centroid.py
+++ b/projects/dendrites/permutedMNIST/experiments/si_centroid.py
@@ -111,8 +111,18 @@ SI_CENTROID_50.update(
     num_classes=10 * 50,
 )
 
+SI_CENTROID_100 = deepcopy(SI_CENTROID_50)
+SI_CENTROID_100["dataset_args"].update(num_tasks=100)
+SI_CENTROID_100["model_args"].update(num_segments=100)
+SI_CENTROID_100.update(
+    num_tasks=100,
+    num_classes=100 * 50,
+    optimizer_args=dict(lr=5e-4),
+)
+
 # Export configurations in this file
 CONFIGS = dict(
     si_centroid_10=SI_CENTROID_10,
     si_centroid_50=SI_CENTROID_50,
+    si_centroid_100=SI_CENTROID_100,
 )

--- a/projects/dendrites/permutedMNIST/experiments/si_centroid.py
+++ b/projects/dendrites/permutedMNIST/experiments/si_centroid.py
@@ -116,7 +116,7 @@ SI_CENTROID_100["dataset_args"].update(num_tasks=100)
 SI_CENTROID_100["model_args"].update(num_segments=100)
 SI_CENTROID_100.update(
     num_tasks=100,
-    num_classes=100 * 50,
+    num_classes=10 * 100,
     optimizer_args=dict(lr=5e-4),
 )
 


### PR DESCRIPTION
Here I introduce

1. Configs for 100-task experiments for dendritic networks on permutedMNIST both with & without SI,
2. Flexibility to the SI mixin so that SI can be optionally applied to dendritic weights via just a single config arg.