### PR TITLE
MLP on permutedMNIST

### DIFF
--- a/nupic/research/frameworks/pytorch/models/__init__.py
+++ b/nupic/research/frameworks/pytorch/models/__init__.py
@@ -18,6 +18,7 @@
 #  http://numenta.org/licenses/
 #
 
+from .common_models import *
 from .le_sparse_net import LeSparseNet
 from .mobilenetv1 import (
     MobileNetV1,
@@ -28,4 +29,3 @@ from .mobilenetv1 import (
 from .not_so_densenet import DenseNetCIFAR, NoSoDenseNetCIFAR
 from .resnet_models import ResNet, resnet9
 from .vgg_sparse_net import VGGSparseNet, vgg19_dense_net, vgg19_sparse_net
-from .common_models import StandardMLP, OMLNetwork, OmniglotCNN, MetaContinualLearningMLP

--- a/nupic/research/frameworks/pytorch/models/common_models.py
+++ b/nupic/research/frameworks/pytorch/models/common_models.py
@@ -25,7 +25,7 @@ from nupic.research.frameworks.pytorch.models.le_sparse_net import (
     add_sparse_linear_layer,
 )
 
-_all__ = [
+__all__ = [
     "StandardMLP",
     "ModifiedInitStandardMLP",
     "SparseMLP",

--- a/nupic/research/frameworks/pytorch/models/common_models.py
+++ b/nupic/research/frameworks/pytorch/models/common_models.py
@@ -67,8 +67,8 @@ class ModifiedInitStandardMLP(StandardMLP):
     +/- 1/sqrt(I x W x F)
 
     where I is the density of the input for a given layer, W is always 1.0 (since MLPs
-    have dense weights), and F is the number of inputs received. This only differs from
-    Kaiming initialization by incorporating input_density and weight_density. Biases
+    have dense weights), and F is fan-in. This only differs from Kaiming Uniform
+    initialization by incorporating input density (I) and weight density (W). Biases
     are unaffected.
     """
 

--- a/nupic/research/frameworks/pytorch/models/common_models.py
+++ b/nupic/research/frameworks/pytorch/models/common_models.py
@@ -25,6 +25,15 @@ from nupic.research.frameworks.pytorch.models.le_sparse_net import (
     add_sparse_linear_layer,
 )
 
+_all__ = [
+    "StandardMLP",
+    "ModifiedInitStandardMLP",
+    "SparseMLP",
+    "OmniglotCNN",
+    "OMLNetwork",
+    "MetaContinualLearningMLP"
+]
+
 
 class StandardMLP(nn.Module):
 
@@ -48,6 +57,40 @@ class StandardMLP(nn.Module):
 
     def forward(self, x):
         return self.classifier(x)
+
+
+class ModifiedInitStandardMLP(StandardMLP):
+    """
+    A standard MLP which differs only in feed-forward weight initialization: the bounds
+    of the Uniform distribution used to initialization weights are
+
+    +/- 1/sqrt(I x W x F)
+
+    where I is the density of the input for a given layer, W is always 1.0 (since MLPs
+    have dense weights), and F is the number of inputs received. This only differs from
+    Kaiming initialization by incorporating input_density and weight_density. Biases
+    are unaffected.
+    """
+
+    def __init__(self, input_size, num_classes, hidden_sizes):
+        super().__init__(input_size, num_classes, hidden_sizes)
+
+        # Modified Kaiming weight initialization which considers 1) the density of
+        # the input vector and 2) the weight density in addition to the fan-in
+
+        weight_density = 1.0
+        input_flag = False
+        for layer in self.classifier:
+            if isinstance(layer, nn.Linear):
+
+                # Assume input is fully dense, but hidden layer activations are only
+                # 50% dense due to ReLU
+                input_density = 1.0 if not input_flag else 0.5
+                input_flag = True
+
+                _, fan_in = layer.weight.size()
+                bound = 1.0 / np.sqrt(input_density * weight_density * fan_in)
+                nn.init.uniform_(layer.weight, -bound, bound)
 
 
 class SparseMLP(nn.Sequential):

--- a/projects/dendrites/permutedMNIST/experiments/__init__.py
+++ b/projects/dendrites/permutedMNIST/experiments/__init__.py
@@ -25,6 +25,7 @@ from .batch_mnist import CONFIGS as BATCH_MNIST
 from .centroid import CONFIGS as CENTROID
 from .gating import CONFIGS as GATING
 from .hyperparameter_search import CONFIGS as HYPERPARAMETERSEARCH
+from .mlp import CONFIGS as MLP
 from .no_dendrites import CONFIGS as NO_DENDRITES
 from .profiler import CONFIGS as PROFILER
 from .si_centroid import CONFIGS as SI_CENTROID
@@ -44,6 +45,7 @@ CONFIGS.update(BATCH_MNIST)
 CONFIGS.update(CENTROID)
 CONFIGS.update(GATING)
 CONFIGS.update(HYPERPARAMETERSEARCH)
+CONFIGS.update(MLP)
 CONFIGS.update(NO_DENDRITES)
 CONFIGS.update(PROFILER)
 CONFIGS.update(SI_CENTROID)

--- a/projects/dendrites/permutedMNIST/experiments/mlp.py
+++ b/projects/dendrites/permutedMNIST/experiments/mlp.py
@@ -37,11 +37,6 @@ from nupic.research.frameworks.dendrites.dendrite_cl_experiment import (
 from nupic.research.frameworks.pytorch.datasets import PermutedMNIST
 from nupic.research.frameworks.pytorch.models import ModifiedInitStandardMLP
 from nupic.research.frameworks.vernon import mixins
-from nupic.torch.functions import kwinners
-
-
-def kwinners_wrapper(y):
-    return kwinners(y, duty_cycles=None, k=102, boost_strength=0)
 
 
 class MLPExperiment(mixins.PermutedMNISTTaskIndices,
@@ -85,8 +80,11 @@ THREE_LAYER_MLP_10.update(
     num_tasks=10,
     num_classes=10 * 10,
 
+    # The following number of training epochs and learning rate were chosen based on a
+    # hyperparameter search that maximized final test accuracy across all tasks for the
+    # MLP
     epochs=5,
-    optimizer_args=dict(lr=3e-6)
+    optimizer_args=dict(lr=3e-6) 
 )
 
 
@@ -96,6 +94,9 @@ THREE_LAYER_MLP_100.update(
     num_tasks=100,
     num_classes=10 * 100,
 
+    # The following number of training epochs and learning rate were chosen based on a
+    # hyperparameter search that maximized final test accuracy across all tasks for the
+    # MLP
     epochs=3,
     optimizer_args=dict(lr=1e-6)
 )
@@ -113,6 +114,9 @@ TEN_LAYER_MLP_10.update(
     num_tasks=10,
     num_classes=10 * 10,
 
+    # The following number of training epochs and learning rate were chosen based on a
+    # hyperparameter search that maximized final test accuracy across all tasks for the
+    # MLP
     epochs=3,
     optimizer_args=dict(lr=3e-6)
 )
@@ -124,6 +128,9 @@ TEN_LAYER_MLP_100.update(
     num_tasks=100,
     num_classes=10 * 100,
 
+    # The following number of training epochs and learning rate were chosen based on a
+    # hyperparameter search that maximized final test accuracy across all tasks for the
+    # MLP
     epochs=3,
     optimizer_args=dict(lr=3e-7)
 )

--- a/projects/dendrites/permutedMNIST/experiments/mlp.py
+++ b/projects/dendrites/permutedMNIST/experiments/mlp.py
@@ -84,7 +84,7 @@ THREE_LAYER_MLP_10.update(
     # hyperparameter search that maximized final test accuracy across all tasks for the
     # MLP
     epochs=5,
-    optimizer_args=dict(lr=3e-6) 
+    optimizer_args=dict(lr=3e-6)
 )
 
 

--- a/projects/dendrites/permutedMNIST/experiments/mlp.py
+++ b/projects/dendrites/permutedMNIST/experiments/mlp.py
@@ -1,0 +1,164 @@
+# ----------------------------------------------------------------------
+# Numenta Platform for Intelligent Computing (NuPIC)
+# Copyright (C) 2021, Numenta, Inc.  Unless you have an agreement
+# with Numenta, Inc., for a separate license for this software code, the
+# following terms and conditions apply:
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# See the GNU Affero Public License for more details.
+#
+# You should have received a copy of the GNU Affero Public License
+# along with this program.  If not, see http://www.gnu.org/licenses.
+#
+# http://numenta.org/licenses/
+# ----------------------------------------------------------------------
+
+"""
+Continual Learning experiments with standard MLPs.
+"""
+
+import os
+from copy import deepcopy
+
+import numpy as np
+import ray.tune as tune
+import torch
+import torch.nn.functional as F
+
+from nupic.research.frameworks.dendrites.dendrite_cl_experiment import (
+    DendriteContinualLearningExperiment,
+)
+from nupic.research.frameworks.pytorch.datasets import PermutedMNIST
+from nupic.research.frameworks.pytorch.models import StandardMLP
+from nupic.research.frameworks.vernon import mixins
+from nupic.torch.functions import kwinners
+
+
+def kwinners_wrapper(y):
+    return kwinners(y, duty_cycles=None, k=102, boost_strength=0)
+
+
+class MLPExperiment(mixins.PermutedMNISTTaskIndices,
+                    DendriteContinualLearningExperiment):
+    pass
+
+
+class ContinualLearningMLP(StandardMLP):
+    """
+    An MLP used for continual learning experiments on permutedMNIST. The weight
+    initialization has been modified to improve performance.
+    """
+
+    def __init__(self, input_size, num_classes, hidden_sizes):
+        super().__init__(input_size, num_classes, hidden_sizes)
+
+        # Modified Kaiming weight initialization which considers 1) the density of
+        # the input vector and 2) the weight density in addition to the fan-in
+
+        weight_density = 1.0
+        input_flag = False
+        for layer in self.classifier:
+            if isinstance(layer, torch.nn.Linear):
+
+                # Assume input is fully dense, but hidden layer activations are only
+                # 50% dense due to ReLU
+                input_density = 1.0 if not input_flag else 0.5
+                input_flag = True
+
+                _, fan_in = layer.weight.size()
+                bound = 1.0 / np.sqrt(input_density * weight_density * fan_in)
+                torch.nn.init.uniform_(layer.weight, -bound, bound)
+
+
+DEFAULT = dict(
+    experiment_class=MLPExperiment,
+    local_dir=os.path.expanduser("~/nta/results/experiments/mlp"),
+    num_samples=8,
+
+    dataset_class=PermutedMNIST,
+    dataset_args=dict(
+        root=os.path.expanduser("~/nta/results/data/"),
+        seed=42,
+        download=False,
+    ),
+
+    model_args=dict(input_size=784, num_classes=10),
+
+    batch_size=256,
+    val_batch_size=512,
+    tasks_to_validate=[9, 99],
+
+    distributed=False,
+    seed=tune.sample_from(lambda spec: np.random.randint(2, 10000)),
+
+    loss_function=F.cross_entropy,
+    optimizer_class=torch.optim.Adam,
+)
+
+
+# MLP with 3 layers on 10 permutedMNIST tasks
+THREE_LAYER_MLP_10 = deepcopy(DEFAULT)
+THREE_LAYER_MLP_10["dataset_args"].update(num_tasks=10)
+THREE_LAYER_MLP_10["model_args"].update(hidden_sizes=[2048, 2048])
+THREE_LAYER_MLP_10.update(
+    model_class=ContinualLearningMLP,
+
+    num_tasks=10,
+    num_classes=10 * 10,
+
+    epochs=5,
+    optimizer_args=dict(lr=3e-6)
+)
+
+
+# MLP with 3 layers on 100 permutedMNIST tasks
+THREE_LAYER_MLP_100 = deepcopy(THREE_LAYER_MLP_10)
+THREE_LAYER_MLP_100.update(
+    num_tasks=100,
+    num_classes=10 * 100,
+
+    epochs=3,
+    optimizer_args=dict(lr=1e-6)
+)
+
+
+# MLP with 10 layers on 10 permutedMNIST tasks
+TEN_LAYER_MLP_10 = deepcopy(DEFAULT)
+TEN_LAYER_MLP_10["dataset_args"].update(num_tasks=100)
+TEN_LAYER_MLP_10["model_args"].update(
+    hidden_sizes=[2048 for _ in range(9)]
+)
+TEN_LAYER_MLP_10.update(
+    model_class=ContinualLearningMLP,
+
+    num_tasks=10,
+    num_classes=10 * 10,
+
+    epochs=3,
+    optimizer_args=dict(lr=3e-6)
+)
+
+
+# MLP with 10 layers on 100 permutedMNIST tasks
+TEN_LAYER_MLP_100 = deepcopy(TEN_LAYER_MLP_10)
+TEN_LAYER_MLP_100.update(
+    num_tasks=100,
+    num_classes=10 * 100,
+
+    epochs=3,
+    optimizer_args=dict(lr=3e-7)
+)
+
+
+CONFIGS = dict(
+    three_layer_mlp_10=THREE_LAYER_MLP_10,
+    three_layer_mlp_100=THREE_LAYER_MLP_100,
+    ten_layer_mlp_10=TEN_LAYER_MLP_10,
+    ten_layer_mlp_100=TEN_LAYER_MLP_100
+)


### PR DESCRIPTION
Here, I do the following:

1. add configuration files for training a 3- and 10-layer MLP on permutedMNIST, and
2. add an MLP class with modified weight initialization used by the configs to `nupic/research/frameworks/pytorch/models` so future MLP experiments can also use these.