### PR TITLE
remove TFLoggerPlus from default loggers

### DIFF
--- a/packages/ray/src/nupic/research/frameworks/ray/ray_custom_loggers.py
+++ b/packages/ray/src/nupic/research/frameworks/ray/ray_custom_loggers.py
@@ -238,7 +238,7 @@ class CSVLoggerPlus(CSVLogger):
         self._file.flush()
 
 
-DEFAULT_LOGGERS = (JsonLogger, CSVLoggerPlus, TFLoggerPlus)
+DEFAULT_LOGGERS = (JsonLogger, CSVLoggerPlus)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
TFLoggerPlus is deprecated, we're removing it from DEFAULT LOGGERS