### PR TITLE
Configs for Small BERT Models

### DIFF
--- a/projects/transformers/calculate_sparsity_param.py
+++ b/projects/transformers/calculate_sparsity_param.py
@@ -97,6 +97,7 @@ def calculate_sparsity_param(
     print(f"   sparsity_desired: {sparsity_desired}")
     print(f"   parameters_desired: {parameters_desired}")
     print(f"   sparsifiable_params: {sparsifiable_params}")
+    print(f"   total_params: {total_params}")
     print(f"   target_sparsity: {target_sparsity} (set your sparsity to this)")
     print()
 

--- a/projects/transformers/experiments/bertitos.py
+++ b/projects/transformers/experiments/bertitos.py
@@ -201,6 +201,17 @@ small_bert_50k.update(
 small_bert_100k_fp16 = dict(**small_bert_100k, fp16=True)
 small_bert_50k_fp16 = dict(**small_bert_50k, fp16=True)
 
+
+small_bert_large_dataset_100k = deepcopy(small_bert_100k)
+small_bert_large_dataset_100k.update(
+    max_steps=100000,
+    max_seq_length=128,
+    dataset_name=("wikipedia", "bookcorpus"),
+    dataset_config_name=("20200501.en", None),
+    tokenized_data_cache_dir="/mnt/datasets/huggingface/preprocessed-datasets/text",  # noqa: E501
+)
+
+
 # samples/second = 6.686 (on one p3.2xlarge)
 mini_bert_100k = deepcopy(bert_100k)
 mini_bert_100k.update(
@@ -276,4 +287,5 @@ CONFIGS = dict(
 
     small_bert_100k_fp16=small_bert_100k_fp16,
     small_bert_50k_fp16=small_bert_50k_fp16,
+    small_bert_large_dataset_100k=small_bert_large_dataset_100k,
 )

--- a/projects/transformers/experiments/trifecta.py
+++ b/projects/transformers/experiments/trifecta.py
@@ -20,6 +20,7 @@
 # ----------------------------------------------------------------------
 from copy import deepcopy
 
+from ray import tune
 from transformers import Trainer
 
 from callbacks import RezeroWeightsCallback, TrackEvalMetrics
@@ -59,6 +60,25 @@ class KDLRRangeTestTrainer(LRRangeTestMixin,
                            Trainer):
     pass
 
+
+lr_range_test_args = dict(
+    max_steps=100,
+    trainer_class=KDLRRangeTestTrainer,
+
+    trainer_mixin_args=dict(
+        # LR Range Test
+        min_lr=0.0001,
+        max_lr=0.05,
+        test_mode="linear",
+
+        # KD
+        teacher_model_names_or_paths=[
+            "/mnt/efs/results/pretrained-models/transformers-local/bert_1mi",
+        ],
+    ),
+    overwrite_output_dir=True,
+    do_eval=True,
+)
 
 # ---------
 # Tiny BERT
@@ -148,6 +168,16 @@ tiny_bert_trifecta_lr_range_test.update(
 # Small BERT
 # ---------
 
+
+# Dataset used for BERT-Base but with max_seq_length made smaller.
+small_bert_dataset_args = dict(
+    max_seq_length=128,
+    dataset_name=("wikipedia", "bookcorpus"),
+    dataset_config_name=("20200501.en", None),
+    tokenized_data_cache_dir="/mnt/datasets/huggingface/preprocessed-datasets/text",  # noqa: E501
+)
+
+
 # This combines KD + RigL + OneCycle LR on Small BERT.
 # This gets a NaN eval-loss for max_lr=0.006
 small_bert_trifecta_300k = deepcopy(small_bert_sparse_100k)
@@ -192,34 +222,177 @@ small_bert_trifecta_300k.update(
 )
 
 
+# Small BERT 80% Sparse Trifecta Model
 small_bert_trifecta_100k = deepcopy(small_bert_trifecta_300k)
 small_bert_trifecta_100k.update(
     max_steps=100000,
+    **small_bert_dataset_args,
+)
+small_bert_trifecta_100k["trainer_mixin_args"].update(
+    # The LR Range test suggests to use max_lr=0.0076
+    # But using a small one as `small_bert_trifecta_300k`
+    # resulted in NaN loss with a similar sparsity and lr.
+    max_lr=0.005,
+)
+small_bert_trifecta_100k["config_kwargs"].update(
+    # This will have 5,481,940 params, actual sparsity will be 80.08%
+    sparsity=0.8027,
 )
 
 
-# LR Range Test for training with KD and OneCycle LR. It's assumed the observed max_lr
-# will carry over to training with RigL.
-small_bert_trifecta_lr_range_test = deepcopy(small_bert_trifecta_300k)
+# Search for the best max_lr parameters for tiny BERT trained with KD and OneCycle LR
+def max_lr_hp_space(trial):
+    return dict(
+        trainer_mixin_args=dict(
+            max_lr=tune.grid_search([
+                0.004, 0.0045, 0.005, 0.0055, 0.006, 0.0065, 0.007, 0.0075, 0.008,
+                0.0085, 0.009,
+            ]),
+        )
+    )
+
+
+small_bert_trifecta_100k_maxlr_0005 = deepcopy(small_bert_trifecta_100k)
+small_bert_trifecta_100k_maxlr_0005["trainer_mixin_args"].update(
+    max_lr=0.0005,
+)
+small_bert_trifecta_100k_maxlr_001 = deepcopy(small_bert_trifecta_100k)
+small_bert_trifecta_100k_maxlr_001["trainer_mixin_args"].update(
+    max_lr=0.001,
+)
+small_bert_trifecta_100k_maxlr_0015 = deepcopy(small_bert_trifecta_100k)
+small_bert_trifecta_100k_maxlr_0015["trainer_mixin_args"].update(
+    max_lr=0.0015,
+)
+small_bert_trifecta_100k_maxlr_002 = deepcopy(small_bert_trifecta_100k)
+small_bert_trifecta_100k_maxlr_002["trainer_mixin_args"].update(
+    max_lr=0.002,
+)
+small_bert_trifecta_100k_maxlr_0025 = deepcopy(small_bert_trifecta_100k)
+small_bert_trifecta_100k_maxlr_0025["trainer_mixin_args"].update(
+    max_lr=0.0025,
+)
+small_bert_trifecta_100k_maxlr_003 = deepcopy(small_bert_trifecta_100k)
+small_bert_trifecta_100k_maxlr_003["trainer_mixin_args"].update(
+    max_lr=0.003,
+)
+small_bert_trifecta_100k_maxlr_0035 = deepcopy(small_bert_trifecta_100k)
+small_bert_trifecta_100k_maxlr_0035["trainer_mixin_args"].update(
+    max_lr=0.0035,
+)
+
+# LR Range test for `small_bert_trifecta_100k`
+# Results here: https://wandb.ai/numenta/huggingface/runs/3ocz9yac
+small_bert_trifecta_lr_range_test = deepcopy(small_bert_trifecta_100k)
 small_bert_trifecta_lr_range_test.update(
-    max_steps=100,
-    trainer_class=KDLRRangeTestTrainer,
-
-    trainer_mixin_args=dict(
-        # LR Range Test
-        min_lr=0.0001,
-        max_lr=0.05,
-        test_mode="linear",
-
-        # KD
-        teacher_model_names_or_paths=[
-            "/mnt/efs/results/pretrained-models/transformers-local/bert_1mi",
-        ],
-    ),
-    overwrite_output_dir=True,
-    do_eval=True,
+    **lr_range_test_args
 )
 
+
+# Small BERT 85% Sparse Trifecta Model
+small_bert_trifecta_85_100k = deepcopy(small_bert_trifecta_100k)
+small_bert_trifecta_85_100k["trainer_mixin_args"].update(
+    # The LR Range test suggests to use max_lr=0.0086
+    # As with `small_bert_trifecta_100k`, we'll use a slightly
+    # smaller lr than the test suggests.
+    max_lr=0.006,
+)
+small_bert_trifecta_85_100k.update(
+    max_steps=100000,
+)
+small_bert_trifecta_85_100k["config_kwargs"].update(
+    # This will have 4,128,460 params, actual sparsity will be 85.13%
+    sparsity=0.8529,
+)
+
+
+# LR Range test for `small_bert_trifecta_85_100k`
+# Results here: https://wandb.ai/numenta/huggingface/runs/1pfur4bb
+small_bert_trifecta_85_lr_range_test = deepcopy(small_bert_trifecta_85_100k)
+small_bert_trifecta_85_lr_range_test.update(
+    **lr_range_test_args
+)
+
+
+# Small BERT 90% Sparse Trifecta Model
+small_bert_trifecta_90_100k = deepcopy(small_bert_trifecta_100k)
+small_bert_trifecta_90_100k["trainer_mixin_args"].update(
+    # The LR Range test suggests to use max_lr=0.01
+    # As with `small_bert_trifecta_100k`, we'll use a slightly
+    # smaller lr than the test suggests.
+    max_lr=0.007,
+)
+small_bert_trifecta_90_100k.update(
+    max_steps=100000,
+)
+small_bert_trifecta_90_100k["config_kwargs"].update(
+    # This will have 2,745,672 params, actual sparsity will be 90.02%
+    sparsity=0.90309,
+)
+
+
+# LR Range test for `small_bert_trifecta_90_100k`
+# Results here: https://wandb.ai/numenta/huggingface/runs/1m9bcglt
+small_bert_trifecta_90_lr_range_test = deepcopy(small_bert_trifecta_90_100k)
+small_bert_trifecta_90_lr_range_test.update(
+    **lr_range_test_args
+)
+
+
+# Small BERT 2x Wide Sparse Trifecta Model
+small_bert_trifecta_2x_100k = deepcopy(small_bert_trifecta_100k)
+small_bert_trifecta_2x_100k["trainer_mixin_args"].update(
+    # The LR Range test suggests to use max_lr=0.01
+    # As with `small_bert_trifecta_100k`, we'll use a slightly
+    # smaller lr than the test suggests.
+    max_lr=0.006,
+)
+small_bert_trifecta_2x_100k.update(
+    max_steps=100000,
+)
+small_bert_trifecta_2x_100k["config_kwargs"].update(
+    # This will have 4,057,928 params, actual sparsity will be 94.94%
+    # Note that the 85% model has 4,128,460 which this tries to mimic.
+    hidden_size=512 * 2,
+    intermediate_size=2048 * 2,
+    sparsity=0.9507,
+)
+
+
+# LR Range test for `small_bert_trifecta_90_100k`
+# Results here: https://wandb.ai/numenta/huggingface/runs/18luah0e
+small_bert_trifecta_2x_lr_range_test = deepcopy(small_bert_trifecta_2x_100k)
+small_bert_trifecta_2x_lr_range_test.update(
+    **lr_range_test_args
+)
+
+
+# Small BERT 4x Wide Sparse Trifecta Model
+small_bert_trifecta_4x_100k = deepcopy(small_bert_trifecta_100k)
+small_bert_trifecta_4x_100k["trainer_mixin_args"].update(
+    # The LR Range test suggests to use max_lr=0.013
+    # As with `small_bert_trifecta_100k`, we'll use a slightly
+    # smaller lr than the test suggests.
+    max_lr=0.008,
+)
+small_bert_trifecta_4x_100k.update(
+    max_steps=100000,
+)
+small_bert_trifecta_4x_100k["config_kwargs"].update(
+    # This will have 2,686,988 params, actual sparsity will be 98.97%
+    # Note that the 90% model has 2,745,672 which this tries to mimic.
+    hidden_size=512 * 4,
+    intermediate_size=2048 * 4,
+    sparsity=0.9909,
+)
+
+
+# LR Range test for `small_bert_trifecta_90_100k`
+# Results here: https://wandb.ai/numenta/huggingface/runs/2kwe9dic
+small_bert_trifecta_4x_lr_range_test = deepcopy(small_bert_trifecta_4x_100k)
+small_bert_trifecta_4x_lr_range_test.update(
+    **lr_range_test_args
+)
 
 # ---------
 # BERT Base
@@ -497,9 +670,31 @@ CONFIGS = dict(
     finetuning_tiny_bert_trifecta_100k=finetuning_tiny_bert_trifecta_100k,
 
     # Small BERT
+    #   80% sparse
     small_bert_trifecta_100k=small_bert_trifecta_100k,
     small_bert_trifecta_300k=small_bert_trifecta_300k,
     small_bert_trifecta_lr_range_test=small_bert_trifecta_lr_range_test,
+
+    small_bert_trifecta_100k_maxlr_0005=small_bert_trifecta_100k_maxlr_0005,
+    small_bert_trifecta_100k_maxlr_001=small_bert_trifecta_100k_maxlr_001,
+    small_bert_trifecta_100k_maxlr_0015=small_bert_trifecta_100k_maxlr_0015,
+    small_bert_trifecta_100k_maxlr_002=small_bert_trifecta_100k_maxlr_002,
+    small_bert_trifecta_100k_maxlr_0025=small_bert_trifecta_100k_maxlr_0025,
+    small_bert_trifecta_100k_maxlr_003=small_bert_trifecta_100k_maxlr_003,
+    small_bert_trifecta_100k_maxlr_0035=small_bert_trifecta_100k_maxlr_0035,
+
+    #   85% sparse
+    small_bert_trifecta_85_100k=small_bert_trifecta_85_100k,
+    small_bert_trifecta_85_lr_range_test=small_bert_trifecta_85_lr_range_test,
+    #   90% sparse
+    small_bert_trifecta_90_100k=small_bert_trifecta_90_100k,
+    small_bert_trifecta_90_lr_range_test=small_bert_trifecta_90_lr_range_test,
+    #   2x wide
+    small_bert_trifecta_2x_100k=small_bert_trifecta_2x_100k,
+    small_bert_trifecta_2x_lr_range_test=small_bert_trifecta_2x_lr_range_test,
+    #   4x wide
+    small_bert_trifecta_4x_100k=small_bert_trifecta_4x_100k,
+    small_bert_trifecta_4x_lr_range_test=small_bert_trifecta_4x_lr_range_test,
 
     # BERT Base
     #   80% sparse


### PR DESCRIPTION
These are the configs used to run the 80, 85, 90, 2x, and 4x models