### PR TITLE
GMP Pruning and Related Functionality

### DIFF
--- a/nupic/research/frameworks/dynamic_sparse/__init__.py
+++ b/nupic/research/frameworks/dynamic_sparse/__init__.py
@@ -20,4 +20,5 @@
 # ----------------------------------------------------------------------
 
 from .global_pruning import *
+from .gmp_lr_scheduler import *
 from .prune_scheduler import *

--- a/nupic/research/frameworks/dynamic_sparse/gmp_lr_scheduler.py
+++ b/nupic/research/frameworks/dynamic_sparse/gmp_lr_scheduler.py
@@ -36,6 +36,7 @@ class ThreeStageGMPLR(LambdaLR):
         3) cooldown - decay the learning rate twice (like a StepLR)
 
     :param max_lr: this is the maximum lr reached
+    :param min_lr: initial lr during the warmup phase
     :param warmup_steps: number of steps for the warmup phase
     :param cooldown_steps: number of steps for the cooldown phase
     :param total_steps: total number of steps; used to derive pruning steps
@@ -50,8 +51,10 @@ class ThreeStageGMPLR(LambdaLR):
         warmup_steps,
         cooldown_steps,
         total_steps,
-        cooldown_gamma
+        cooldown_gamma,
+        min_lr=0,
     ):
+        self.min_lr = min_lr
         self.max_lr = max_lr
         self.warmup_steps = warmup_steps
         self.cooldown_steps = cooldown_steps
@@ -87,9 +90,9 @@ class ThreeStageGMPLR(LambdaLR):
 
     # Warm-up phase.
     def warmup_lr(self, step: int):
-        """Linearly ramp up the lr from 0 to max_lr in `warmup_steps`"""
-        min_lr = 0
-        return (self.max_lr - min_lr) / (self.warmup_steps - 1) * step + min_lr
+        """Linearly ramp up the lr from min_lr to max_lr in `warmup_steps`"""
+        slope = (self.max_lr - self.min_lr) / (self.warmup_steps - 1)
+        return slope * step + self.min_lr
 
     # Pruning phase
     def pruning_lr(self, step: int):

--- a/nupic/research/frameworks/dynamic_sparse/gmp_lr_scheduler.py
+++ b/nupic/research/frameworks/dynamic_sparse/gmp_lr_scheduler.py
@@ -1,0 +1,119 @@
+# ----------------------------------------------------------------------
+# Numenta Platform for Intelligent Computing (NuPIC)
+# Copyright (C) 2021, Numenta, Inc.  Unless you have an agreement
+# with Numenta, Inc., for a separate license for this software code, the
+# following terms and conditions apply:
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# See the GNU Affero Public License for more details.
+#
+# You should have received a copy of the GNU Affero Public License
+# along with this program.  If not, see http://www.gnu.org/licenses.
+#
+# http://numenta.org/licenses/
+# ----------------------------------------------------------------------
+
+from torch.optim.lr_scheduler import LambdaLR
+
+__all__ = [
+    "ThreeStageGMPLR",
+]
+
+
+class ThreeStageGMPLR(LambdaLR):
+    """
+    This is an lr schedule for Gradual Magnitude Pruning (GMP) consisting of three
+    stages:
+        1) warmup - linearly ramp up from 0 to max_lr; this differs from the paper
+                    which uses a constant lr
+        2) pruning - maintain a constant max_lr
+        3) cooldown - decay the learning rate twice (like a StepLR)
+
+    :param max_lr: this is the maximum lr reached
+    :param warmup_steps: number of steps for the warmup phase
+    :param cooldown_steps: number of steps for the cooldown phase
+    :param total_steps: total number of steps; used to derive pruning steps
+    :param cooldown_gamma: how much to decay the lr during cooldown
+                           e.g. lr <- lr * cooldown_gamma; used to decay the lr twice
+    """
+
+    def __init__(
+        self,
+        optimizer,
+        max_lr,
+        warmup_steps,
+        cooldown_steps,
+        total_steps,
+        cooldown_gamma
+    ):
+        self.max_lr = max_lr
+        self.warmup_steps = warmup_steps
+        self.cooldown_steps = cooldown_steps
+        self.total_steps = total_steps
+        self.pruning_steps = total_steps - warmup_steps - cooldown_steps
+        self.cooldown_gamma = 0.1
+        assert int(cooldown_steps / 3) >= 2, (
+            "Too few `cooldown_steps`. The lr will be decayed twice throughout the "
+            "cooldown period."
+        )
+
+        super().__init__(optimizer, self.composed_lr)
+
+    def composed_lr(self, step: int):
+        """
+        LR schedule for GMP Pruning consisting of three phases. Here `step` starts at 0.
+        """
+
+        # Step starts at 0, but will make it start at 1.
+        train_step = step + 1
+
+        # Phase 1: Warm-up phase - linear warmup.
+        if train_step < self.warmup_steps:
+            return self.warmup_lr(step)
+
+        # Phase 3: Cool-down phase - StepLR like decay
+        elif train_step > self.total_steps - self.cooldown_steps:
+            return self.cooldown_lr(step)
+
+        # Phase 2: Pruning phase - constant lr.
+        else:
+            return self.pruning_lr(step)
+
+    # Warm-up phase.
+    def warmup_lr(self, step: int):
+        """Linearly ramp up the lr from 0 to max_lr in `warmup_steps`"""
+        min_lr = 0
+        return (self.max_lr - min_lr) / (self.warmup_steps - 1) * step + min_lr
+
+    # Pruning phase
+    def pruning_lr(self, step: int):
+        """Keep the lr constant"""
+        return self.max_lr
+
+    # Cool-down phase
+    def cooldown_lr(self, step: int):
+        """
+        Similar to StepLR, decay the learning twice throughout the cooldown phase.
+        Right now it only supports decaying the lr twice.
+        """
+
+        step_size = int(self.cooldown_steps / 3)
+        step_into_cooldown = (step + 1) - self.warmup_steps - self.pruning_steps
+
+        # Decay twice when past `2 * step_size`
+        if step_into_cooldown > 2 * step_size:
+            return self.max_lr * self.cooldown_gamma ** 2
+
+        # Decay one when past `step_size`
+        elif step_into_cooldown > step_size:
+            return self.max_lr * self.cooldown_gamma
+
+        # Don't decay when not past the step_size.
+        else:
+            return self.max_lr

--- a/projects/transformers/create_prunable_checkpoint.py
+++ b/projects/transformers/create_prunable_checkpoint.py
@@ -1,0 +1,96 @@
+# ----------------------------------------------------------------------
+# Numenta Platform for Intelligent Computing (NuPIC)
+# Copyright (C) 2021, Numenta, Inc.  Unless you have an agreement
+# with Numenta, Inc., for a separate license for this software code, the
+# following terms and conditions apply:
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# See the GNU Affero Public License for more details.
+#
+# You should have received a copy of the GNU Affero Public License
+# along with this program.  If not, see http://www.gnu.org/licenses.
+#
+# http://numenta.org/licenses/
+# ----------------------------------------------------------------------
+
+"""
+Pretrained models need to be exported to be used for finetuning.
+Only required argument for this script is the checkpoint folder.
+
+Not tested for modified sparse models.
+"""
+
+import argparse
+
+# FIXME: The experiments import Ray, but it must be imported before Pickle # noqa I001
+import ray  # noqa: F401, I001
+from transformers import AutoModelForMaskedLM, HfArgumentParser
+
+from experiments import CONFIGS
+from nupic.research.frameworks.pytorch.model_utils import filter_params, get_module_attr
+from nupic.torch.modules.sparse_weights import SparseWeightsBase
+from run_args import ModelArguments
+from run_utils import init_config, init_tokenizer
+
+
+def convert_to_prunable_checkpoint(checkpoint_folder, experiment):
+    """
+    This loads a dense models weights and a prunable model of similar architecture (one
+    with SparseWeightsBase layers), copies the weights of the former into the latter,
+    and then saves a new checkpoint at `{checkpoint_folder}_prunable`.
+
+    :param checkpoint_folder: path to dense checkpoint
+    :param experiment: name of experiment config with a prunable architecture
+    """
+
+    # We'll use `sparsity=0` to ensure it's dense but prunable model.
+    exp_config = CONFIGS[experiment]
+    exp_config["config_kwargs"]["sparsity"] = 0
+    exp_parser = HfArgumentParser(ModelArguments)
+    model_args = exp_parser.parse_dict(exp_config)[0]
+
+    # Initialize prunable model and dense model.
+    config = init_config(model_args)
+    tokenizer = init_tokenizer(model_args)
+    prunable_model = AutoModelForMaskedLM.from_config(config)
+    prunable_model.resize_token_embeddings(len(tokenizer))
+
+    dense_model = AutoModelForMaskedLM.from_pretrained(checkpoint_folder)
+
+    # Determine which parameters belong to SparseWeightsBase classes.
+    sparse_params = filter_params(prunable_model, include_modules=[SparseWeightsBase])
+    sparse_dataptrs = [p.data_ptr() for p in sparse_params.values()]
+
+    # Load the dense params into the prunable params.
+    for n2, p2 in prunable_model.named_parameters():
+
+        # e.g. replace `linear.module.weight` with `linear.weight` when appropriate.
+        if p2.data_ptr() in sparse_dataptrs:
+            n1 = n2.replace(".module", "")
+        else:
+            n1 = n2
+
+        p1 = get_module_attr(dense_model, n1)
+        p2.data[:] = p1
+
+    # Save the prunable model.
+    new_folder_name = checkpoint_folder + "_prunable"
+    prunable_model.save_pretrained(new_folder_name)
+    print(f"Saved prunable model to:\n{new_folder_name}")
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("checkpoint_folder", type=str,
+                        help="Path to checkpoint to convert")
+    parser.add_argument("-e", "--experiment", choices=list(CONFIGS.keys()),
+                        help="Available experiments", required=True)
+
+    args = parser.parse_args()
+    convert_to_prunable_checkpoint(**args.__dict__)

--- a/projects/transformers/experiments/__init__.py
+++ b/projects/transformers/experiments/__init__.py
@@ -41,6 +41,7 @@ from .sparse_bert import CONFIGS as SPARSE_BERT
 from .sparse_bertitos import CONFIGS as SPARSE_BERTITOS
 from .trifecta import CONFIGS as TRIFECTA
 from .wide_bert import CONFIGS as WIDE_BERT
+from .wide_bert_fixed_num_params import CONFIGS as WIDE_BERT_FIXED_NUM_PARAMS
 
 """
 Import and collect all experiment configurations into one CONFIG
@@ -67,3 +68,4 @@ CONFIGS.update(SPARSE_BERT)
 CONFIGS.update(SPARSE_BERTITOS)
 CONFIGS.update(TRIFECTA)
 CONFIGS.update(WIDE_BERT)
+CONFIGS.update(WIDE_BERT_FIXED_NUM_PARAMS)

--- a/projects/transformers/experiments/__init__.py
+++ b/projects/transformers/experiments/__init__.py
@@ -33,6 +33,7 @@ from .eighty_percent_sparse import CONFIGS as EIGHT_PERCENT_SPARSE
 from .finetuning import CONFIGS as FINETUNING
 from .hpchase import CONFIGS as HPCHASE
 from .hpsearch import CONFIGS as HPSEARCH
+from .gmp_bert import CONFIGS as GMP_BERT
 from .one_cycle_lr import CONFIGS as ONE_CYCLE_LR
 from .profiler import CONFIGS as PROFILER
 from .regressions import CONFIGS as REGRESSIONS
@@ -60,6 +61,7 @@ CONFIGS.update(EIGHT_PERCENT_SPARSE)
 CONFIGS.update(FINETUNING)
 CONFIGS.update(HPSEARCH)
 CONFIGS.update(HPCHASE)
+CONFIGS.update(GMP_BERT)
 CONFIGS.update(ONE_CYCLE_LR)
 CONFIGS.update(PROFILER)
 CONFIGS.update(REGRESSIONS)

--- a/projects/transformers/experiments/gmp_bert.py
+++ b/projects/transformers/experiments/gmp_bert.py
@@ -1,0 +1,235 @@
+# ----------------------------------------------------------------------
+# Numenta Platform for Intelligent Computing (NuPIC)
+# Copyright (C) 2021, Numenta, Inc.  Unless you have an agreement
+# with Numenta, Inc., for a separate license for this software code, the
+# following terms and conditions apply:
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# See the GNU Affero Public License for more details.
+#
+# You should have received a copy of the GNU Affero Public License
+# along with this program.  If not, see http://www.gnu.org/licenses.
+#
+# http://numenta.org/licenses/
+# ----------------------------------------------------------------------
+
+
+from copy import deepcopy
+
+from transformers import Trainer
+
+from callbacks import PlotDensitiesCallback, RezeroWeightsCallback
+from trainer_mixins import (
+    DistillationTrainerMixin,
+    GradualMagnitudePruningMixin,
+    OneCycleLRMixin,
+    ThreeStageLRMixin,
+)
+
+from .bertitos import tiny_bert_100k, tiny_bert_debug
+from .trifecta import KDLRRangeTestTrainer
+
+
+class GMPPretrainedTrainer(GradualMagnitudePruningMixin,
+                           ThreeStageLRMixin,
+                           DistillationTrainerMixin,
+                           Trainer):
+    """
+    GMP on pretrained network. This uses a three stage lr for stabilization, pruning and
+    fine-tuning.
+    """
+    pass
+
+
+class GMPTrainer(GradualMagnitudePruningMixin,
+                 OneCycleLRMixin,
+                 DistillationTrainerMixin,
+                 Trainer):
+    """
+    GMP on pretrained network. This uses one-cycle lr.
+    """
+    pass
+
+
+# Pretrained models to prune via GMP.
+base_dir = "/mnt/efs/results/pretrained-models/transformers-local/"
+tiny_bert_100k_pretrained = base_dir + "tiny_bert_100k_prunable"
+tiny_bert_kd_onecycle_100k_pretrained = base_dir + "tiny_bert_onecycle_lr_kd_100k_prunable"  # noqa: E501
+
+
+# Just a debug config.
+tiny_bert_gmp_debug = deepcopy(tiny_bert_debug)
+tiny_bert_gmp_debug.update(
+    max_steps=100,
+    do_eval=False,
+    model_name_or_path=tiny_bert_100k_pretrained,
+    # evaluation_strategy="steps",
+    # eval_steps=2,
+    model_type="fully_static_sparse_bert",
+    trainer_callbacks=[
+        RezeroWeightsCallback(log_steps=10),
+    ],
+    trainer_class=GMPPretrainedTrainer,
+    trainer_mixin_args=dict(
+        start_sparsity=0,
+        end_sparsity=0.8,
+        warmup_steps=30,
+        cooldown_steps=30,
+        prune_period=10,
+        max_lr=0.01,
+        verbose_gmp_logging=True,
+    ),
+)
+tiny_bert_gmp_debug["config_kwargs"].update(
+    sparsity=0.8,
+    sparsify_all_embeddings=False,
+)
+
+
+# ----------
+# Tiny BERT
+# ----------
+
+
+# Perform LR range test with pretrained Tiny BERT.
+tiny_bert_pretrained_gmp_lr_range_test = deepcopy(tiny_bert_100k)
+tiny_bert_pretrained_gmp_lr_range_test.update(
+    max_steps=100,
+
+    # LR Range test for `tiny_bert_pretrained_gmp_52k`
+    # trainer_class=LRRangeTestTrainer,
+    # model_name_or_path=tiny_bert_100k_pretrained,
+
+    # LR Range test for `tiny_bert_kd_onecycle_pretrained_gmp_52k`
+    trainer_class=KDLRRangeTestTrainer,
+    model_name_or_path=tiny_bert_kd_onecycle_100k_pretrained,
+
+    # eval_steps=1,
+    trainer_mixin_args=dict(
+        # LR Range Test
+        min_lr=1e-8,
+        max_lr=5e-5,
+        test_mode="linear",
+
+        # KD
+        teacher_model_names_or_paths=[
+            "/mnt/efs/results/pretrained-models/transformers-local/bert_1mi",
+        ],
+    ),
+    overwrite_output_dir=True,
+    do_eval=True,
+)
+
+
+# Apply GMP pruning on pretrained Tiny BERT. Pre-trianing done w/o KD + OneCycle LR
+tiny_bert_pretrained_gmp_52k = deepcopy(tiny_bert_100k)
+tiny_bert_pretrained_gmp_52k.update(
+    # steps: 2000 warmup, 30000 pruning (every 1000), 20000 cooldown
+    max_steps=2000 + 30000 + 20000,
+    model_type="fully_static_sparse_bert",
+    model_name_or_path=tiny_bert_100k_pretrained,
+    trainer_callbacks=[
+        RezeroWeightsCallback(),
+        PlotDensitiesCallback(plot_freq=10000),
+    ],
+    trainer_class=GMPPretrainedTrainer,
+    trainer_mixin_args=dict(
+        # GMP
+        start_sparsity=0,
+        end_sparsity=0.8,
+        warmup_steps=2000,
+        cooldown_steps=20000,
+        prune_period=1000,
+        max_lr=2e-5,
+        verbose_gmp_logging=True,
+
+        # KD
+        teacher_model_names_or_paths=[
+            "/mnt/efs/results/pretrained-models/transformers-local/bert_1mi",
+        ],
+    ),
+)
+
+
+# Apply GMP pruning on pretrained Tiny BERT. Pre-trianing done with KD + OneCycle LR
+# LR-Range Test here https://wandb.ai/numenta/huggingface/runs/34iuv3s5
+tiny_bert_kd_onecycle_pretrained_gmp_52k = deepcopy(tiny_bert_pretrained_gmp_52k)
+tiny_bert_kd_onecycle_pretrained_gmp_52k.update(
+    model_name_or_path=tiny_bert_kd_onecycle_100k_pretrained,
+)
+tiny_bert_kd_onecycle_pretrained_gmp_52k["trainer_mixin_args"].update(
+    max_lr=2e-5,
+)
+
+tiny_bert_kd_onecycle_pretrained_gmp_52k_maxlr_002 = deepcopy(tiny_bert_kd_onecycle_pretrained_gmp_52k)  # noqa E501
+tiny_bert_kd_onecycle_pretrained_gmp_52k_maxlr_002["trainer_mixin_args"].update(
+    max_lr=2e-3,
+)
+
+tiny_bert_kd_onecycle_pretrained_gmp_52k_maxlr_02 = deepcopy(tiny_bert_kd_onecycle_pretrained_gmp_52k)  # noqa E501
+tiny_bert_kd_onecycle_pretrained_gmp_52k_maxlr_02["trainer_mixin_args"].update(
+    max_lr=2e-2,
+)
+
+# Apply GMP pruning Tiny BERT throughout pretraining.
+tiny_bert_gmp_100k = deepcopy(tiny_bert_100k)
+tiny_bert_gmp_100k.update(
+    model_type="fully_static_sparse_bert",
+    trainer_callbacks=[
+        RezeroWeightsCallback(),
+        PlotDensitiesCallback(plot_freq=10000),
+    ],
+    trainer_class=GMPTrainer,
+    trainer_mixin_args=dict(
+        # GMP
+        start_sparsity=0,
+        end_sparsity=0.8,
+        warmup_steps=5000,
+        cooldown_steps=20000,
+        prune_period=500,
+        verbose_gmp_logging=True,
+
+        # OneCycle LR
+        max_lr=0.03,
+
+        # KD
+        teacher_model_names_or_paths=[
+            "/mnt/efs/results/pretrained-models/transformers-local/bert_1mi",
+        ],
+    ),
+)
+tiny_bert_gmp_100k["config_kwargs"].update(
+    # Only sparsify the word_embeddings
+    sparsify_all_embeddings=False,
+    sparsity=0,
+)
+
+
+tiny_bert_gmp_100k_maxlr_01 = deepcopy(tiny_bert_gmp_100k)
+tiny_bert_gmp_100k_maxlr_01["trainer_mixin_args"].update(
+    max_lr=0.01,
+)
+
+tiny_bert_gmp_100k_maxlr_05 = deepcopy(tiny_bert_gmp_100k)
+tiny_bert_gmp_100k_maxlr_05["trainer_mixin_args"].update(
+    max_lr=0.05,
+)
+
+
+CONFIGS = dict(
+    tiny_bert_gmp_debug=tiny_bert_gmp_debug,
+    tiny_bert_pretrained_gmp_lr_range_test=tiny_bert_pretrained_gmp_lr_range_test,
+    tiny_bert_pretrained_gmp_52k=tiny_bert_pretrained_gmp_52k,
+    tiny_bert_kd_onecycle_pretrained_gmp_52k=tiny_bert_kd_onecycle_pretrained_gmp_52k,
+    tiny_bert_kd_onecycle_pretrained_gmp_52k_maxlr_02=tiny_bert_kd_onecycle_pretrained_gmp_52k_maxlr_02,  # noqa 501
+    tiny_bert_kd_onecycle_pretrained_gmp_52k_maxlr_002=tiny_bert_kd_onecycle_pretrained_gmp_52k_maxlr_002,  # noqa 501
+    tiny_bert_gmp_100k=tiny_bert_gmp_100k,
+    tiny_bert_gmp_100k_maxlr_01=tiny_bert_gmp_100k_maxlr_01,
+    tiny_bert_gmp_100k_maxlr_05=tiny_bert_gmp_100k_maxlr_05,
+)

--- a/projects/transformers/experiments/wide_bert.py
+++ b/projects/transformers/experiments/wide_bert.py
@@ -85,7 +85,7 @@ tiny_bert_125_percent_wide_args = dict(
     sparsify_all_embeddings=False,
 )
 
-# Bert with layers of 12.5 percent wider
+# Bert with layers of 50 percent wider
 tiny_bert_150_percent_wide_args = dict(
     hidden_size=192,
     intermediate_size=768,
@@ -93,15 +93,25 @@ tiny_bert_150_percent_wide_args = dict(
     sparsify_all_embeddings=False,
 )
 
-# Bert with layers of 12.5 percent wider
+# Bert with layers of 100 percent wider
 tiny_bert_200_percent_wide_args = dict(
     hidden_size=256,
     intermediate_size=1024,
-    sparsity=0.9083,
+    # sparsity=0.9083,
+    sparsity=0.9283,
     sparsify_all_embeddings=False,
 )
 
-# Bert with layers of 12.5 percent wider
+# Bert with layers of 300 percent wider
+tiny_bert_400_percent_wide_args = dict(
+    hidden_size=512,
+    intermediate_size=2048,
+    sparsity=0.973,
+    # sparsity=0.963,
+    sparsify_all_embeddings=False,
+)
+
+# Bert with layers of 387.5 percent wider
 tiny_bert_487_percent_wide_args = dict(
     hidden_size=624,
     intermediate_size=2496,
@@ -142,19 +152,41 @@ tiny_bert_trifecta_200_perc_wide_100k["config_kwargs"].update(
     **tiny_bert_200_percent_wide_args,
 )
 
+
+# This helps decide the max_lr for `tiny_bert_trifecta_200_perc_wide_100k` above.
+tiny_bert_trifecta_200_perc_wide_lr_range_test = deepcopy(tiny_bert_trifecta_200_perc_wide_100k)  # noqa E501
+tiny_bert_trifecta_200_perc_wide_lr_range_test.update(
+    **lr_range_test_args,
+)
+
+# Sparse Tiny BERT with hidden and intermediate sizes 4.0x bigger.
+# Trained with RigL + KD + OneCycle LR (Trifecta)
+tiny_bert_trifecta_400_perc_wide_100k = deepcopy(tiny_bert_trifecta_100k)
+tiny_bert_trifecta_400_perc_wide_100k["config_kwargs"].update(
+    **tiny_bert_400_percent_wide_args,
+)
+
+
+# This helps decide the max_lr for `tiny_bert_trifecta_400_perc_wide_100k` above.
+tiny_bert_trifecta_400_perc_wide_lr_range_test = deepcopy(tiny_bert_trifecta_400_perc_wide_100k)  # noqa E501
+tiny_bert_trifecta_400_perc_wide_lr_range_test.update(
+    **lr_range_test_args,
+)
+
+
 # Sparse Tiny BERT with hidden and intermediate sizes 4.87x bigger.
 # This is the same size in terms of parameters as Small BERT.
 # Trained with RigL + KD + OneCycle LR (Trifecta)
 tiny_bert_trifecta_487_perc_wide_100k = deepcopy(tiny_bert_trifecta_100k)
 tiny_bert_trifecta_487_perc_wide_100k["config_kwargs"].update(
     **tiny_bert_487_percent_wide_args,
-    sparsity=0.97,  # this sparsity mimics dense Tiny BERT 1.0x Wide
+    sparsity=0.972,  # this sparsity mimics dense Tiny BERT 1.0x Wide
 )
-tiny_bert_trifecta_487_perc_wide_100k.update(
-    # Using batch_size of 16 instead of 128 since we're training on 8 GPUs.
-    per_device_train_batch_size=16,
-    per_device_eval_batch_size=16,
-)
+# tiny_bert_trifecta_487_perc_wide_100k.update(
+#     # Using batch_size of 16 instead of 128 since we're training on 8 GPUs.
+#     per_device_train_batch_size=16,
+#     per_device_eval_batch_size=16,
+# )
 
 # This experiment is like the one of the same name above, but it's meant to be
 # compared to Small BERT. Thus, it uses the same number of attention heads and
@@ -166,7 +198,7 @@ tiny_bert_trifecta_487_perc_wide_100k.update(
 #     # This better mimics Small BERT's architecture. Tiny BERT usually just has 2.
 #     attention_heads=8,
 #     # This mimics Small BERT 1.0x Wide at 96.95% sparse
-#     sparsity=0.972,
+#     sparsity=0.97,
 # )
 # tiny_bert_trifecta_487_perc_wide_100k["trainer_mixin_args"].update(
 #     # This max_lr is determined by the test below:
@@ -214,6 +246,9 @@ CONFIGS = dict(
     tiny_bert_trifecta_125_perc_wide_100k=tiny_bert_trifecta_125_perc_wide_100k,
     tiny_bert_trifecta_150_perc_wide_100k=tiny_bert_trifecta_150_perc_wide_100k,
     tiny_bert_trifecta_200_perc_wide_100k=tiny_bert_trifecta_200_perc_wide_100k,
+    tiny_bert_trifecta_200_perc_wide_lr_range_test=tiny_bert_trifecta_200_perc_wide_lr_range_test,  # noqa E501
+    tiny_bert_trifecta_400_perc_wide_100k=tiny_bert_trifecta_400_perc_wide_100k,
+    tiny_bert_trifecta_400_perc_wide_lr_range_test=tiny_bert_trifecta_400_perc_wide_lr_range_test,  # noqa E501
     tiny_bert_trifecta_487_perc_wide_100k=tiny_bert_trifecta_487_perc_wide_100k,
     tiny_bert_trifecta_487_perc_wide_lr_range_test=tiny_bert_trifecta_487_perc_wide_lr_range_test,  # noqa E501
 

--- a/projects/transformers/experiments/wide_bert_fixed_num_params.py
+++ b/projects/transformers/experiments/wide_bert_fixed_num_params.py
@@ -1,0 +1,273 @@
+# ----------------------------------------------------------------------
+# Numenta Platform for Intelligent Computing (NuPIC)
+# Copyright (C) 2021, Numenta, Inc.  Unless you have an agreement
+# with Numenta, Inc., for a separate license for this software code, the
+# following terms and conditions apply:
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# See the GNU Affero Public License for more details.
+#
+# You should have received a copy of the GNU Affero Public License
+# along with this program.  If not, see http://www.gnu.org/licenses.
+#
+# http://numenta.org/licenses/
+# ----------------------------------------------------------------------
+
+from copy import deepcopy
+
+from .trifecta import tiny_bert_trifecta_100k
+
+"""
+These experiments attempt to vary the width and the number of on-params of a BERT model
+while maintaining some fixed level of loss. They differ from `wide_bert.py` as that file
+only varies the width while keeping the on-params fixed.
+"""
+
+# Set training to be distributed.
+tiny_bert_trifecta_100k_dist = deepcopy(tiny_bert_trifecta_100k)
+tiny_bert_trifecta_100k_dist.update(
+    # Using batch_size of 16 instead of 128 since we're training on 8 GPUs.
+    per_device_train_batch_size=16,
+    per_device_eval_batch_size=16,
+)
+
+# Specify the max lr for 300k on-params.
+tiny_bert_trifecta_300k_params = deepcopy(tiny_bert_trifecta_100k_dist)
+tiny_bert_trifecta_300k_params["trainer_mixin_args"].update(
+    max_lr=0.010,
+)
+# Specify the max lr for 400k on-params.
+tiny_bert_trifecta_400k_params = deepcopy(tiny_bert_trifecta_100k_dist)
+tiny_bert_trifecta_400k_params["trainer_mixin_args"].update(
+    max_lr=0.009,
+)
+# Specify the max lr for 500k on-params.
+tiny_bert_trifecta_500k_params = deepcopy(tiny_bert_trifecta_100k_dist)
+tiny_bert_trifecta_500k_params["trainer_mixin_args"].update(
+    max_lr=0.0085,
+)
+# Specify the max lr for 600k on-params.
+tiny_bert_trifecta_600k_params = deepcopy(tiny_bert_trifecta_100k_dist)
+tiny_bert_trifecta_600k_params["trainer_mixin_args"].update(
+    max_lr=0.0081,
+)
+# Specify the max lr for 700k on-params.
+tiny_bert_trifecta_700k_params = deepcopy(tiny_bert_trifecta_100k_dist)
+tiny_bert_trifecta_700k_params["trainer_mixin_args"].update(
+    max_lr=0.0078,
+)
+# Specify the max lr for 800k on-params.
+tiny_bert_trifecta_800k_params = deepcopy(tiny_bert_trifecta_100k_dist)
+tiny_bert_trifecta_800k_params["trainer_mixin_args"].update(
+    max_lr=0.0075,
+)
+# Specify the max lr for 900k on-params.
+tiny_bert_trifecta_900k_params = deepcopy(tiny_bert_trifecta_100k_dist)
+tiny_bert_trifecta_900k_params["trainer_mixin_args"].update(
+    max_lr=0.0071,
+)
+
+
+# Bert with layers of 4x wider
+tiny_bert_4x_wide_args = dict(
+    hidden_size=512,
+    intermediate_size=2048,
+    sparsify_all_embeddings=False,
+)
+
+
+# Bert with layers of 2x wider
+tiny_bert_2x_wide_args = dict(
+    hidden_size=256,
+    intermediate_size=1024,
+    sparsify_all_embeddings=False,
+)
+
+
+# --------
+# 1x Wide
+# --------
+
+# ~300k on-params
+tiny_bert_trifecta_1x_wide_9318sparse_100k = deepcopy(tiny_bert_trifecta_300k_params)
+tiny_bert_trifecta_1x_wide_9318sparse_100k["config_kwargs"].update(
+    sparsity=0.9318,
+)
+
+# ~400k on-params
+tiny_bert_trifecta_1x_wide_9075sparse_100k = deepcopy(tiny_bert_trifecta_400k_params)
+tiny_bert_trifecta_1x_wide_9075sparse_100k["config_kwargs"].update(
+    sparsity=0.9075,
+)
+
+# ~500k on-params
+tiny_bert_trifecta_1x_wide_8831sparse_100k = deepcopy(tiny_bert_trifecta_500k_params)
+tiny_bert_trifecta_1x_wide_8831sparse_100k["config_kwargs"].update(
+    sparsity=0.8831,
+)
+
+# ~600k on-params
+tiny_bert_trifecta_1x_wide_8588sparse_100k = deepcopy(tiny_bert_trifecta_600k_params)
+tiny_bert_trifecta_1x_wide_8588sparse_100k["config_kwargs"].update(
+    sparsity=0.8588,
+)
+
+# ~700k on-params
+tiny_bert_trifecta_1x_wide_8344sparse_100k = deepcopy(tiny_bert_trifecta_700k_params)
+tiny_bert_trifecta_1x_wide_8344sparse_100k["config_kwargs"].update(
+    sparsity=0.8344,
+)
+
+# ~800k on-params
+tiny_bert_trifecta_1x_wide_81sparse_100k = deepcopy(tiny_bert_trifecta_800k_params)
+tiny_bert_trifecta_1x_wide_81sparse_100k["config_kwargs"].update(
+    sparsity=0.81,
+)
+
+# ~900k on-params
+tiny_bert_trifecta_1x_wide_7857sparse_100k = deepcopy(tiny_bert_trifecta_900k_params)
+tiny_bert_trifecta_1x_wide_7857sparse_100k["config_kwargs"].update(
+    sparsity=0.7857,
+)
+
+
+# --------
+# 2x Wide
+# --------
+
+# ~300k on-params
+tiny_bert_trifecta_2x_wide_9711sparse_100k = deepcopy(tiny_bert_trifecta_300k_params)
+tiny_bert_trifecta_2x_wide_9711sparse_100k["config_kwargs"].update(
+    sparsity=0.9711,
+    **tiny_bert_2x_wide_args,
+)
+
+# ~400k on-params
+tiny_bert_trifecta_2x_wide_96sparse_100k = deepcopy(tiny_bert_trifecta_400k_params)
+tiny_bert_trifecta_2x_wide_96sparse_100k["config_kwargs"].update(
+    sparsity=0.96,
+    **tiny_bert_2x_wide_args,
+)
+
+# ~500k on-params
+tiny_bert_trifecta_2x_wide_9489sparse_100k = deepcopy(tiny_bert_trifecta_500k_params)
+tiny_bert_trifecta_2x_wide_9489sparse_100k["config_kwargs"].update(
+    sparsity=0.9489,
+    **tiny_bert_2x_wide_args,
+)
+
+# ~600k on-params
+tiny_bert_trifecta_2x_wide_9378sparse_100k = deepcopy(tiny_bert_trifecta_600k_params)
+tiny_bert_trifecta_2x_wide_9378sparse_100k["config_kwargs"].update(
+    sparsity=0.9378,
+    **tiny_bert_2x_wide_args,
+)
+
+# ~700k on-params
+tiny_bert_trifecta_2x_wide_9267sparse_100k = deepcopy(tiny_bert_trifecta_700k_params)
+tiny_bert_trifecta_2x_wide_9267sparse_100k["config_kwargs"].update(
+    sparsity=0.9267,
+    **tiny_bert_2x_wide_args,
+)
+
+# ~800k on-params
+tiny_bert_trifecta_2x_wide_9156sparse_100k = deepcopy(tiny_bert_trifecta_800k_params)
+tiny_bert_trifecta_2x_wide_9156sparse_100k["config_kwargs"].update(
+    sparsity=0.9156,
+    **tiny_bert_2x_wide_args,
+)
+
+# ~900k on-params
+tiny_bert_trifecta_2x_wide_9045sparse_100k = deepcopy(tiny_bert_trifecta_900k_params)
+tiny_bert_trifecta_2x_wide_9045sparse_100k["config_kwargs"].update(
+    sparsity=0.9045,
+    **tiny_bert_2x_wide_args,
+)
+
+
+# --------
+# 4x Wide
+# --------
+
+# ~300k on-params
+tiny_bert_trifecta_4x_wide_9896sparse_100k = deepcopy(tiny_bert_trifecta_300k_params)
+tiny_bert_trifecta_4x_wide_9896sparse_100k["config_kwargs"].update(
+    sparsity=0.9896,
+    **tiny_bert_4x_wide_args,
+)
+
+# ~400k on-params
+tiny_bert_trifecta_4x_wide_9849sparse_100k = deepcopy(tiny_bert_trifecta_400k_params)
+tiny_bert_trifecta_4x_wide_9849sparse_100k["config_kwargs"].update(
+    sparsity=0.9849,
+    **tiny_bert_4x_wide_args,
+)
+
+# ~500k on-params
+tiny_bert_trifecta_4x_wide_9802sparse_100k = deepcopy(tiny_bert_trifecta_500k_params)
+tiny_bert_trifecta_4x_wide_9802sparse_100k["config_kwargs"].update(
+    sparsity=0.9802,
+    **tiny_bert_4x_wide_args,
+)
+
+# ~600k on-params
+tiny_bert_trifecta_4x_wide_9754sparse_100k = deepcopy(tiny_bert_trifecta_600k_params)
+tiny_bert_trifecta_4x_wide_9754sparse_100k["config_kwargs"].update(
+    sparsity=0.9754,
+    **tiny_bert_4x_wide_args,
+)
+
+# ~700k on-params
+tiny_bert_trifecta_4x_wide_9707sparse_100k = deepcopy(tiny_bert_trifecta_700k_params)
+tiny_bert_trifecta_4x_wide_9707sparse_100k["config_kwargs"].update(
+    sparsity=0.9707,
+    **tiny_bert_4x_wide_args,
+)
+
+# ~800k on-params
+tiny_bert_trifecta_4x_wide_966sparse_100k = deepcopy(tiny_bert_trifecta_800k_params)
+tiny_bert_trifecta_4x_wide_966sparse_100k["config_kwargs"].update(
+    sparsity=0.966,
+    **tiny_bert_4x_wide_args,
+)
+
+# ~900k on-params
+tiny_bert_trifecta_4x_wide_9612sparse_100k = deepcopy(tiny_bert_trifecta_900k_params)
+tiny_bert_trifecta_4x_wide_9612sparse_100k["config_kwargs"].update(
+    sparsity=0.9612,
+    **tiny_bert_4x_wide_args,
+)
+
+
+CONFIGS = dict(
+    # 1x wide
+    tiny_bert_trifecta_1x_wide_9318sparse_100k=tiny_bert_trifecta_1x_wide_9318sparse_100k,  # noqa: E501
+    tiny_bert_trifecta_1x_wide_9075sparse_100k=tiny_bert_trifecta_1x_wide_9075sparse_100k,  # noqa: E501
+    tiny_bert_trifecta_1x_wide_8831sparse_100k=tiny_bert_trifecta_1x_wide_8831sparse_100k,  # noqa: E501
+    tiny_bert_trifecta_1x_wide_8588sparse_100k=tiny_bert_trifecta_1x_wide_8588sparse_100k,  # noqa: E501
+    tiny_bert_trifecta_1x_wide_8344sparse_100k=tiny_bert_trifecta_1x_wide_8344sparse_100k,  # noqa: E501
+    tiny_bert_trifecta_1x_wide_81sparse_100k=tiny_bert_trifecta_1x_wide_81sparse_100k,  # noqa: E501
+    tiny_bert_trifecta_1x_wide_7857sparse_100k=tiny_bert_trifecta_1x_wide_7857sparse_100k,  # noqa: E501
+    # 2x wide
+    tiny_bert_trifecta_2x_wide_9711sparse_100k=tiny_bert_trifecta_2x_wide_9711sparse_100k,  # noqa: E501
+    tiny_bert_trifecta_2x_wide_96sparse_100k=tiny_bert_trifecta_2x_wide_96sparse_100k,  # noqa: E501
+    tiny_bert_trifecta_2x_wide_9489sparse_100k=tiny_bert_trifecta_2x_wide_9489sparse_100k,  # noqa: E501
+    tiny_bert_trifecta_2x_wide_9378sparse_100k=tiny_bert_trifecta_2x_wide_9378sparse_100k,  # noqa: E501
+    tiny_bert_trifecta_2x_wide_9267sparse_100k=tiny_bert_trifecta_2x_wide_9267sparse_100k,  # noqa: E501
+    tiny_bert_trifecta_2x_wide_9156sparse_100k=tiny_bert_trifecta_2x_wide_9156sparse_100k,  # noqa: E501
+    tiny_bert_trifecta_2x_wide_9045sparse_100k=tiny_bert_trifecta_2x_wide_9045sparse_100k,  # noqa: E501
+    # 4x wide
+    tiny_bert_trifecta_4x_wide_9896sparse_100k=tiny_bert_trifecta_4x_wide_9896sparse_100k,  # noqa: E501
+    tiny_bert_trifecta_4x_wide_9849sparse_100k=tiny_bert_trifecta_4x_wide_9849sparse_100k,  # noqa: E501
+    tiny_bert_trifecta_4x_wide_9802sparse_100k=tiny_bert_trifecta_4x_wide_9802sparse_100k,  # noqa: E501
+    tiny_bert_trifecta_4x_wide_9754sparse_100k=tiny_bert_trifecta_4x_wide_9754sparse_100k,  # noqa: E501
+    tiny_bert_trifecta_4x_wide_9707sparse_100k=tiny_bert_trifecta_4x_wide_9707sparse_100k,  # noqa: E501
+    tiny_bert_trifecta_4x_wide_966sparse_100k=tiny_bert_trifecta_4x_wide_966sparse_100k,  # noqa: E501
+    tiny_bert_trifecta_4x_wide_9612sparse_100k=tiny_bert_trifecta_4x_wide_9612sparse_100k,  # noqa: E501
+)

--- a/projects/transformers/models/static_sparse_bert.py
+++ b/projects/transformers/models/static_sparse_bert.py
@@ -196,7 +196,11 @@ class FullyStaticSparseBertModel(BertModel):
         linear_modules = filter_modules(encoder, include_modules=[torch.nn.Linear])
         for name, module in linear_modules.items():
             layer_sparsity = get_sparsity("bert.encoder." + name)
-            sparse_module = SparseWeights(module, sparsity=layer_sparsity)
+            sparse_module = SparseWeights(
+                module,
+                sparsity=layer_sparsity,
+                allow_extremes=True  # this allows the model to start fully dense
+            )
             set_module_attr(self.encoder, name, sparse_module.to(device))
 
         # Replace the embedding layers in a similar fashion.

--- a/projects/transformers/trainer_mixins/__init__.py
+++ b/projects/transformers/trainer_mixins/__init__.py
@@ -21,6 +21,7 @@
 
 from .distillation import DistillationTrainerMixin
 from .lr_range_test import LRRangeTestMixin
+from .gmp import GradualMagnitudePruningMixin, ThreeStageLRMixin
 from .one_cycle_lr import OneCycleLRMixin
 from .profiler import TorchProfilerMixin
 from .rigl import RigLMixin

--- a/projects/transformers/trainer_mixins/gmp.py
+++ b/projects/transformers/trainer_mixins/gmp.py
@@ -22,6 +22,7 @@
 import numpy as np
 import wandb
 from torch.nn.parallel import DistributedDataParallel
+from transformers.modeling_utils import unwrap_model
 
 from nupic.research.frameworks.dynamic_sparse import (
     ThreeStageGMPLR,
@@ -161,7 +162,7 @@ class GradualMagnitudePruningMixin:
         Prune every `prune_period` steps during the pruning phase.
         """
 
-        model = get_model(model)  # extract from DistributedDataParallel
+        model = unwrap_model(model)  # extract from DistributedDataParallel
         train_loss = super().training_step(model, inputs)
 
         if not self._setup_done:
@@ -275,14 +276,6 @@ class ThreeStageLRMixin:
             cooldown_steps=self.cooldown_steps,
             cooldown_gamma=self.cooldown_gamma,
         )
-
-
-def get_model(model):
-    """Extract model from DistributedDataParallel."""
-    if isinstance(model, DistributedDataParallel):
-        return model.module
-    else:
-        return model
 
 
 def calc_on_params(sparse_modules):

--- a/projects/transformers/trainer_mixins/gmp.py
+++ b/projects/transformers/trainer_mixins/gmp.py
@@ -21,7 +21,6 @@
 
 import numpy as np
 import wandb
-from torch.nn.parallel import DistributedDataParallel
 from transformers.modeling_utils import unwrap_model
 
 from nupic.research.frameworks.dynamic_sparse import (

--- a/projects/transformers/trainer_mixins/gmp.py
+++ b/projects/transformers/trainer_mixins/gmp.py
@@ -1,0 +1,296 @@
+# ----------------------------------------------------------------------
+# Numenta Platform for Intelligent Computing (NuPIC)
+# Copyright (C) 2021, Numenta, Inc.  Unless you have an agreement
+# with Numenta, Inc., for a separate license for this software code, the
+# following terms and conditions apply:
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# See the GNU Affero Public License for more details.
+#
+# You should have received a copy of the GNU Affero Public License
+# along with this program.  If not, see http://www.gnu.org/licenses.
+#
+# http://numenta.org/licenses/
+# ----------------------------------------------------------------------
+
+import numpy as np
+import wandb
+from torch.nn.parallel import DistributedDataParallel
+
+from nupic.research.frameworks.dynamic_sparse import (
+    ThreeStageGMPLR,
+    global_prune_by_abs_weight,
+)
+from nupic.research.frameworks.pytorch.model_utils import (
+    calc_model_sparsity,
+    count_nonzero_params,
+    filter_modules,
+)
+from nupic.torch.modules.sparse_weights import SparseWeightsBase
+
+
+class GradualMagnitudePruningMixin:
+    """
+    This mixin implements Gradual Magnitude Pruning (GMP) as described in the paper
+        https://arxiv.org/pdf/1710.01878.pdf
+    More accurately, it implements the overview of the method described in the blog post
+        https://neuralmagic.com/blog/pruning-gmp/
+
+    To summarize, GMP consists of three stages, typically performed on a pre-trained
+    network. These include:
+        1) stabilization - allows the network to stabilize before pruning occurs;
+                           in this mixin it's called the warmup phase
+        2) pruning - when pruning occurs; will take the network from being fully dense
+                     to the desired end sparsity; pruning occurs according to a cubic
+                     function where more weights are pruned earlier on and less so later
+        2) fine-tuning - no pruning occurs; at this point the sparse network is
+                         fine-tuned to recover or solidify it's evaluation accuracy;
+                         in this mixin it's called the cooldown stage.
+
+
+    This mixin can be used to prune a pre-trained fully dense model or to perform GMP
+    throughout pre-training to start dense and end sparse. For the former, use the
+    ThreeStageLRMixin or, for the latter, use whatever LR scheduler makes sense, such as
+    the one for OneCycleLR.
+
+    Params to add to 'trainer_mixin_args':
+    :param warmup_steps: how many training iterations in the warm-up phase
+    :param cooldown_steps: how many training iterations in the cool-down phase
+    :param prune_period: how often pruning occurs during the pruning phase
+    :param start_sparsity: this can be given just for the user's clarity of
+                           documentation in their config, but only a starting sparsity
+                           of 0 is allowed; that is, the model must start fully dense
+    :param end_sparsity: the desired ending sparsity of the model; given between 0 and 1
+    :param verbose_gmp_logging: this will additional pruning info to wandb
+
+    Note: The sparsities (start_sparsity and end_sparsity) indicate the overall sparsity
+          of the BERT model. This is in contrast to the sparsity measured among just the
+          sparse modules as done with other experiment configs. Specifically, this mixin
+          is concerned with the sparsity measured via `calc_model_sparsity(model.bert)`.
+
+    Note: This mixin can or cannot be used with ThreeStageLRMixin. If pruning a fully
+          dense, already pre-trained, network, then it makes sense to use the
+          three-stage lr mixin. Otherwise, if GMP pruning during pre-training, it may
+          make more sense to use OneCycleLR.
+
+    Note: Notice how this mixin requires the same params for warmup_steps and
+          cooldown_steps as does ThreeStageLRMixin. This is intentional as the phases
+          are meant to align.
+
+    Note: If using `gradient_accumulation_steps` be careful to define warmup_steps and
+          cooldown_steps as the overall number of training iterations will be increased.
+          For instance, if `gradient_accumulation_steps=2`, the training steps will be
+          doubled and so you'll need to double the number of warmup_steps and
+          cooldown_steps as well.
+    """
+    def __init__(self, *args, **kwargs):
+
+        super().__init__(*args, **kwargs)
+        mixin_args = self.args.trainer_mixin_args
+        assert "warmup_steps" in mixin_args
+        assert "cooldown_steps" in mixin_args
+        assert "prune_period" in mixin_args
+
+        # The start sparsity is inferred from the model.
+        self.end_sparsity = mixin_args.get("end_sparsity", 0.2)
+        self.start_sparsity = mixin_args.get("start_sparsity", 0.2)
+        assert self.start_sparsity == 0, "For now, only starting dense is supported."
+
+        # These dictate when during training pruning will occur and how often.
+        self.warmup_steps = mixin_args["warmup_steps"]
+        self.cooldown_steps = mixin_args["cooldown_steps"]
+        self.prune_period = mixin_args["prune_period"]
+
+        # For verbose logging.
+        self.verbose_gmp_logging = mixin_args.get("verbose_gmp_logging", False)
+
+        # These get initialized in `setup_pruning`
+        self.start_on_params = None
+        self.end_on_params = None
+        self.total_prune_iterations = None
+
+        self._setup_done = False
+        self.max_steps = self.args.max_steps
+        self.prune_iteration = 1
+
+    def setup_pruning(self, args, model):
+        """
+        This infers things about the pruning setup such how many many steps to prune
+        and how many params to start and end with. Note that we're concerned with
+        pruning the parameters within the sparse modules. Thus, any SparseWeightsBase
+        will be involved in global pruning. However, the start and end sparsity will
+        be measured over all parameters within `model.bert`.
+        """
+
+        # Calculate the number of steps in the pruning phase.
+        pruning_steps = self.max_steps - self.warmup_steps - self.cooldown_steps
+        assert pruning_steps > 0
+        assert pruning_steps % self.prune_period == 0
+
+        # Calculate how many times we'll prune.
+        self.total_prune_iterations = pruning_steps / self.prune_period + 1
+
+        # Calculate the params that belong to BERT and how many to start and end with.
+        total_params, _ = count_nonzero_params(model.bert)
+        model_start_params = total_params * (1 - self.start_sparsity)
+        model_end_params = total_params * (1 - self.end_sparsity)
+
+        # Get all the sparse modules in BERT.
+        sparse_modules = filter_modules(model.bert, include_modules=[SparseWeightsBase])
+        self.sparse_modules = list(sparse_modules.values())
+
+        # Calculate the number of params that belong to the non-sparse modules.
+        sparse_module_params = 0
+        for m in self.sparse_modules:
+            sparse_module_params += m.weight.numel()
+        non_sparse_module_params = total_params - sparse_module_params
+
+        # Solve for the number of params that will be on. Specifically for the
+        # sparse module parameters.
+        self.start_on_params = model_start_params - non_sparse_module_params
+        self.end_on_params = model_end_params - non_sparse_module_params
+
+    def training_step(self, model, inputs):
+        """
+        Prune every `prune_period` steps during the pruning phase.
+        """
+
+        model = get_model(model)  # extract from DistributedDataParallel
+        train_loss = super().training_step(model, inputs)
+
+        if not self._setup_done:
+            self.setup_pruning(self.args, model)
+            self._setup_done = True
+
+        # Track the steps by starting at `step=1`
+        train_step = self.state.global_step + 1
+
+        # Return if still in warm-up phase.
+        if train_step < self.warmup_steps:
+            return train_loss
+
+        # Return if in cool-down phase.
+        if train_step > self.max_steps - self.cooldown_steps:
+            return train_loss
+
+        # Return if step within pruning phase isn't divisible by pruning period.
+        if not (train_step - self.warmup_steps) % self.prune_period == 0:
+            return train_loss
+
+        # Fraction of the way through the pruning phase.
+        fraction_through_pruning = self.prune_iteration / self.total_prune_iterations
+
+        # Target number of on-params at time t.
+        lambda_t = np.power(1 - fraction_through_pruning, 3)  # varies from 0 to 1
+        target_on_params = self.end_on_params + (
+            self.start_on_params - self.end_on_params) * lambda_t
+
+        # Actual number of on-params at time t.
+        current_on_params = calc_on_params(self.sparse_modules)
+        remove_params = current_on_params - int(target_on_params)
+
+        # Prune the specified number of params.
+        actual_removed = global_prune_by_abs_weight(
+            self.sparse_modules,
+            num_remove=remove_params
+        )
+
+        # Log how much was pruned and resulting sparsity.
+        if self.verbose_gmp_logging:
+
+            bert_sparsity = calc_model_sparsity(model.bert)
+            logs = dict({
+                "gmp/target_pruned_params": remove_params,
+                "gmp/actual_pruned_params": actual_removed,
+                "gmp/post_prune_bert_sparsity": bert_sparsity,
+            })
+
+        if wandb.run is not None:
+            wandb.log(logs, commit=False)
+            self.control.should_log = True
+
+        self.prune_iteration += 1
+        return train_loss
+
+
+class ThreeStageLRMixin:
+    """
+    This mixin overrides the lr scheduler to use the ThreeStageGMPLR which consists of
+    three stages:
+        1) warmup - linearly ramp up from 0 to max_lr
+        2) pruning - maintain a constant max_lr
+        3) cooldown - decay the learning rate twice (like a StepLR)
+
+    This LR is used for GMP pruning on already pre-trained fully dense network. In
+    contrast, one would most likely not want to use this mixin for GMP style pruning
+    during pre-training. Instead, it may be better to use OneCycle LR to achieve a
+    better eval-loss.
+
+    Params to add to 'trainer_mixin_args':
+    :param warmup_steps: number of warmup steps (i.e. the the stabilization phase)
+    :param cooldown_steps: number of cooldown steps
+    :param max_lr: the lr held constant throughout the pruning phase
+    :param cooldown_gamma: (optional) how much to decay the lr during the cooldown phase
+                           e.g. lr <- lr * cooldown_gamma; used to decay the lr twice;
+                           defaults to 0.1
+
+    Note: This mixin can't be used with the OneCycleLRMixin as they both override
+          `create_scheduler`.
+
+    Note: Notice how this mixin requires the same params for warmup_steps and
+          cooldown_steps as does GradualMagnitudePruningMixin. This is intentional as
+          the phases are meant to align
+    """
+    def __init__(self, *args, **kwargs):
+
+        super().__init__(*args, **kwargs)
+        mixin_args = self.args.trainer_mixin_args
+        assert "warmup_steps" in mixin_args
+        assert "cooldown_steps" in mixin_args
+        assert "max_lr" in mixin_args
+
+        self.max_steps = self.args.max_steps
+        self.warmup_steps = mixin_args["warmup_steps"]
+        self.cooldown_steps = mixin_args["cooldown_steps"]
+        self.max_lr = mixin_args["max_lr"]
+        self.cooldown_gamma = mixin_args.get("cooldown_gamma", 0.1)
+
+        # The LambdaLR (parent class of ThreeStageGMPLR) will multiply this base lr of
+        # 1 times the one at the given step.
+        kwargs["args"].learning_rate = 1
+
+    def create_scheduler(self, num_training_steps: int):
+
+        self.lr_scheduler = ThreeStageGMPLR(
+            self.optimizer,
+            max_lr=self.max_lr,
+            total_steps=self.max_steps,
+            warmup_steps=self.warmup_steps,
+            cooldown_steps=self.cooldown_steps,
+            cooldown_gamma=self.cooldown_gamma,
+        )
+
+
+def get_model(model):
+    """Extract model from DistributedDataParallel."""
+    if isinstance(model, DistributedDataParallel):
+        return model.module
+    else:
+        return model
+
+
+def calc_on_params(sparse_modules):
+    """
+    Calculate the total number of on-params throughout the sparse modules.
+    """
+    on_params = 0
+    for m in sparse_modules:
+        on_mask = ~m.zero_mask.bool()
+        on_params += on_mask.sum().item()
+    return on_params

--- a/projects/transformers/trainer_mixins/rigl.py
+++ b/projects/transformers/trainer_mixins/rigl.py
@@ -169,7 +169,7 @@ def inputs_to_device(inputs, device):
 def calc_cumulative_sparsity(sparse_modules):
     """
     Calculate the sparsities across a list of sparse modules. Both the weight sparsity
-    and the zero mask sparsity is calculated.
+    and the zero mask sparsity are calculated.
     """
     total_off = 0
     total_zero = 0


### PR DESCRIPTION
This PR is for GMP pruning mixins, configs, and related functionality. It includes the following changes:
- Enable fully dense but sparsifiable models at initialization 
- Updated wide tiny-bert experiments
- Add script to create a prunable checkpoint (one with SparseWeight modules) of a densely trained model.
- LR schedule for GMP pruning on a fully dense model.
- The `RezeroWeights` callback is now configurable to log every `log_steps`  instead of after every training step.
- New mixins: `GradualMagnitudePruningMixin` and  `ThreeStageLRMixin`

The last two mixins can be used together or independently depending on the use case. One may apply GMP pruning during pre-training or afterwards. If the latter, `ThreeStageLRMixin` should be used to enable lr phases of stabilization, pruning, and fine-tuning. Otherwise, a OneCycle LR or other schedule may be used for GMP throughout pre-training. As of now, there are experiments that try out both methods and it's an open question as to which leads to the best eval-loss. 