### PR TITLE
Add config for GMP on a Pre-Trained BERT Base

### DIFF
--- a/projects/transformers/experiments/gmp_bert.py
+++ b/projects/transformers/experiments/gmp_bert.py
@@ -243,7 +243,7 @@ bert_1mi_pretrained_gmp_52k.update(
     max_steps=2000 + 30000 + 20000,  # longer may be better
     model_type="fully_static_sparse_bert",
     model_name_or_path=bert_1mi_pretrained,
-    tokenized_data_cache_dir="/mnt/datasets/huggingface/preprocessed-datasets/text",  
+    tokenized_data_cache_dir="/mnt/datasets/huggingface/preprocessed-datasets/text",
     overwrite_output_dir=True,
     trainer_callbacks=[
         RezeroWeightsCallback(),

--- a/projects/transformers/experiments/gmp_bert.py
+++ b/projects/transformers/experiments/gmp_bert.py
@@ -32,6 +32,7 @@ from trainer_mixins import (
     ThreeStageLRMixin,
 )
 
+from .bert_replication import bert_1mi
 from .bertitos import tiny_bert_100k, tiny_bert_debug
 from .trifecta import KDLRRangeTestTrainer
 
@@ -222,7 +223,52 @@ tiny_bert_gmp_100k_maxlr_05["trainer_mixin_args"].update(
 )
 
 
+# ---------
+# BERT Base
+# ---------
+
+
+bert_1mi_pretrained = "/mnt/efs/results/pretrained-models/transformers-local/bert_1mi_prunable"  # noqa E501
+
+
+# The max_lr for this run is chosen based off this lr-range test
+# https://wandb.ai/nupic-research/huggingface/runs/26eavts5 This is for an untrained
+# BERT Base, while the config below starts with a pre-trained BERT Base. Nonetheless,
+# previous experiments suggest this is a good starting point. Thus, we use a max_lr
+# slightly lower than what the test suggests.
+bert_1mi_pretrained_gmp_52k = deepcopy(bert_1mi)
+bert_1mi_pretrained_gmp_52k.update(
+    fp16=True,
+    # steps: 2000 warmup, 30000 pruning (every 1000), 20000 cooldown
+    max_steps=2000 + 30000 + 20000,  # longer may be better
+    model_type="fully_static_sparse_bert",
+    model_name_or_path=bert_1mi_pretrained,
+    tokenized_data_cache_dir="/mnt/datasets/huggingface/preprocessed-datasets/text",  
+    overwrite_output_dir=True,
+    trainer_callbacks=[
+        RezeroWeightsCallback(),
+        PlotDensitiesCallback(plot_freq=10000),
+    ],
+    trainer_class=GMPPretrainedTrainer,
+    trainer_mixin_args=dict(
+        # GMP
+        start_sparsity=0,
+        end_sparsity=0.8,
+        warmup_steps=2000,
+        cooldown_steps=20000,
+        prune_period=1000,
+        max_lr=0.0003,
+        verbose_gmp_logging=True,
+        # KD
+        teacher_model_names_or_paths=[
+            "/mnt/efs/results/pretrained-models/transformers-local/bert_1mi",
+        ],
+    ),
+)
+
+
 CONFIGS = dict(
+    # Tiny BERT
     tiny_bert_gmp_debug=tiny_bert_gmp_debug,
     tiny_bert_pretrained_gmp_lr_range_test=tiny_bert_pretrained_gmp_lr_range_test,
     tiny_bert_pretrained_gmp_52k=tiny_bert_pretrained_gmp_52k,
@@ -232,4 +278,7 @@ CONFIGS = dict(
     tiny_bert_gmp_100k=tiny_bert_gmp_100k,
     tiny_bert_gmp_100k_maxlr_01=tiny_bert_gmp_100k_maxlr_01,
     tiny_bert_gmp_100k_maxlr_05=tiny_bert_gmp_100k_maxlr_05,
+
+    # BERT Base
+    bert_1mi_pretrained_gmp_52k=bert_1mi_pretrained_gmp_52k,
 )

--- a/projects/transformers/experiments/trifecta.py
+++ b/projects/transformers/experiments/trifecta.py
@@ -20,7 +20,6 @@
 # ----------------------------------------------------------------------
 from copy import deepcopy
 
-from ray import tune
 from transformers import Trainer
 
 from callbacks import RezeroWeightsCallback, TrackEvalMetrics
@@ -239,47 +238,6 @@ small_bert_trifecta_100k["config_kwargs"].update(
     sparsity=0.8027,
 )
 
-
-# Search for the best max_lr parameters for tiny BERT trained with KD and OneCycle LR
-def max_lr_hp_space(trial):
-    return dict(
-        trainer_mixin_args=dict(
-            max_lr=tune.grid_search([
-                0.004, 0.0045, 0.005, 0.0055, 0.006, 0.0065, 0.007, 0.0075, 0.008,
-                0.0085, 0.009,
-            ]),
-        )
-    )
-
-
-small_bert_trifecta_100k_maxlr_0005 = deepcopy(small_bert_trifecta_100k)
-small_bert_trifecta_100k_maxlr_0005["trainer_mixin_args"].update(
-    max_lr=0.0005,
-)
-small_bert_trifecta_100k_maxlr_001 = deepcopy(small_bert_trifecta_100k)
-small_bert_trifecta_100k_maxlr_001["trainer_mixin_args"].update(
-    max_lr=0.001,
-)
-small_bert_trifecta_100k_maxlr_0015 = deepcopy(small_bert_trifecta_100k)
-small_bert_trifecta_100k_maxlr_0015["trainer_mixin_args"].update(
-    max_lr=0.0015,
-)
-small_bert_trifecta_100k_maxlr_002 = deepcopy(small_bert_trifecta_100k)
-small_bert_trifecta_100k_maxlr_002["trainer_mixin_args"].update(
-    max_lr=0.002,
-)
-small_bert_trifecta_100k_maxlr_0025 = deepcopy(small_bert_trifecta_100k)
-small_bert_trifecta_100k_maxlr_0025["trainer_mixin_args"].update(
-    max_lr=0.0025,
-)
-small_bert_trifecta_100k_maxlr_003 = deepcopy(small_bert_trifecta_100k)
-small_bert_trifecta_100k_maxlr_003["trainer_mixin_args"].update(
-    max_lr=0.003,
-)
-small_bert_trifecta_100k_maxlr_0035 = deepcopy(small_bert_trifecta_100k)
-small_bert_trifecta_100k_maxlr_0035["trainer_mixin_args"].update(
-    max_lr=0.0035,
-)
 
 # LR Range test for `small_bert_trifecta_100k`
 # Results here: https://wandb.ai/numenta/huggingface/runs/3ocz9yac
@@ -674,15 +632,6 @@ CONFIGS = dict(
     small_bert_trifecta_100k=small_bert_trifecta_100k,
     small_bert_trifecta_300k=small_bert_trifecta_300k,
     small_bert_trifecta_lr_range_test=small_bert_trifecta_lr_range_test,
-
-    small_bert_trifecta_100k_maxlr_0005=small_bert_trifecta_100k_maxlr_0005,
-    small_bert_trifecta_100k_maxlr_001=small_bert_trifecta_100k_maxlr_001,
-    small_bert_trifecta_100k_maxlr_0015=small_bert_trifecta_100k_maxlr_0015,
-    small_bert_trifecta_100k_maxlr_002=small_bert_trifecta_100k_maxlr_002,
-    small_bert_trifecta_100k_maxlr_0025=small_bert_trifecta_100k_maxlr_0025,
-    small_bert_trifecta_100k_maxlr_003=small_bert_trifecta_100k_maxlr_003,
-    small_bert_trifecta_100k_maxlr_0035=small_bert_trifecta_100k_maxlr_0035,
-
     #   85% sparse
     small_bert_trifecta_85_100k=small_bert_trifecta_85_100k,
     small_bert_trifecta_85_lr_range_test=small_bert_trifecta_85_lr_range_test,

--- a/projects/transformers/requirements.txt
+++ b/projects/transformers/requirements.txt
@@ -24,7 +24,7 @@
 
 datasets>=1.6.1,<1.7.0
 torch>=1.8.1,<1.9.0
-wandb>=0.10.27
+wandb>=0.10.27,<0.11.0 # this can be updated in a future version of transformers, for now 0.11.1, seems to not log properly with the transformers repo
 cloudpickle>=1.6.0
 pickle5>=0.0.11
 ray==1.4.0  # required to use Ray Tune


### PR DESCRIPTION
This PR adds a new config for GMP on the bert_1mi checkpoint. There are some minor updates and cleaning to other configs as well. 