### PR TITLE
Force x86 on apple m1 laptops

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -8,6 +8,10 @@ channels:
   - nvidia
   - conda-forge
 
+variables:
+  # Force x86 on Apple M1 laptops for now
+  CONDA_SUBDIR: osx-64
+
 dependencies:
   - python=3.8
   - pip


### PR DESCRIPTION
This is temporary due to `ray==0.8` and `h5py` dependencies. Once we update those dependencies to a version supporting M1 processors we can remove this variable