### PR TITLE
2x and 4x Configs and Minor Updates

### DIFF
--- a/projects/transformers/callbacks/metrics.py
+++ b/projects/transformers/callbacks/metrics.py
@@ -75,8 +75,9 @@ class TrackEvalMetrics(TrainerCallback):
             # track learning rate
             # get_last_lr() returns lr for each parameter group. For now,
             # assume lrs are the same for all and just track one.
-            last_lr = kwargs["lr_scheduler"].get_last_lr()
-            self.eval_metrics["lr"].append(last_lr[0])
+            if kwargs["lr_scheduler"] is not None:
+                last_lr = kwargs["lr_scheduler"].get_last_lr()
+                self.eval_metrics["lr"].append(last_lr[0])
 
             # TODO
             # Possibly update train_results

--- a/projects/transformers/models/static_sparse_bert.py
+++ b/projects/transformers/models/static_sparse_bert.py
@@ -181,7 +181,7 @@ class FullyStaticSparseBertModel(BertModel):
         device = self.device
 
         # Use `getattr` here for backwards compatibility for configs without this param.
-        sparsify_all_embeddings = getattr(self.config, "sparsify_all_embeddings", True)
+        sparsify_all_embeddings = getattr(self.config, "sparsify_all_embeddings", False)
 
         def get_sparsity(name):
             if isinstance(sparsity, dict):

--- a/projects/transformers/trainer_mixins/rigl.py
+++ b/projects/transformers/trainer_mixins/rigl.py
@@ -59,8 +59,9 @@ class RigLMixin:
         self.prune_fraction = mixin_args.get("prune_fraction", 0.3)
         self.prune_freq = mixin_args.get("prune_freq", 100)
         self.warmup_steps = mixin_args.get("warmup_steps", self.prune_freq)
+        total_steps = self.args.max_steps * self.args.gradient_accumulation_steps
         self.prune_scheduler = CosineDecayPruneScheduler(
-            total_steps=self.args.max_steps,
+            total_steps=total_steps,
             prune_fraction=self.prune_fraction,
             warmup_steps=self.warmup_steps
         )


### PR DESCRIPTION
This includes the most up-to-date 2x and 4x configs as well as
- Small fixes to RigL when gradient_accumulation_steps>1 and prune_fractionn is 0.
- Fix default `sparsify_all_embeddings` to False - this isn't needed to properly run the 80% sparse model as it's already False in the config. But it's helpful to have there for later.
- The lr range test has been refactored to avoid this bug here https://github.com/pytorch/pytorch/issues/47589
- A small fix in metrics.py when `kwargs["lr_scheduler"] is None`