### PR TITLE
Fix ray local-mode

### DIFF
--- a/nupic/research/frameworks/vernon/run_with_raytune.py
+++ b/nupic/research/frameworks/vernon/run_with_raytune.py
@@ -44,8 +44,12 @@ def run(config):
         return run_single_instance(config)
 
     # Connect to ray
-    address = os.environ.get("REDIS_ADDRESS", config.get("redis_address"))
-    ray.init(address=address, local_mode=config.get("local_mode", False))
+    local_mode = config.get("local_mode", False)
+    if local_mode:
+        address = None
+    else:
+        address = os.environ.get("REDIS_ADDRESS", config.get("redis_address"))
+    ray.init(address=address, local_mode=local_mode)
 
     # Register serializer and deserializer - needed when logging arrays and tensors.
     if not config.get("local_mode", False):


### PR DESCRIPTION
Fix option to call `ray` in `local-mode` using the command line arguments

```
python run.py -e some_experiment --local-mode
```