### PR TITLE
Pure Python version of Spatial Pooler

### DIFF
--- a/packages/spatial_pooler/setup.cfg
+++ b/packages/spatial_pooler/setup.cfg
@@ -1,0 +1,36 @@
+# ------------------------------------------------------------------------------
+#  Numenta Platform for Intelligent Computing (NuPIC)
+#  Copyright (C) 2022, Numenta, Inc.  Unless you have an agreement
+#  with Numenta, Inc., for a separate license for this software code, the
+#  following terms and conditions apply:
+#
+#  This program is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU Affero Public License version 3 as
+#  published by the Free Software Foundation.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#  See the GNU Affero Public License for more details.
+#
+#  You should have received a copy of the GNU Affero Public License
+#  along with this program.  If not, see http://www.gnu.org/licenses.
+#
+#  http://numenta.org/licenses/
+#
+# ------------------------------------------------------------------------------
+[metadata]
+name = nupic.research.spatial_pooler
+version = 0.0.1.dev0
+
+[options]
+zip_safe = False
+packages = find_namespace:
+package_dir =
+    =src
+install_requires =
+    nupic.research
+
+[options.packages.find]
+where = src
+

--- a/packages/spatial_pooler/setup.py
+++ b/packages/spatial_pooler/setup.py
@@ -1,0 +1,24 @@
+# ------------------------------------------------------------------------------
+#  Numenta Platform for Intelligent Computing (NuPIC)
+#  Copyright (C) 2021, Numenta, Inc.  Unless you have an agreement
+#  with Numenta, Inc., for a separate license for this software code, the
+#  following terms and conditions apply:
+#
+#  This program is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU Affero Public License version 3 as
+#  published by the Free Software Foundation.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#  See the GNU Affero Public License for more details.
+#
+#  You should have received a copy of the GNU Affero Public License
+#  along with this program.  If not, see http://www.gnu.org/licenses.
+#
+#  http://numenta.org/licenses/
+#
+# ------------------------------------------------------------------------------
+from setuptools import setup
+
+setup()

--- a/packages/spatial_pooler/src/nupic/research/frameworks/spatial_pooler/__init__.py
+++ b/packages/spatial_pooler/src/nupic/research/frameworks/spatial_pooler/__init__.py
@@ -1,0 +1,22 @@
+# ----------------------------------------------------------------------
+# Numenta Platform for Intelligent Computing (NuPIC)
+# Copyright (C) 2022, Numenta, Inc.  Unless you have an agreement
+# with Numenta, Inc., for a separate license for this software code, the
+# following terms and conditions apply:
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# See the GNU Affero Public License for more details.
+#
+# You should have received a copy of the GNU Affero Public License
+# along with this program.  If not, see http://www.gnu.org/licenses.
+#
+# http://numenta.org/licenses/
+# ----------------------------------------------------------------------
+
+from .spatial_pooler import SpatialPooler

--- a/packages/spatial_pooler/src/nupic/research/frameworks/spatial_pooler/spatial_pooler.py
+++ b/packages/spatial_pooler/src/nupic/research/frameworks/spatial_pooler/spatial_pooler.py
@@ -1,0 +1,834 @@
+# ----------------------------------------------------------------------
+# Numenta Platform for Intelligent Computing (NuPIC)
+# Copyright (C) 2022, Numenta, Inc.  Unless you have an agreement
+# with Numenta, Inc., for a separate license for this software code, the
+# following terms and conditions apply:
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# See the GNU Affero Public License for more details.
+#
+# You should have received a copy of the GNU Affero Public License
+# along with this program.  If not, see http://www.gnu.org/licenses.
+#
+# http://numenta.org/licenses/
+# ----------------------------------------------------------------------
+
+import numpy as np
+import itertools
+
+real_type = np.float32
+uint_type = np.uint32
+
+class SpatialPooler():
+    def __init__(self, 
+                 input_dims=(32, 32),
+                 minicolumn_dims=(64, 64),
+                 num_active_minicolumns_per_inh_area=10,
+                 local_density=-1.0,
+                 potential_radius=16,
+                 potential_percent=0.5,
+                 global_inhibition=False,
+                 stimulus_threshold=0,
+                 synapse_perm_inc=0.05,
+                 synapse_perm_dec=0.008,
+                 synapse_perm_connected=0.1,
+                 min_percent_overlap_duty_cycles=0.001,
+                 duty_cycle_period=1000,
+                 boost_strength=0.0,
+                 seed=-1,
+                 ):
+        '''
+        input_dims:                             dimensions of input vector. 
+                                                default ``(32, 32)``.
+
+        minicolumn_dims:                        dimensions of cortical minicolumns. 
+                                                default ``(64, 64)``.
+
+        num_active_minicolumns_per_inh_area:    sets number of minicolumns that remain on within a local inhibition area.
+                                                as minicolumns learn and grow their effective receptive fields, the inhibition radius will also grow. 
+                                                when this happens, net density of the number of active minicolumns *decreases* if this method is used.
+                                                default ``10.0``.
+
+        local_density:                          sets desired density of active minicolumns within local inhibition area. ensures that at most
+                                                N minicolumns remain on within a local inhibition area, 
+                                                where N = local_density * (total number of minicolumns in inhibition area). 
+                                                density of active minicolumns stays the same regardless of size of minicolumns' receptive fields. 
+                                                default ``-1.0``.
+
+        potential_radius:                       number of input bits visible to each minicolumn. large enough value means that every minicolumn can 
+                                                potentially connect to every input bit. this parameter defines a square/hypercube area: a minicolumn
+                                                will have a max square potential pool with sides of length (2 * potential_radius + 1).
+                                                default ``16``.
+
+        potential_percent:                      percent of inputs within a minicolumn's potential_radius that a minicolumn can be connected to. 
+                                                if set to 1, minicolumn will be connected to every input within its potential radius. at 
+                                                initialization, we choose:
+                                                ( (2*potential_radius + 1)^(# input dimensions) * potential_percent ) 
+                                                input bits to comprise the minicolumn's potential pool.
+                                                default ``0.5``.
+
+        global_inhibition:                      if True, then during inhibition phase the winning minicolumns are selected as the most 
+                                                active minicolumns from the region as a whole. else, winning minicolumns are selected w.r.t. their 
+                                                local neighborhoods. 
+                                                default ``False``.
+
+        stimulus_threshold:                     minimum number of synapses that must be on in order for a minicolumn to turn on. prevents noise from 
+                                                activating minicolumns. specified as a percent of a fully grown synapse.
+                                                default ``0``.
+
+        synapse_perm_inc:                       amount by which an active synapse is incremented in each round. specified as a percent of a fully
+                                                grown synapse.
+                                                default ``0.05``.
+
+        synapse_perm_dec:                       amount by which an inactive synapse is decremented in each round. specified as a percent of a fully
+                                                grown synapse.
+                                                default ``0.008``.
+
+        synapse_perm_connected:                 default connected threshold. any synapse whose permanence value is above the connected threshold is 
+                                                a "connected synapse", meaning it can conribute to the cell's firing.
+                                                default ``0.1``.
+
+        min_percent_overlap_duty_cycles:        floor on how often a minicolumn should have at least stimulus_threshold active inputs. periodically, 
+                                                each minicolumn looks at the overlap duty cycle of all other minicolumns within its inhibition radius 
+                                                and sets its own internal minimal acceptable duty cycle to: 
+                                                (minimum percent duty cycle before inhibition) * max(other minicolumns' duty cycles). 
+                                                if any minicolumn whose overlap duty cycle falls below this, all permanence values get boosted by 
+                                                synapse_perm_inc. raising permanences before inhibition allows a cell to search for new inputs 
+                                                when either its previously learned inputs are no longer ever active or when vast majority of inputs
+                                                are "hijacked" by other minicolumns.
+                                                default ``0.001``.
+
+        duty_cycle_period:                      period used to calculate duty cycles. higher values means it takes longer to respond in changes in 
+                                                boosting or synapses per connected cell. shorter values make it more unstable and likely to oscillate.
+                                                default ``1000``.
+
+        boost_strength:                         a number >= 0.0 that is used to control the strength of boosting. boosting increases as a function
+                                                of boost_strength. encourages minicolumns to have similar active duty cycles as their neighbors, which 
+                                                will lead to more efficient use of minicolumns. too much boosting may lead to instability of spatial
+                                                pooler outputs.
+                                                default ``0.0``.  
+
+        seed:                                   seed for numpy random generator.                    
+        '''
+
+        ''' controls number of minicolumns that are on within a local inhibition area '''
+        self.num_active_minicolumns_per_inh_area = int(num_active_minicolumns_per_inh_area)
+        self.local_density = local_density
+
+        assert (self.num_active_minicolumns_per_inh_area > 0) or (0 < self.local_density <= 0.5)
+
+
+        ''' input and and minicolumn dimensionality '''
+        self.input_dims = np.array(input_dims, ndmin=1)
+        self.minicolumn_dims = np.array(minicolumn_dims, ndmin=1)
+        self.num_inputs = np.prod(self.input_dims)
+        self.num_minicolumns = np.prod(self.minicolumn_dims)
+
+        assert (self.num_inputs > 0) and (self.num_minicolumns > 0)
+        assert (self.input_dims.size == self.minicolumn_dims.size)
+
+
+        ''' global or local inhibition '''
+        self.global_inhibition = global_inhibition
+
+
+        ''' defines extent of input that each minicolumn can potentially connect to '''
+        self.potential_percent = potential_percent
+        self.potential_radius = int(min(potential_radius, self.num_inputs))
+        
+
+        ''' rules for synaptic connections '''
+        self.stimulus_threshold = stimulus_threshold
+        self.synapse_perm_inc = synapse_perm_inc
+        self.synapse_perm_dec = synapse_perm_dec
+        self.synapse_perm_below_stimulus_inc = synapse_perm_connected / 10.0
+        self.synapse_perm_connected = synapse_perm_connected
+        self.synapse_perm_min = 0.0
+        self.synapse_perm_max = 1.0
+        self.synapse_perm_trim_threshold = synapse_perm_inc / 2.0
+        self.permanence_epsilon = 0.000001
+
+        assert (self.synapse_perm_trim_threshold < self.synapse_perm_connected)
+
+        
+        ''' cycle period, update period, and iteration count '''
+        self.duty_cycle_period = duty_cycle_period
+        self.update_period = 50
+        self.iteration_num = 0
+        self.iteration_learn_num = 0
+
+
+        ''' 
+        duty cycles + overlap metrics + boosting 
+        
+        - overlap_duty_cycles[i] shows the moving average of the number of inputs which overlaps with minicolumn "i".
+
+        - active_duty_cycles[i] shows the moving average of the frequency of activation for minicolumn "i".
+
+        - min_overlap_duty_cycles[i] is minimum duty cycles defining normal activity for minicolumn "i". a minicolumn with active_duty_cycle below 
+          this threshold is boosted.
+        
+        - boost_factors[i] is the boost factor for minicolumn "i". used to increase the overlap of inactive minicolumns to improve their chances of 
+          becoming active. depends on active_duty_cycles via an exponential function.
+
+        - overlaps[i] determines overlap between minicolumn "i" and input vector. overlap = number of connected synapses to input bits which are on.
+
+        - boosted_overlaps[i] = boost_factors[i] * overlaps[i] if spatial pooler is learning, else boosted_overlaps[i] = overlaps[i]
+        '''
+        self.overlap_duty_cycles = np.zeros(self.num_minicolumns, dtype=real_type)
+        self.active_duty_cycles = np.zeros(self.num_minicolumns, dtype=real_type)
+        self.min_overlap_duty_cycles = np.zeros(self.num_minicolumns, dtype=real_type)
+        self.min_percent_overlap_duty_cycles = min_percent_overlap_duty_cycles
+        self.init_connected_percent = 0.5
+        self.boost_strength = boost_strength
+        self.boost_factors = np.ones(self.num_minicolumns, dtype=real_type)
+        self.overlaps = np.zeros(self.num_minicolumns, dtype=real_type)
+        self.boosted_overlaps = np.zeros(self.num_minicolumns, dtype=real_type)
+
+
+        ''' random seed '''
+        if seed == -1:
+            self.seed = np.random.randint(1e10)
+        else:
+            self.seed = seed
+
+        self.generator = np.random.default_rng(seed=self.seed)
+        
+
+        ''' 
+        rows of matrix represent minicolumns: i.e. map from input bits to minicolumns. 
+        columns of matrix represent input bits: i.e. map from minicolumns to input bits.
+
+        - potential_pools[i][j] shows if input bit "j" is in the potential pool of minicolumn "i". a minicolumn can only be connected to inputs in its
+          potential pool.
+
+        - permanences[i][j] shows the permanence for minicolumn "i" to input bit "j".
+
+        - connected_synapses[i][j] shows if minicolumn "i" is connnected to input bit "j".
+
+        - connected_synapse_counts[i] shows the number of connected synapses for minicolumn "i".
+        '''
+        self.potential_pools = np.zeros((self.num_minicolumns, self.num_inputs), dtype=np.bool_) 
+        self.permanences = np.zeros((self.num_minicolumns, self.num_inputs), dtype=real_type)
+        self.connected_synapses = np.zeros((self.num_minicolumns, self.num_inputs), dtype=np.bool_)
+        self.connected_synapses_counts = np.zeros(self.num_minicolumns, dtype=real_type)
+
+
+        for minicolumn_index in range(self.num_minicolumns):
+            potential = self.map_potential(minicolumn_index)
+            self.potential_pools[minicolumn_index, potential.nonzero()[0]] = 1
+            permanence = self.init_permanence(potential)
+            self.update_permanences_for_minicolumn(permanence, minicolumn_index, raise_perm=True)
+
+
+        self.inhibition_radius = 0
+        self.update_inhibition_radius()
+
+    
+    def compute(self, input_vector, learn, active_array):
+        '''
+        primary spatial pooler method. takes an input vector and outputs the indices of the active minicolumns. if learn is True, update the
+        permanences of the minicolumns. 
+
+        input vector is a binary np.array that comprises the input to the spatial pooler. array is treated as a 1D array. only requirement is that
+        the number of bits in input vector must match the number of bits specified by the call to the constructor. i.e., there must be a 0 or 1 in the 
+        array for every input bit. 
+
+        active_array is an array whose size is equal to the number of minicolumns. will be populated with 1's at the indices of the active 
+        minicolumns and 0's everywhere else.
+        '''
+
+        assert isinstance(input_vector, np.ndarray) and (input_vector.size == self.num_inputs)
+
+        self.iteration_num += 1
+        if learn:
+            self.iteration_learn_num += 1
+
+        input_vector = np.array(input_vector, dtype=real_type).reshape(-1)
+        
+        self.overlaps = self.calculate_overlap(input_vector)
+
+        # apply boosting when learning is on
+        if learn:
+            self.boosted_overlaps = self.boost_factors * self.overlaps
+        else:
+            self.boosted_overlaps = self.overlaps
+
+        # apply inhibition to determine the winning minicolumns
+        active_minicolumns = self.inhibit_minicolumns(self.boosted_overlaps)
+
+        if learn:
+            self.adapt_synapses(input_vector, active_minicolumns)
+            self.update_duty_cycles(self.overlaps, active_minicolumns)
+            self.bump_up_weak_minicolumns()
+            self.update_boost_factors()
+
+            if (self.iteration_num % self.update_period) == 0:
+                self.update_inhibition_radius()
+                self.update_min_duty_cycles()
+
+        active_array.fill(0)
+        active_array[active_minicolumns] = 1     
+        
+
+    def map_potential(self, index):
+        '''
+        maps minicolumn to input bits. 
+        
+        takes index of minicolumn and determines what indices of the input vector are located within the minicolumn's 
+        potential pool. returns list containing indices of the input bits. 
+
+        if the potential radius is greater than or equal to the largest input dimension, then each minicolumn connects to all of the inputs.
+        '''
+        center_input = self.map_minicolumn(index)
+        minicolumn_inputs = self.get_input_neighborhood(center_input).astype(uint_type)
+
+        # select a subset of the receptive field to serve as the potential pool
+        num_potential = int(minicolumn_inputs.size * self.potential_percent + 0.5)
+
+        selected_inputs = self.generator.choice(minicolumn_inputs, size=num_potential, replace=False).astype(uint_type)
+
+        potential = np.zeros(self.num_inputs, dtype=uint_type)
+        potential[selected_inputs] = 1
+
+        return potential
+
+
+    def map_minicolumn(self, index):
+        '''
+        maps a minicolumn index to respective input index, keeping topology of the region. 
+
+        in other words, takes index of minicolumn as argument and calculates index of flattened input vector 
+        that is to be the center of the minicolumn's potential pool. 
+        '''
+
+        minicolumn_coordinates = np.array(np.unravel_index(index, self.minicolumn_dims), dtype=real_type)
+
+        # map minicolumn index to find appropriate input index
+        input_coordinates = self.input_dims * (minicolumn_coordinates / self.minicolumn_dims)
+
+        # shift input index by (1/2M)(I) 
+        input_coordinates += (0.5 * self.input_dims)/self.minicolumn_dims
+
+        # get valid index
+        input_coordinates = input_coordinates.astype(int)
+
+        input_index = np.ravel_multi_index(input_coordinates, self.input_dims)
+
+        return input_index
+
+    
+    def get_input_neighborhood(self, center_input):
+        '''
+        return a neighborhood of inputs.
+        '''
+        
+        return self.neighborhood(center_input, self.potential_radius, self.input_dims)
+
+
+    def get_minicolumn_neighborhood(self, center_minicolumn):
+        '''
+        return a neighborhood of minicolumns.
+        '''
+        
+        return self.neighborhood(center_minicolumn, self.inhibition_radius, self.minicolumn_dims)
+
+
+    def neighborhood(self, center_input, radius, dimensions):
+        '''
+        gets the points in the neighborhood of a point. a point's neighborhood is the n-dimensional hypercube with sides ranging 
+        [center - radius, center + radius] inclusive. if there are two dimensions and radius = 3, then neighborhood is 6x6. neighborhoods are 
+        truncated when they are near an edge.
+        '''
+
+        center_position = np.unravel_index(center_input, dimensions)
+
+        intervals = []
+        for i, dimension in enumerate(dimensions):
+            left = max(0, center_position[i] - radius)
+            right = min(dimension - 1, center_position[i] + radius)
+            intervals.append(range(left, right + 1))
+
+        coordinates = np.array(list(itertools.product(*intervals)))
+
+        return np.ravel_multi_index(coordinates.T, dimensions)
+
+    
+    def update_inhibition_radius(self):
+        '''
+        update inhibition radius, which is a measure of the hypersquare of minicolumns that each minicolumn is "connected to" on average. 
+        since minicolumns are not connected to each other directly, we determine this quantity by figuring out how many *inputs* a minicolumn is 
+        connected to and multiply this by the total number of minicolumns that exist for each input. for multiple dimensions, these calculations are
+        averaged over al dimensions of inputs and minicolumns.
+
+        this computation is not used if global_inhibition is enabled. 
+        '''
+
+        if self.global_inhibition:
+            self.inhibition_radius = int(self.minicolumn_dims.max())
+            return
+        
+        # how many inputs a minicolumn is connected to on average
+        average_connected_span = np.average([self.average_connected_synapses_per_minicolumn(m) for m in range(self.num_minicolumns)])
+
+        # how many minicolumns exist for each input on average
+        minicolumns_per_input = self.average_minicolumns_per_input()
+
+        diameter = average_connected_span * minicolumns_per_input
+        radius = (diameter - 1) / 2.0
+        radius = max(radius, 1.0)
+
+        self.inhibition_radius = int(radius + 0.5)
+
+
+    def average_connected_synapses_per_minicolumn(self, minicolumn_index):
+        '''
+        range of connected synapses per minicolumn, averaged for each dimension. value is used to calculate the inhibition radius.
+        '''
+
+        connected = self.connected_synapses[minicolumn_index, :].nonzero()[0]
+
+        if connected.size == 0:
+            return 0
+        else:
+            min_coordinate = np.empty(self.input_dims.size)
+            max_coordinate = np.empty(self.input_dims.size)
+
+            min_coordinate.fill(max(self.input_dims))
+            max_coordinate.fill(-1)
+
+            for i in connected:
+                min_coordinate = np.minimum(min_coordinate, np.unravel_index(i, self.input_dims))
+                max_coordinate = np.maximum(max_coordinate, np.unravel_index(i, self.input_dims))
+
+            return np.average(max_coordinate - min_coordinate + 1)
+
+    
+    def average_minicolumns_per_input(self):
+        '''
+        average number of minicolumns per input, value is used to calculate the inhibition radius. 
+
+        if the minicolumn dimensions don't match the input dimensions, missing dimensions are treated as "ones".
+        '''
+
+        num_dim = max(self.minicolumn_dims.size, self.input_dims.size)
+
+        minicol_dim = np.ones(num_dim)
+        minicol_dim[:self.minicolumn_dims.size] = self.minicolumn_dims
+
+        input_dim = np.ones(num_dim)
+        input_dim[:self.input_dims.size] = self.input_dims
+
+        minicolumns_per_input = minicol_dim.astype(real_type) / input_dim
+
+        return np.average(minicolumns_per_input)
+
+
+    def init_permanence(self, potential):
+        '''
+        takes in a np.array specifying the potential pool of the minicolumn.
+        initializes the permanence of a minicolumn. returns a 1D array the size of the input, where each entry represents the initial permanence value
+        between the input bit at the index and minicolumn represented by the index. 
+        '''
+
+        permanence = np.zeros(self.num_inputs, dtype=real_type)
+
+        for i in range(self.num_inputs):
+            if (potential[i] < 1):
+                continue
+
+            if (self.generator.random() <= self.init_connected_percent):
+                # initialize connected permanence
+                # use a randomly generated permanence value that is close to synapse_perm_connected
+
+                p = self.synapse_perm_connected + (self.synapse_perm_max - self.synapse_perm_connected)*self.generator.random()
+                p = int(p * 100000) / 100000.0
+
+                permanence[i] = p
+            else:
+                # initialize unconnected permanence
+                
+                p = self.synapse_perm_connected * self.generator.random()
+                p = int(p * 100000) / 100000.0
+
+                permanence[i] = p
+
+        # clip off low values
+        permanence[permanence < self.synapse_perm_trim_threshold] = 0
+
+        return permanence
+
+
+    def update_permanences_for_minicolumn(self, permanence, minicolumn_index, raise_perm=True):
+        '''
+        updates the permanence matrix with a minicolumn's new permanence values. 
+
+        this method is responsible for clipping the permanence values so they remain between 0 and 1. also responsible for trimming permanence values
+        below synapse_perm_trim_threshold, which enforces sparsity.
+
+        permanences is a dense array that describes permanence values for each minicolumn (dense = contains all the zeros and non-zero values).
+        raise_perm is a boolean value indicating whether permanence values should be raised until a minimum number of synapses are in a connected 
+        state. should be False when a direct assignment is required. 
+        '''
+
+        mask_potential = np.where(self.potential_pools[minicolumn_index, :] > 0)[0]
+
+        if raise_perm:
+            self.raise_permanence_to_threshold(permanence, mask_potential)
+        
+        permanence[permanence < self.synapse_perm_trim_threshold] = 0
+        np.clip(permanence, self.synapse_perm_min, self.synapse_perm_max, out=permanence)
+        self.permanences[minicolumn_index, :] = permanence
+
+        new_connected = np.where(permanence >= (self.synapse_perm_connected - self.permanence_epsilon))[0]
+        # remove old synaptic connections and make new ones
+        self.connected_synapses[minicolumn_index, :] = 0 
+        self.connected_synapses[minicolumn_index, new_connected] = 1
+        self.connected_synapses_counts[minicolumn_index] = new_connected.size
+
+    
+    def raise_permanence_to_threshold(self, permanence, mask_potential):
+        '''
+        ensures that each minicolumn has enough connections to input bits to allow it to become active. 
+        takes in an array of permanence values for a minicolumn and its synapse indices whose permanences need to be raised.
+
+        reasoning: since a minicolumn must have at least stimulus_threshold overlaps in oder to be considered during the inhibition phase, minicolumns 
+                   without this minimal number of connections have no chance of reaching the threshold, even if all input bits they are connected
+                   to are on. for such minicolumns, the permanence values are increased until the minimum number of connections are formed. 
+        '''
+
+        assert len(mask_potential) >= self.stimulus_threshold
+
+        np.clip(permanence, self.synapse_perm_min, self.synapse_perm_max, out=permanence)
+
+        while True:
+            num_connected = np.nonzero( permanence > (self.synapse_perm_connected - self.permanence_epsilon) )[0].size
+
+            if num_connected >= self.stimulus_threshold:
+                return
+            else:
+                permanence[mask_potential] += self.synapse_perm_below_stimulus_inc
+
+
+    def calculate_overlap(self, input_vector):
+        '''
+        determines each minicolumn's overlap with the current input vector. overlap of a minicolumn is the number of connected synapses to input
+        bits which are turned on. 
+        '''
+
+        overlaps = np.zeros(self.num_minicolumns, dtype=real_type)
+
+        for m in range(self.num_minicolumns):
+            overlaps[m] = input_vector[self.connected_synapses[m,:] > 0].sum()
+        
+        return overlaps
+
+
+    def inhibit_minicolumns(self, overlaps):
+        '''
+        performs inhibition. calculates the necessary values needed to actually perform inhibition (either global or local inhibition).
+
+        takes in overlaps, which is an array containing overlap score for each minicolumn. 
+        overlap score for a minicolumn = number of connected synapses to input bits which are turned on.
+        '''
+
+        if self.local_density > 0:
+            density = self.local_density
+        else:
+            inhibition_area = min(self.num_minicolumns, (2 * self.inhibition_radius + 1)**self.minicolumn_dims.size)
+
+            density = float(self.num_active_minicolumns_per_inh_area) / inhibition_area
+            density = min(density, 0.5)
+
+        if self.global_inhibition or self.inhibition_radius > max(self.minicolumn_dims):
+            return self.inhibit_minicolumns_global(overlaps, density)
+        else:
+            return self.inhibit_minicolumns_local(overlaps, density)
+
+
+    def inhibit_minicolumns_global(self, overlaps, density):
+        '''
+        global inhibition -- pick the top num_active minicolumns with the highest overlap score in the entire region. 
+        
+        at most half of the minicolumns in a local neighborhood are allowed to be active. 
+        minicolumns with an overlap score below the stimulus_threshold are always inhibited.
+        '''
+
+        # calculate num_active minicolumns per inhibition area
+        num_active = int(density * self.num_minicolumns)
+        
+        # calculate winners using sorting algorithm 
+        winning_minicolumn_indices = np.argsort(overlaps, kind='mergesort')
+
+        # enforce the stimulus threshold
+        start = len(winning_minicolumn_indices) - num_active
+        while start < len(winning_minicolumn_indices):
+            if overlaps[ winning_minicolumn_indices[start] ] >= self.stimulus_threshold:
+                # once one minicolumn has an overlap greater than the threshold, the rest in the sorted list will also be higher than the threshold
+                break
+            else:
+                start += 1
+        
+        return winning_minicolumn_indices[start:][::-1]
+
+
+    def inhibit_minicolumns_local(self, overlaps, density):
+        '''
+        local inhibition -- performed on a minicolumn by minicolumn basis. each minicolumn observes the overlaps of its neighbors and is selected
+        if its overlap score is within the top num_active in its local neighborhood. 
+        
+        at most half of the minicolumns in a local neighborhood are allowed to be active. 
+        minicolumns with an overlap score below the stimulus_threshold are always inhibited. 
+        '''
+
+        active_array = np.zeros(self.num_minicolumns, dtype=np.bool_)
+
+        for minicolumn, overlap in enumerate(overlaps):
+            if overlap >= self.stimulus_threshold:
+                neighborhood = self.get_minicolumn_neighborhood(minicolumn)
+
+                neighborhood_overlaps = overlaps[neighborhood]
+
+                # how many neighbors have an overlap value greater than current minicolumn
+                num_bigger = np.count_nonzero(neighborhood_overlaps > overlap)
+        
+                # when there is a tie (neighboring minicolumns have same overlap as current minicolumn), favor neighbors already selected as active
+                tied_neighbors = neighborhood[ np.where(neighborhood_overlaps == overlap) ]
+                num_ties_lost = np.count_nonzero(active_array[tied_neighbors])
+
+                # maximum number of active minicolumns in neighborhood
+                num_active = int(0.5 + density * len(neighborhood))
+
+                # activate current minicolumn if enough neighbors aren't "better" 
+                # (better = higher overlap value or same overlap value but already active)
+                if (num_bigger + num_ties_lost) < num_active:
+                    active_array[minicolumn] = True
+
+        return active_array.nonzero()[0]
+
+    
+    def adapt_synapses(self, input_vector, active_minicolumns):
+        '''
+        primary method in charge of learning. adapts the permanence values of the synapses based on input vectors, and the chosen minicolumns after
+        inhibition round. 
+
+        permanence values are increased for synapses connected to input bits that are turned on. 
+        permanence values are decreased for synapses connected to input bits that are turned off. 
+        '''
+
+        input_indices = np.where(input_vector > 0)[0]
+
+        # for input bits that are on, increase synaptic permanence. for inputs bits that are off, decrease synaptic permanence.
+        permanence_changes = np.zeros(self.num_inputs, dtype=real_type)
+        permanence_changes.fill(-1 * self.synapse_perm_dec)
+        permanence_changes[input_indices] = self.synapse_perm_inc
+
+        for minicolumn_index in active_minicolumns:
+            # find synaptic permanences for all input bits of current minicolumn
+            permanence = self.permanences[minicolumn_index, :]
+
+            # find which input bits can *possibly* connect to current minicolumn 
+            mask_potential = np.where(self.potential_pools[minicolumn_index, :] > 0)[0]
+
+            # only update synaptic permanences for input bits that can *possibly* connect to current minicolumn
+            permanence[mask_potential] += permanence_changes[mask_potential]
+
+            # do the update
+            self.update_permanences_for_minicolumn(permanence, minicolumn_index, raise_perm=True)
+
+    
+    def update_duty_cycles(self, overlaps, active_minicolumns):
+        '''
+        updates the duty cycles for each minicolumn. 
+
+        overlap duty cycles is a moving average of the number of inputs which overlapped with each minicolumn.
+        active duty cycles is a moving average of the frequency of activation for each minicolumn.
+
+                        (period - 1)*duty_cycle + new_value
+        duty_cycle := ---------------------------------------
+                                period
+        '''
+
+        period = self.duty_cycle_period
+        if (period > self.iteration_num):
+            period = self.iteration_num
+        assert (period >= 1)
+
+        overlap_array = np.zeros(self.num_minicolumns, dtype=real_type)
+        overlap_array[overlaps > 0] = 1
+        self.overlap_duty_cycles = (self.overlap_duty_cycles * (period - 1.0) + overlap_array) / period
+
+        active_array = np.zeros(self.num_minicolumns, dtype=real_type)
+        active_array[active_minicolumns] = 1
+        self.active_duty_cycles = (self.active_duty_cycles * (period - 1.0) + active_array) / period
+
+
+    def bump_up_weak_minicolumns(self):
+        '''
+        increases the permanence values of synapses of minicolumns whose activity level has been too low. 
+        such minicolumns are identified by having an overlap duty cycle that drops too much below those of their peers. 
+        the permanence values for such minicolumns are increased. 
+        '''
+
+        weak_minicolumns = np.where(self.overlap_duty_cycles < self.min_overlap_duty_cycles)[0]
+
+        for minicolumn_index in weak_minicolumns:
+            # find synaptic permanences for all input bits of current minicolumn
+            permanence = self.permanences[minicolumn_index, :].astype(real_type)
+            
+            # find which input bits can *possibly* connect to current minicolumn 
+            mask_potential = np.where(self.potential_pools[minicolumn_index, :] > 0)[0]
+            
+            # only update synaptic permanences for input bits that can *possibly* connect to current minicolumn
+            permanence[mask_potential] += self.synapse_perm_below_stimulus_inc
+
+            # do the update
+            self.update_permanences_for_minicolumn(permanence, minicolumn_index, raise_perm=False) 
+
+    
+    def update_boost_factors(self):
+        '''
+        update boost_factors for all minicolumns. boost_factors are used to increase the overlap of inactive minicolumns to improve their chances of 
+        becoming active. 
+
+        boosting function: boost_factors = exp[ - boost_strength * (duty_cycle - target_density) ]
+
+        minicolumns that have been active at the target activation level --> boost_factors of 1 (their overlap is not boosted)
+        minicolumns that have an active duty cycle below their neighbors --> boosted depending on how infrequently they have been active
+        minicolumns that have an active duty cycle above the target activation level --> boost_factors below 1 (their overlap is suppressed)
+
+        boost_factors depends on the active_duty_cycle via an exponential function
+
+        boost_factors
+                ^
+                |
+                |\
+                | \
+          1  _  |  \
+                |    _
+                |      _ _
+                |          _ _ _ _
+                +--------------------> activeDutyCycle
+                   |
+              targetDensity
+        '''
+
+        if self.global_inhibition:
+            self.update_boost_factors_global()
+        else:
+            self.update_boost_factors_local()
+
+    
+    def update_boost_factors_global(self):
+        ''''
+        update boost factors when global inhibition is used. target_density is the sparsity of the spatial pooler.
+        '''
+
+        if self.local_density > 0:
+            target_density = self.local_density
+        else:
+            inhibition_area = min((2 * self.inhibition_radius + 1)**self.minicolumn_dims.size, self.num_minicolumns)
+
+            target_density = float(self.num_active_minicolumns_per_inh_area) / inhibition_area
+            target_density = min(target_density, 0.5)
+        
+        self.boost_factors = np.exp( -self.boost_strength * (self.active_duty_cycles - target_density) )
+    
+
+    def update_boost_factors_local(self):
+        ''''
+        update boost factors when local inhibition is used. target_density is the average active_duty_cycles of the neighboring minicolumns of each
+        minicolumn.
+        '''
+
+        target_density = np.zeros(self.num_minicolumns, dtype=real_type)
+
+        for m in range(self.num_minicolumns):
+            mask_neighbors = self.get_minicolumn_neighborhood(m)
+
+            target_density[m] = np.mean(self.active_duty_cycles[mask_neighbors])
+
+        self.boost_factors = np.exp( -self.boost_strength * (self.active_duty_cycles - target_density) )
+
+
+    def update_min_duty_cycles(self):
+        '''
+        updates minimum duty cycles defining normal activity for a minicolumn. a minicolumn with active_duty_cycle below this threshold is boosted.
+        '''
+
+        if self.global_inhibition or self.inhibition_radius > max(self.minicolumn_dims):
+            self.update_min_duty_cycles_global()
+        else:
+            self.update_min_duty_cycles_local()
+
+    
+    def update_min_duty_cycles_global(self):
+        '''
+        set the minimum duty cycles for the overlap of all minicolumns to be a percent of the maximum in the region, specified by 
+        min_percent_overlap_duty_cycles. 
+        '''
+
+        self.min_overlap_duty_cycles.fill(self.min_percent_overlap_duty_cycles * self.overlap_duty_cycles.max())
+
+
+    def update_min_duty_cycles_local(self):
+        '''
+        each minicolumn's duty cycles are set to be a percent of the maximum duty cycles in the minicolumn's neighborhood.
+        '''
+
+        for minicolumn in range(self.num_minicolumns):
+            neighborhood = self.get_minicolumn_neighborhood(minicolumn)
+            
+            max_overlap_duty = self.overlap_duty_cycles[neighborhood].max()
+
+            self.min_overlap_duty_cycles[minicolumn] = (self.min_percent_overlap_duty_cycles * max_overlap_duty)
+
+    
+    '''
+    getter methods
+    '''
+    def get_num_inputs(self):
+        return self.num_inputs
+    def get_num_minicolumns(self):
+        return self.num_minicolumns
+    def get_iteration_learn_num(self):
+        return self.iteration_learn_num
+    def get_boost_factors(self):
+        return self.boost_factors
+    def get_active_duty_cycles(self):
+        return self.active_duty_cycles
+    def get_potential_pools(self):
+        return self.potential_pools
+    def get_permanences(self):
+        return self.permanences
+    def get_connected_synapses(self):
+        return self.connected_synapses
+    def get_connected_synapses_counts(self):
+        return self.connected_synapses_counts
+    def get_overlaps(self):
+        return self.overlaps
+    def get_boosted_overlaps(self):
+        return self.boosted_overlaps
+    def get_min_overlap_duty_cycles(self):
+        return self.min_overlap_duty_cycles
+
+    
+    '''
+    setter methods
+    '''
+    def set_inhibition_radius(self, radius):
+        self.inhibition_radius = radius
+    def set_boost_factors(self, boost_factors):
+        self.boost_factors = boost_factors
+    def set_overlap_duty_cycles(self, overlap_duty_cycles):
+        self.overlap_duty_cycles = overlap_duty_cycles
+    def set_active_duty_cycles(self, active_duty_cycles):
+        self.active_duty_cycles = active_duty_cycles
+    def set_min_percent_overlap_duty_cycles(self, min_percent_overlap_duty_cycles):
+        self.min_percent_overlap_duty_cycles = min_percent_overlap_duty_cycles

--- a/packages/spatial_pooler/tests/spatial_pooler_boost_test.py
+++ b/packages/spatial_pooler/tests/spatial_pooler_boost_test.py
@@ -1,0 +1,243 @@
+# ----------------------------------------------------------------------
+# Numenta Platform for Intelligent Computing (NuPIC)
+# Copyright (C) 2022, Numenta, Inc.  Unless you have an agreement
+# with Numenta, Inc., for a separate license for this software code, the
+# following terms and conditions apply:
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# See the GNU Affero Public License for more details.
+#
+# You should have received a copy of the GNU Affero Public License
+# along with this program.  If not, see http://www.gnu.org/licenses.
+#
+# http://numenta.org/licenses/
+# ----------------------------------------------------------------------
+
+import numpy as np
+import time
+import unittest
+
+from nupic.research.frameworks.spatial_pooler import SpatialPooler
+
+real_type = np.float32
+uint_type = np.uint32
+
+SEED = int((time.time() % 10000) * 10)
+
+
+def compute_overlap(x, y):
+    '''
+    compute overlap between 2 binary arrays
+    '''
+
+    return ((x+y) == 2).sum()
+
+
+def sdrs_unique(sdrs_dict):
+    ''' 
+    return True iff all SDRs in dict are unique
+    '''
+
+    for k1, v1 in sdrs_dict.items():
+        for k2, v2 in sdrs_dict.items():
+            if (k1 != k2) and ((v1 == v2).sum() == v1.size):
+                return False
+    return True
+
+
+class SpatialPoolerBoostTest(unittest.TestCase):
+    '''
+    Test boosting.
+  
+    The test is constructed as follows: we construct a set of 5 known inputs. Two
+    of the input patterns have 50% overlap while all other combinations have 0%
+    overlap. Each input pattern has 20 bits on to ensure reasonable overlap with
+    almost all minicolumns.
+
+    SP parameters:  The SP is set to have 600 minicolumns with 10% output sparsity.
+    This ensures that the 5 inputs cannot use up all the minicolumns. Yet we still can
+    have a reasonable number of winning minicolumns at each step in order to test
+    overlap properties. boostStrength is set to 10 so that some boosted minicolumns are
+    guaranteed to win eventually but not necessarily quickly. potentialPct is set
+    to 0.9 to ensure all minicolumns have at least some overlap with at least one
+    input bit. Thus, when sufficiently boosted, every minicolumn should become a
+    winner at some point. We set permanence increment and decrement to 0 so that
+    winning minicolumns don't change unless they have been boosted.
+
+    Learning is OFF for Phase 1 & 4 and ON for Phase 2 & 3
+
+    Phase 1: Run spatial pooler on the dataset with learning off to get a baseline
+    The boosting factors should be all ones in this phase. A significant fraction
+    of the minicolumns will not be used at all. There will be significant overlap
+    between the first two inputs.
+
+    Phase 2: Learning is on over the next 10 iterations. During this phase,
+    minicolumns that are active frequently will have low boost factors, and minicolumns
+    that are not active enough will have high boost factors. All minicolumns should
+    be active at some point in phase 2.
+
+    Phase 3: Run one more batch on with learning on. Because of the artificially
+    induced thrashing behavior in this test due to boosting, all the inputs should
+    now have pretty distinct patterns.
+    
+    Phase 4: Run spatial pooler with learning off. Make sure boosting factors
+    do not change when learning is off.
+    '''
+
+    def set_up(self):
+        '''
+        set up various constraints. create input patterns and spatial pooler.
+        '''
+
+        self.input_size = 90
+        self.minicolumn_dims = 600
+
+        self.x = np.zeros((5, self.input_size), dtype=uint_type)
+        self.x[0, 0:20] = 1     # pattern A
+        self.x[1, 10:30] = 1    # pattern A' (half of bits overlap with A)
+        self.x[2, 30:50] = 1    # pattern B (no overlap with others)
+        self.x[3, 50:70] = 1    # pattern C (no overlap with others)
+        self.x[4, 70:90] = 1    # pattern D (no overlap with others)
+
+        # for each minicolmn, this will contain the last iteration number where that column was a winner
+        self.winning_iteration = np.zeros(self.minicolumn_dims)
+
+        # for each input vector i, last_sdr[i] contains the most recent SDR output by the SP
+        self.last_sdr = {}
+
+        self.sp = SpatialPooler(
+            input_dims=[self.input_size],
+            minicolumn_dims=[self.minicolumn_dims],
+            num_active_minicolumns_per_inh_area=60,
+            local_density=-1,
+            potential_radius=self.input_size,
+            potential_percent=0.9,
+            global_inhibition=True,
+            stimulus_threshold=0.0,
+            synapse_perm_inc=0.0,
+            synapse_perm_dec=0.0,
+            synapse_perm_connected=0.1,
+            min_percent_overlap_duty_cycles=0.001,
+            duty_cycle_period=10,
+            boost_strength=10.0,
+            seed=SEED
+        )
+
+
+    def verify_sdr_properties(self):
+        '''
+        verify that all SDRs have properties desired for this test.
+
+        the bounds fo checking overlap are loosely set since there is some variance due to randomness and the artificial parameters used in this test.
+        '''
+
+        # verify that all SDRs are unique
+        self.assertTrue(sdrs_unique(self.last_sdr), 'all SDRs are unique')
+
+        # verify that first two SDRs have some overlap
+        self.assertGreater(compute_overlap(self.last_sdr[0], self.last_sdr[1]), 9, 'first two SDRs do not overlap much')
+
+        # verify that last three SDRs have low overlap with everyone else
+        for i in [2, 3, 4]:
+            for j in range(5):
+                if (i != j):
+                    self.assertLess(compute_overlap(self.last_sdr[i], self.last_sdr[j]), 18, 'one of the last three SDRs has high overlap')
+
+    
+    def boost_test_phase1(self):
+        y = np.zeros(self.minicolumn_dims, dtype=uint_type)
+
+        # one batch through input patterns while learning is off
+        for idx, v in enumerate(self.x):
+            y.fill(0)
+            self.sp.compute(v, False, y)
+            self.winning_iteration[y.nonzero()[0]] = self.sp.get_iteration_learn_num()
+            self.last_sdr[idx] = y.copy()
+
+        
+        # boost factor for all minicolumns should be at 1
+        boost = self.sp.get_boost_factors()
+        self.assertEqual((boost == 1).sum(), self.minicolumn_dims, 'boost factors are not all 1')
+
+        # at least half of minicolumns should have never been active
+        self.assertGreaterEqual((self.winning_iteration == 0).sum(), self.minicolumn_dims//2, 'more than half of all minicolumns have been active')
+
+        self.verify_sdr_properties()
+
+    
+    def boost_test_phase2(self):
+        y = np.zeros(self.minicolumn_dims, dtype=uint_type)
+
+        # 10 training batch through input patterns
+        for _ in range(10):
+            for idx, v in enumerate(self.x):
+                y.fill(0)
+                self.sp.compute(v, True, y)
+                self.winning_iteration[y.nonzero()[0]] = self.sp.get_iteration_learn_num()
+                self.last_sdr[idx] = y.copy()
+
+        # all never-active minicolumns should have duty cycle of 0
+        duty_cycles = self.sp.get_active_duty_cycles()
+        self.assertEqual(duty_cycles[self.winning_iteration == 0].sum(), 0, 'inactive minicolumns have positive duty cycle')
+
+        boost = self.sp.get_boost_factors()
+        self.assertLessEqual(np.max(boost[np.where(duty_cycles > 0.1)]), 1.0, 'strongly active minicolumns have high boost factors')
+        self.assertGreaterEqual(np.min(boost[np.where(duty_cycles < 0.1)]), 1.0, 'weakly active columns have low boost factors')
+
+        # every minicolumn should have been sufficiently boosted to win at least once. number of minicolumns that have never won should be 0
+        num_losers_after = (self.winning_iteration == 0).sum()
+        self.assertEqual(num_losers_after, 0)
+
+        # artificially induced thrashing --> even the first two patterns should have low overlap. verify this.
+        self.assertLess(compute_overlap(self.last_sdr[0], self.last_sdr[1]), 7, 'first two SDRs overlap significantly when they should not')
+
+
+    def boost_test_phase3(self):
+        y = np.zeros(self.minicolumn_dims, dtype=uint_type)
+
+        # one more training batch through input patterns
+        for idx, v in enumerate(self.x):
+            y.fill(0)
+            self.sp.compute(v, True, y)
+            self.winning_iteration[y.nonzero()[0]] = self.sp.get_iteration_learn_num()
+            self.last_sdr[idx] = y.copy()
+
+        # by now, every minicolumn should have been sufficiently boosted to win at least once. number of minicolumns that have never won should be 0.
+        num_losers_after = (self.winning_iteration == 0).sum()
+        self.assertEqual(num_losers_after, 0)
+
+        # artificially induced thrashing --> even the first two patterns should have low overlap. verify this.
+        self.assertLess(compute_overlap(self.last_sdr[0], self.last_sdr[1]), 7, 'first two SDRs overlap significantly when they should not')
+
+    
+    def boost_test_phase4(self):
+        y = np.zeros(self.minicolumn_dims, dtype=uint_type)
+        
+        boost_at_beginning = self.sp.get_boost_factors()
+
+        # one more training batch through input parameters with **learning OFF**
+        for idx, v in enumerate(self.x):
+            y.fill(0)
+            self.sp.compute(v, False, y)
+
+            boost = self.sp.get_boost_factors()
+            self.assertEqual(boost.sum(), boost_at_beginning.sum(), 'boost factors changed when learning was off')
+    
+
+    def test_boost(self):
+        self.set_up()
+
+        self.boost_test_phase1()
+        self.boost_test_phase2()
+        self.boost_test_phase3()
+        self.boost_test_phase4() 
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/packages/spatial_pooler/tests/spatial_pooler_compute_test.py
+++ b/packages/spatial_pooler/tests/spatial_pooler_compute_test.py
@@ -1,0 +1,129 @@
+# ----------------------------------------------------------------------
+# Numenta Platform for Intelligent Computing (NuPIC)
+# Copyright (C) 2022, Numenta, Inc.  Unless you have an agreement
+# with Numenta, Inc., for a separate license for this software code, the
+# following terms and conditions apply:
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# See the GNU Affero Public License for more details.
+#
+# You should have received a copy of the GNU Affero Public License
+# along with this program.  If not, see http://www.gnu.org/licenses.
+#
+# http://numenta.org/licenses/
+# ----------------------------------------------------------------------
+
+import numpy as np
+import time 
+import unittest
+
+from nupic.research.frameworks.spatial_pooler import SpatialPooler
+
+real_type = np.float32
+uint_type = np.uint32
+
+
+class SpatialPoolerComputeTest(unittest.TestCase):
+    '''
+    end-to-end test of the compute function
+    '''
+
+    def basic_compute_loop(self, sp, input_size, minicolumn_dims):
+        '''
+        feed in some vectors and retrieve outputs. ensure the right number of minicolumns win and that we always get binary outputs. 
+        '''
+
+        num_records = 100
+        generator = np.random.default_rng()
+
+        input_matrix = (generator.random((num_records, input_size)) > 0.8).astype(uint_type)
+
+        y = np.zeros(minicolumn_dims, dtype=uint_type)
+
+        # with learning
+        for v in input_matrix:
+            y.fill(0)
+            sp.compute(v, True, y)
+            self.assertEqual(sp.num_active_minicolumns_per_inh_area, y.sum())
+            self.assertEqual(0, y.min())
+            self.assertEqual(1, y.max())
+
+        # without learning
+        for v in input_matrix:
+            y.fill(0)
+            sp.compute(v, False, y)
+            self.assertEqual(sp.num_active_minicolumns_per_inh_area, y.sum())
+            self.assertEqual(0, y.min())
+            self.assertEqual(1, y.max())
+
+
+    def test_basic_compute1(self):
+        '''
+        run basic_compute_loop with mostly default parameters.
+        '''
+        
+        input_size = 30
+        minicolumn_dims = 50
+
+        sp = SpatialPooler(
+            input_dims=[input_size],
+            minicolumn_dims=[minicolumn_dims],
+            num_active_minicolumns_per_inh_area=10,
+            local_density=-1,
+            potential_radius=input_size,
+            potential_percent=0.5,
+            global_inhibition=True,
+            stimulus_threshold=0.0,
+            synapse_perm_inc=0.05,
+            synapse_perm_dec=0.008,
+            synapse_perm_connected=0.1,
+            min_percent_overlap_duty_cycles=0.001,
+            duty_cycle_period=1000,
+            boost_strength=0.0,
+            seed=int((time.time() % 10000)*10)
+        )
+
+        print('test_basic_compute1, SP seed set to:', sp.seed)
+
+        self.basic_compute_loop(sp, input_size, minicolumn_dims)
+    
+
+    def test_basic_compute2(self):
+        '''
+        run basic_compute_loop with learning turned off. 
+        '''
+        
+        input_size = 100
+        minicolumn_dims = 100
+
+        sp = SpatialPooler(
+            input_dims=[input_size],
+            minicolumn_dims=[minicolumn_dims],
+            num_active_minicolumns_per_inh_area=10,
+            local_density=-1,
+            potential_radius=input_size,
+            potential_percent=0.5,
+            global_inhibition=True,
+            stimulus_threshold=0.0,
+            synapse_perm_inc=0.0,
+            synapse_perm_dec=0.0,
+            synapse_perm_connected=0.1,
+            min_percent_overlap_duty_cycles=0.001,
+            duty_cycle_period=1000,
+            boost_strength=0.0,
+            seed=int((time.time() % 10000)*10)
+        )
+
+        print('test_basic_compute2, SP seed set to:', sp.seed)
+
+        self.basic_compute_loop(sp, input_size, minicolumn_dims)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/packages/spatial_pooler/tests/spatial_pooler_unit_test.py
+++ b/packages/spatial_pooler/tests/spatial_pooler_unit_test.py
@@ -1,0 +1,1371 @@
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# See the GNU Affero Public License for more details.
+#
+# You should have received a copy of the GNU Affero Public License
+# along with this program.  If not, see http://www.gnu.org/licenses.
+#
+# http://numenta.org/licenses/
+# ----------------------------------------------------------------------
+
+import numpy as np
+import time 
+import unittest
+from unittest.mock import Mock
+from copy import copy
+
+from nupic.research.frameworks.spatial_pooler import SpatialPooler
+
+real_type = np.float32
+uint_type = np.uint32
+
+SEED = int((time.time() % 10000) * 10)
+
+
+class SpatialPoolerUnitTest(unittest.TestCase):
+    ''' 
+    unit tests for SpatialPooler class. 
+    '''
+
+    def setUp(self):
+        '''
+        create spatial pooler's base parameters.
+        '''
+
+        self.base_params = {
+            'input_dims' : [5],
+            'minicolumn_dims' : [5],
+            'num_active_minicolumns_per_inh_area' : 3,
+            'local_density' : -1,
+            'potential_radius' : 5,
+            'potential_percent' : 0.5,
+            'global_inhibition' : False,
+            'stimulus_threshold' : 0.0,
+            'synapse_perm_inc' : 0.1,
+            'synapse_perm_dec' : 0.01,
+            'synapse_perm_connected' : 0.1,
+            'min_percent_overlap_duty_cycles' : 0.1,
+            'duty_cycle_period' : 10,
+            'boost_strength' : 10.0,
+            'seed' : SEED
+        }
+
+
+    def test_compute1(self):
+        '''
+        check that feeding in same input vectors leads to polarized permanence values: either zeros or ones but no fractions
+        '''
+
+        sp = SpatialPooler(
+            input_dims=[9],
+            minicolumn_dims=[5],
+            num_active_minicolumns_per_inh_area=3,
+            local_density=-1,
+            potential_radius=3,
+            potential_percent=0.5,
+            global_inhibition=False,
+            stimulus_threshold=1,
+            synapse_perm_inc=0.1,
+            synapse_perm_dec=0.1,
+            synapse_perm_connected=0.1,
+            min_percent_overlap_duty_cycles=0.1,
+            duty_cycle_period=10,
+            boost_strength=10.0,
+            seed=SEED
+        )
+
+        sp.potential_pools = np.ones((sp.num_minicolumns, sp.num_inputs))
+
+        # mock that all minicolumns have won during the local inhibition process
+        sp.inhibit_minicolumns = Mock(return_value=np.array(range(5)))
+
+        input_vector = np.array([1, 0, 1, 0, 1, 0, 0, 1, 1])
+        active_array = np.zeros(5)
+
+        for i in range(20):
+            sp.compute(input_vector, True, active_array)
+        
+        for i in range(sp.num_minicolumns):
+            permanence = sp.get_permanences()[i, :]
+
+            self.assertEqual(list(permanence), list(input_vector))
+        
+
+    def test_compute2(self):
+        '''
+        check that minicolumns only change the permanence values for inputs that are within their potential pool
+        '''
+
+        sp = SpatialPooler(
+            input_dims=[10],
+            minicolumn_dims=[5],
+            num_active_minicolumns_per_inh_area=3,
+            local_density=-1,
+            potential_radius=3,
+            potential_percent=0.5,
+            global_inhibition=False,
+            stimulus_threshold=1,
+            synapse_perm_inc=0.1,
+            synapse_perm_dec=0.01,
+            synapse_perm_connected=0.1,
+            min_percent_overlap_duty_cycles=0.1,
+            duty_cycle_period=10,
+            boost_strength=10.0,
+            seed=SEED
+        )
+
+        # mock that all minicolumns have won during the local inhibition process
+        self.inhibit_minicolumns = Mock(return_value=np.array((range(5))))
+
+        input_vector = np.ones(sp.num_inputs)
+        active_array = np.zeros(5)
+
+        for i in range(20):
+            sp.compute(input_vector, True, active_array)
+
+        for i in range(sp.num_minicolumns):
+            potential = sp.get_potential_pools()[i, :]
+            permanence = sp.get_permanences()[i, :]
+
+            self.assertEqual(list(potential), list(permanence))
+
+
+    def test_ZeroOverlap_NoStimulusThreshold_GlobalInhibition(self):
+        ''' 
+        when stimulus_threshold is 0, allow minicolumns without any overlap to become active. focuses on global inhibition.
+        '''
+
+        input_size = 10
+        num_minicolumns = 20
+
+        sp = SpatialPooler(
+            input_dims=[input_size],
+            minicolumn_dims=[num_minicolumns],
+            num_active_minicolumns_per_inh_area=3,
+            potential_radius=10,
+            global_inhibition=True,
+            stimulus_threshold=0,
+            seed=SEED
+        )
+
+        input_vector = np.zeros(input_size)
+        active_array = np.zeros(num_minicolumns)
+
+        sp.compute(input_vector, True, active_array)
+
+        self.assertEqual(len(active_array.nonzero()[0]), 3)
+
+
+    def test_ZeroOverlap_StimulusThreshold_GlobalInhibition(self):
+        ''' 
+        when stimulus_threshold is > 0, don't allow minicolumns without any overlap to become active. focuses on global inhibition.
+        '''
+
+        input_size = 10
+        num_minicolumns = 20
+
+        sp = SpatialPooler(
+            input_dims=[input_size],
+            minicolumn_dims=[num_minicolumns],
+            num_active_minicolumns_per_inh_area=3,
+            potential_radius=10,
+            global_inhibition=True,
+            stimulus_threshold=1,
+            seed=SEED
+        )
+
+        input_vector = np.zeros(input_size)
+        active_array = np.zeros(num_minicolumns)
+
+        sp.compute(input_vector, True, active_array)
+
+        self.assertEqual(len(active_array.nonzero()[0]), 0)
+
+    
+    def test_ZeroOverlap_NoStimulusThreshold_LocalInhibition(self):
+        '''
+        when stimulus_threshold is 0, allow minicolumns without any overlap to become active. focuses on local inhibition.
+        '''
+        
+        input_size = 10
+        num_minicolumns = 20
+
+        sp = SpatialPooler(
+            input_dims=[input_size],
+            minicolumn_dims=[num_minicolumns],
+            num_active_minicolumns_per_inh_area=1,
+            potential_radius=5,
+            global_inhibition=False,
+            stimulus_threshold=0,
+            seed=SEED
+        )
+
+        sp.set_inhibition_radius(2)
+
+        input_vector = np.zeros(input_size)
+        active_array = np.zeros(num_minicolumns)
+
+        sp.compute(input_vector, True, active_array)
+
+        self.assertEqual(len(active_array.nonzero()[0]), 7)
+
+    
+    def test_ZeroOverlap_StimulusThreshold_LocalInhibition(self):
+        ''' 
+        when stimulus threshold is > 0, don't allow minicolumns without any overlap to become active. focuses on local inhibition.
+        '''
+
+        input_size = 10
+        num_minicolumns = 20
+
+        sp = SpatialPooler(
+            input_dims=[input_size],
+            minicolumn_dims=[num_minicolumns],
+            num_active_minicolumns_per_inh_area=3,
+            potential_radius=10,
+            global_inhibition=False,
+            stimulus_threshold=1,
+            seed=SEED
+        )
+
+        input_vector = np.zeros(input_size)
+        active_array = np.zeros(num_minicolumns)
+
+        sp.compute(input_vector, True, active_array)
+
+        self.assertEqual(len(active_array.nonzero()[0]), 0)
+
+    
+    def test_overlaps_output(self):
+        ''' 
+        check that overlaps and boosted_overlaps are correctly returned.
+        '''
+
+        sp = SpatialPooler(
+            input_dims=[5],
+            minicolumn_dims=[3],
+            num_active_minicolumns_per_inh_area=5,
+            potential_radius=5,
+            synapse_perm_inc=0.1,
+            synapse_perm_dec=0.1,
+            global_inhibition=True,
+            seed=1
+        )
+        
+        input_vector = np.ones(5)
+        active_array = np.zeros(3)
+
+        expected_output = np.array([2, 1, 1], dtype=real_type)
+
+        boost_factors = 2.0 * np.ones(3)
+        sp.set_boost_factors(boost_factors)
+
+        sp.compute(input_vector, True, active_array)
+
+        overlaps = sp.get_overlaps()
+        boosted_overlaps = sp.get_boosted_overlaps()
+
+        for i in range(sp.get_num_minicolumns()):
+            self.assertEqual(overlaps[i], expected_output[i])
+            self.assertEqual(boosted_overlaps[i], (2 * expected_output[i]))
+
+    
+    def test_exact_output(self):
+        '''
+        given a specific input and initialization, SP should return this exact output.
+        '''
+
+        expected_output = [
+            101, 115, 149, 180, 252, 328, 391, 433, 577, 612, 700, 799, 805, 861, 864, 
+            1122, 1161, 1252, 1336, 1352, 1498, 1576, 1584, 1600, 1688, 1731, 1786,
+            1793, 1850, 1872, 1975, 1980, 1983, 1996, 2011, 2016, 2021, 2037, 2043, 
+            2046
+        ]
+
+        sp = SpatialPooler(
+            input_dims=(1, 188),
+            minicolumn_dims=(2048, 1),
+            num_active_minicolumns_per_inh_area=40,
+            local_density=-1.0,
+            potential_radius=94,
+            potential_percent=0.5,
+            global_inhibition=True,
+            stimulus_threshold=0,
+            synapse_perm_inc=0.1,
+            synapse_perm_dec=0.01,
+            synapse_perm_connected=0.1,
+            min_percent_overlap_duty_cycles=0.001,
+            duty_cycle_period=1000,
+            boost_strength=10.0,
+            seed=1956
+        )
+
+        input_vector = [
+            1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0,
+            0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+            0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+            0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 1.0, 1.0,
+            1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+            0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+            0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+            0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+            0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+            0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+            0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+            0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0,
+            1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0,
+            1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 0.0, 0.0, 0.0, 0.0,
+            0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+            0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0
+        ]
+        input_vector = np.array(input_vector, dtype=real_type)
+
+        active_array = np.zeros(2048)
+
+        sp.compute(input_vector, True, active_array)
+
+        sp_output = [i for i, v in enumerate(active_array) if v != 0]
+
+        self.assertEqual(sorted(sp_output), sorted(expected_output))
+
+
+    def test_strip_never_learned(self):
+        '''
+        verify that the expected set of unlearned minicolumns matches the computed result.
+        '''
+
+        def strip_unlearned_minicolumns(active_duty_cycles, active_array):
+            '''
+            remove set of minicolumns that have never been active from set of active minicolumns.
+            '''
+
+            never_learned = np.where(active_duty_cycles == 0)[0]
+            active_array[never_learned] = 0
+
+
+        sp = SpatialPooler(**self.base_params)
+
+        sp.active_duty_cycles = np.array([0.5, 0.1, 0, 0.2, 0.4, 0])
+        active_array = np.array([1, 1, 1, 0, 1, 0])
+        strip_unlearned_minicolumns(sp.get_active_duty_cycles(), active_array)
+        stripped = np.where(active_array == 1)[0]
+        true_stripped = [0, 1, 4]
+        self.assertListEqual(true_stripped, list(stripped))
+
+        sp.active_duty_cycles = np.array([0.9, 0, 0, 0, 0.4, 0.3])
+        active_array = np.ones(6)
+        strip_unlearned_minicolumns(sp.get_active_duty_cycles(), active_array)
+        stripped = np.where(active_array == 1)[0]
+        true_stripped = [0, 4, 5]
+        self.assertListEqual(true_stripped, list(stripped))
+
+        sp.active_duty_cycles = np.array([0, 0, 0, 0, 0, 0])
+        active_array = np.ones(6)
+        strip_unlearned_minicolumns(sp.get_active_duty_cycles(), active_array)
+        stripped = np.where(active_array == 1)[0]
+        true_stripped = []
+        self.assertListEqual(true_stripped, list(stripped))
+
+        sp.active_duty_cycles = np.ones(6)
+        active_array = np.ones(6)
+        strip_unlearned_minicolumns(sp.get_active_duty_cycles(), active_array)
+        stripped = np.where(active_array == 1)[0]
+        true_stripped = range(6)
+        self.assertListEqual(list(true_stripped), list(stripped))
+
+
+    def test_map_minicolumn(self):
+        params = self.base_params.copy()
+
+        # test 1D
+        params.update({
+            'input_dims' : [12],
+            'minicolumn_dims' : [4]
+        })
+        sp = SpatialPooler(**params)
+
+        self.assertEqual(sp.map_minicolumn(0), 1)
+        self.assertEqual(sp.map_minicolumn(1), 4)
+        self.assertEqual(sp.map_minicolumn(2), 7)
+        self.assertEqual(sp.map_minicolumn(3), 10)
+
+
+        # test 1D with same dimensions of minicolumns and inputs
+        params.update({
+            'input_dims' : [4],
+            'minicolumn_dims' : [4]
+        })
+        sp = SpatialPooler(**params)
+
+        self.assertEqual(sp.map_minicolumn(0), 0)
+        self.assertEqual(sp.map_minicolumn(1), 1)
+        self.assertEqual(sp.map_minicolumn(2), 2)
+        self.assertEqual(sp.map_minicolumn(3), 3)
+
+
+        # test 1D with dimensions of length 1
+        params.update({
+            'input_dims' : [1],
+            'minicolumn_dims' : [1]
+        })
+        sp = SpatialPooler(**params)
+
+        self.assertEqual(sp.map_minicolumn(0), 0)
+
+
+        # test 2D
+        params.update({
+            'input_dims' : [36, 12],
+            'minicolumn_dims' : [12, 4]
+        })
+        sp = SpatialPooler(**params)
+
+        self.assertEqual(sp.map_minicolumn(0), 13)
+        self.assertEqual(sp.map_minicolumn(4), 49)
+        self.assertEqual(sp.map_minicolumn(5), 52)
+        self.assertEqual(sp.map_minicolumn(7), 58)
+        self.assertEqual(sp.map_minicolumn(47), 418)
+
+
+        # test 2D with some input dimensions smaller than minicolumn dimensions
+        params.update({
+            'input_dims' : [3, 5],
+            'minicolumn_dims' : [4, 4]
+        })
+        sp = SpatialPooler(**params)
+
+        self.assertEqual(sp.map_minicolumn(0), 0)
+        self.assertEqual(sp.map_minicolumn(3), 4)
+        self.assertEqual(sp.map_minicolumn(15), 14)
+
+
+    def test_map_potential_1D(self):
+        params = self.base_params.copy()
+
+        params.update({
+            'input_dims' : [12],
+            'minicolumn_dims' : [4],
+            'potential_radius' : 2,
+        })
+
+        params['potential_percent'] = 1
+        sp = SpatialPooler(**params)
+
+        expected_mask = [1, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0]
+        mask = sp.map_potential(0)
+        self.assertListEqual(mask.tolist(), expected_mask)
+
+        expected_mask = [0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 0, 0]
+        mask = sp.map_potential(2)
+        self.assertListEqual(mask.tolist(), expected_mask)
+
+
+    def test_map_potential_2D(self):
+        params = self.base_params.copy()
+
+        params.update({
+            'input_dims': [6, 12],
+            'minicolumn_dims': [2, 4],
+            'potential_radius': 1,
+            'potential_percent': 1,
+        })
+
+        sp = SpatialPooler(**params)
+
+        true_indices = [
+            0, 12, 24,
+            1, 13, 25,
+            2, 14, 26
+        ]
+        mask = sp.map_potential(0)
+        self.assertSetEqual(set(np.flatnonzero(mask).tolist()), set(true_indices))
+
+        true_indices = [
+            6, 18, 30,
+            7, 19, 31,
+            8, 20, 32
+        ]
+        mask = sp.map_potential(2)
+        self.assertSetEqual(set(np.flatnonzero(mask).tolist()), set(true_indices))
+
+
+    def test_map_potential_1_minicolumn_1_input(self):
+        params = self.base_params.copy()
+
+        params.update({
+            'input_dims': [1],
+            'minicolumn_dims': [1],
+            'potential_radius': 2,
+            'potential_percent' : 1,
+        })
+
+        sp = SpatialPooler(**params)
+
+        expected_mask = [1]
+        mask = sp.map_potential(0)
+        self.assertListEqual(mask.tolist(), expected_mask)
+
+
+    def test_inhibit_minicolumns(self):
+        params = self.base_params.copy()
+
+        sp = SpatialPooler(**params)
+
+        sp.inhibit_minicolumns_global = Mock(return_value = 1)
+        sp.inhibit_minicolumns_local = Mock(return_value = 2)
+        sp.num_minicolumns = 5
+        sp.inhibition_radius = 10
+        sp.minicolumn_dims = [5]
+        overlaps = sp.generator.choice(sp.num_minicolumns)
+
+        sp.inhibit_minicolumns_global.reset_mock()
+        sp.inhibit_minicolumns_local.reset_mock()
+        sp.num_active_minicolumns_per_inh_area = 5
+        sp.local_density = 0.1
+        sp.global_inhibition = True
+        sp.inhibition_radius = 5
+        true_density = sp.local_density
+        sp.inhibit_minicolumns(overlaps)
+        self.assertEqual(True, sp.inhibit_minicolumns_global.called)
+        self.assertEqual(False, sp.inhibit_minicolumns_local.called)
+        density = sp.inhibit_minicolumns_global.call_args[0][1]
+        self.assertEqual(true_density, density)
+
+        sp.inhibit_minicolumns_global.reset_mock()
+        sp.inhibit_minicolumns_local.reset_mock()
+        sp.num_minicolumns = 500
+        sp.minicolumn_dims = np.array([50, 10])
+        sp.num_active_minicolumns_per_inh_area = -1
+        sp.local_density = 0.1
+        sp.global_inhibition = False
+        sp.inhibition_radius = 7
+        true_density = sp.local_density
+        overlaps = sp.generator.choice(sp.num_minicolumns)
+        sp.inhibit_minicolumns(overlaps)
+        self.assertEqual(False, sp.inhibit_minicolumns_global.called)
+        self.assertEqual(True, sp.inhibit_minicolumns_local.called)
+        self.assertEqual(true_density, density)
+
+        # test translation of num_minicolumns_per_inh_area into local area density
+        sp.num_minicolumns = 1000
+        sp.minicolumn_dims = np.array([100, 10])
+        sp.inhibit_minicolumns_global.reset_mock()
+        sp.inhibit_minicolumns_local.reset_mock()
+        sp.num_active_minicolumns_per_inh_area = 3
+        sp.local_density = -1
+        sp.global_inhibition = False
+        sp.inhibition_radius = 4
+        true_density = 3.0/81.0
+        overlaps = sp.generator.choice(sp.num_minicolumns)
+        # 3.0 / (((2*4) + 1) ** 2)
+        sp.inhibit_minicolumns(overlaps)
+        self.assertEqual(False, sp.inhibit_minicolumns_global.called)
+        self.assertEqual(True, sp.inhibit_minicolumns_local.called)
+        density = sp.inhibit_minicolumns_local.call_args[0][1]
+        self.assertEqual(true_density, density)
+
+        # test clipping of local area density to 0.5
+        sp.num_minicolumns = 1000
+        sp.minicolumn_dims = np.array([100, 10])
+        sp.inhibit_minicolumns_global.reset_mock()
+        sp.inhibit_minicolumns_local.reset_mock()
+        sp.num_active_minicolumns_per_inh_area = 7
+        sp.local_density = -1
+        sp.global_inhibition = False
+        sp.inhibition_radius = 1
+        true_density = 0.5
+        overlaps = sp.generator.choice(sp.num_minicolumns)
+        sp.inhibit_minicolumns(overlaps)
+        self.assertEqual(False, sp.inhibit_minicolumns_global.called)
+        self.assertEqual(True, sp.inhibit_minicolumns_local.called)
+        density = sp.inhibit_minicolumns_local.call_args[0][1]
+        self.assertEqual(true_density, density)
+
+    
+    def test_update_inhibition_radius(self):
+        params = self.base_params.copy()
+
+        sp = SpatialPooler(**params)
+
+        # test global inhibition case
+        sp.global_inhibition = True
+        sp.minicolumn_dims = np.array([57, 31, 2])
+        sp.update_inhibition_radius()
+        self.assertEqual(sp.inhibition_radius, 57)
+
+        sp.global_inhibition = False
+        sp.average_connected_synapses_per_minicolumn = Mock(return_value = 3)
+        sp.average_minicolumns_per_input = Mock(return_value = 4)
+        true_inhibition_radius = 6
+        # ((3 * 4) - 1) / 2 => round up
+        sp.update_inhibition_radius()
+        self.assertEqual(true_inhibition_radius, sp.inhibition_radius)
+
+        # test clipping at 1.0
+        sp.global_inhibition = False
+        sp.average_connected_synapses_per_minicolumn = Mock(return_value = 0.5)
+        sp.average_minicolumns_per_input = Mock(return_value = 1.2)
+        true_inhibition_radius = 1
+        sp.update_inhibition_radius()
+        self.assertEqual(true_inhibition_radius, sp.inhibition_radius)
+
+        # test rounding up
+        sp.global_inhibition = False
+        sp.average_connected_synapses_per_minicolumn = Mock(return_value = 2.4)
+        sp.average_minicolumns_per_input = Mock(return_value = 2)
+        true_inhibition_radius = 2
+        # ((2 * 2.4) - 1) / 2.0 => round up
+        sp.update_inhibition_radius()
+        self.assertEqual(true_inhibition_radius, sp.inhibition_radius)
+
+
+    def test_average_minicolumns_per_input(self):
+        params = self.base_params.copy()
+
+        sp = SpatialPooler(**params)
+
+        sp.minicolumn_dims = np.array([2, 2, 2, 2])
+        sp.input_dims = np.array([4, 4, 4, 4])
+        self.assertEqual(sp.average_minicolumns_per_input(), 0.5)
+
+        sp.minicolumn_dims = np.array([2, 2, 2, 2])
+        sp.input_dims = np.array(     [7, 5, 1, 3])
+                                   #  2/7 0.4 2 0.666
+        true_average_minicolumns_per_input = (2.0/7 + 2.0/5 + 2.0/1 + 2/3.0) / 4
+        self.assertEqual(sp.average_minicolumns_per_input(), true_average_minicolumns_per_input)
+
+        sp.minicolumn_dims = np.array([3, 3])
+        sp.input_dims = np.array(     [3, 3])
+                                   #   1  1
+        true_average_minicolumns_per_input = 1
+        self.assertEqual(sp.average_minicolumns_per_input(), true_average_minicolumns_per_input)
+
+        sp.minicolumn_dims = np.array([25])
+        sp.input_dims = np.array(     [5])
+                                   #   5
+        true_average_minicolumns_per_input = 5
+        self.assertEqual(sp.average_minicolumns_per_input(), true_average_minicolumns_per_input)
+
+        sp.minicolumn_dims = np.array([3, 3, 3, 5, 5, 6, 6])
+        sp.input_dims = np.array(     [3, 3, 3, 5, 5, 6, 6])
+                                   #   1  1  1  1  1  1  1
+        true_average_minicolumns_per_input = 1
+        self.assertEqual(sp.average_minicolumns_per_input(), true_average_minicolumns_per_input)
+
+        sp.minicolumn_dims = np.array([3, 6, 9, 12])
+        sp.input_dims = np.array(     [3, 3, 3 , 3])
+                                   #   1  2  3   4
+        true_average_minicolumns_per_input = 2.5
+        self.assertEqual(sp.average_minicolumns_per_input(), true_average_minicolumns_per_input)
+
+
+    def test_average_connected_span_for_minicolumn_1D(self):
+        params = self.base_params.copy()
+
+        sp = SpatialPooler(**params)
+
+        sp.num_minicolumns = 9
+        sp.minicolumn_dims = np.array([9])
+        sp.input_dims = np.array([12])
+        sp.connected_synapses = np.array(
+            [
+                [0, 1, 0, 1, 0, 1, 0, 1],
+                [0, 0, 0, 1, 0, 0, 0, 1],
+                [0, 0, 0, 0, 0, 0, 1, 0],
+                [0, 0, 1, 0, 0, 0, 1, 0],
+                [0, 0, 0, 0, 0, 0, 0, 0],
+                [0, 1, 1, 0, 0, 0, 0, 0],
+                [0, 0, 1, 1, 1, 0, 0, 0],
+                [0, 0, 1, 0, 1, 0, 0, 0],
+                [1, 1, 1, 1, 1, 1, 1, 1]
+            ]
+        )
+
+        true_average_connected_span = [7, 5, 1, 5, 0, 2, 3, 3, 8]
+        
+        for i in range(sp.num_minicolumns):
+            connected_span = sp.average_connected_synapses_per_minicolumn(i)
+            self.assertEqual(true_average_connected_span[i], connected_span)
+
+
+    def test_average_connected_span_for_minicolumn_2D(self):
+        params = self.base_params.copy()
+
+        sp = SpatialPooler(**params)
+
+        sp.num_minicolumns = 9
+        sp.minicolumn_dims = np.array([9])
+        sp.num_inputs = 8
+        sp.input_dims = np.array([8])
+        sp.connected_synapses = np.array(
+            [
+                [0, 1, 0, 1, 0, 1, 0, 1],
+                [0, 0, 0, 1, 0, 0, 0, 1],
+                [0, 0, 0, 0, 0, 0, 1, 0],
+                [0, 0, 1, 0, 0, 0, 1, 0],
+                [0, 0, 0, 0, 0, 0, 0, 0],
+                [0, 1, 1, 0, 0, 0, 0, 0],
+                [0, 0, 1, 1, 1, 0, 0, 0],
+                [0, 0, 1, 0, 1, 0, 0, 0],
+                [1, 1, 1, 1, 1, 1, 1, 1]
+            ]
+        )
+
+        true_average_connected_span = [7, 5, 1, 5, 0, 2, 3, 3, 8]
+
+        for i in range(sp.num_minicolumns):
+            connected_span = sp.average_connected_synapses_per_minicolumn(i)
+            self.assertEqual(true_average_connected_span[i], connected_span)
+
+        sp.num_minicolumns = 7
+        sp.minicolumn_dims = np.array([7])
+        sp.num_inputs = 20
+        sp.input_dims = np.array([5, 4])
+        sp.connected_synapses = np.zeros((sp.num_minicolumns, sp.num_inputs))
+
+        connected = np.array([
+            [[0, 1, 1, 1],
+            [0, 1, 1, 1],
+            [0, 1, 1, 1],
+            [0, 0, 0, 0],
+            [0, 0, 0, 0]],
+            # rowspan = 3, colspan = 3, avg = 3
+
+            [[1, 1, 1, 1],
+            [0, 0, 1, 1],
+            [0, 0, 0, 0],
+            [0, 0, 0, 0],
+            [0, 0, 0, 0]],
+            # rowspan = 2 colspan = 4, avg = 3
+
+            [[1, 0, 0, 0],
+            [0, 0, 0, 0],
+            [0, 0, 0, 0],
+            [0, 0, 0, 0],
+            [0, 0, 0, 1]],
+            # row span = 5, colspan = 4, avg = 4.5
+
+            [[0, 1, 0, 0],
+            [0, 0, 0, 0],
+            [0, 0, 0, 0],
+            [0, 1, 0, 0],
+            [0, 1, 0, 0]],
+            # rowspan = 5, colspan = 1, avg = 3
+
+            [[0, 0, 0, 0],
+            [1, 0, 0, 1],
+            [0, 0, 0, 0],
+            [0, 0, 0, 0],
+            [0, 0, 0, 0]],
+            # rowspan = 1, colspan = 4, avg = 2.5
+
+            [[0, 0, 0, 0],
+            [0, 0, 0, 0],
+            [0, 0, 0, 0],
+            [0, 0, 1, 0],
+            [0, 0, 0, 1]],
+            # rowspan = 2, colspan = 2, avg = 2
+
+            [[0, 0, 0, 0],
+            [0, 0, 0, 0],
+            [0, 0, 0, 0],
+            [0, 0, 0, 0],
+            [0, 0, 0, 0]]
+            # rowspan = 0, colspan = 0, avg = 0
+        ])
+
+        true_average_connected_span = [3, 3, 4.5, 3, 2.5, 2, 0]
+        for column_index in range(sp.num_minicolumns):
+            sp.connected_synapses[column_index, :] = connected[column_index,:].reshape(-1)
+
+        for i in range(sp.num_minicolumns):
+            connectedSpan = sp.average_connected_synapses_per_minicolumn(i)
+            self.assertEqual(true_average_connected_span[i], connectedSpan)
+
+
+    def test_average_connected_span_for_minicolumn_ND(self):
+        params = self.base_params.copy()
+
+        sp = SpatialPooler(**params)
+
+        sp.input_dims = np.array([4, 4, 2, 5])
+        sp.num_inputs = np.prod(sp.input_dims)
+        sp.num_minicolumns = 5
+        sp.minicolumn_dims = np.array([5])
+        sp.connected_synapses = np.zeros((sp.num_minicolumns, sp.num_inputs))
+
+        connected = np.zeros(sp.num_inputs).reshape(sp.input_dims)
+        connected[1][0][1][0] = 1
+        connected[1][0][1][1] = 1
+        connected[3][2][1][0] = 1
+        connected[3][0][1][0] = 1
+        connected[1][0][1][3] = 1
+        connected[2][2][1][0] = 1
+        # span:   3  3  1  4, avg = 11/4
+        sp.connected_synapses[0,:] = connected.reshape(-1)
+
+        connected = np.zeros(sp.num_inputs).reshape(sp.input_dims)
+        connected[2][0][1][0] = 1
+        connected[2][0][0][0] = 1
+        connected[3][0][0][0] = 1
+        connected[3][0][1][0] = 1
+        # spn:    2  1  2  1, avg = 6/4
+        sp.connected_synapses[1,:] = connected.reshape(-1)
+
+        connected = np.zeros(sp.num_inputs).reshape(sp.input_dims)
+        connected[0][0][1][4] = 1
+        connected[0][0][0][3] = 1
+        connected[0][0][0][1] = 1
+        connected[1][0][0][2] = 1
+        connected[0][0][1][1] = 1
+        connected[3][3][1][1] = 1
+        # span:   4  4  2  4, avg = 14/4
+        sp.connected_synapses[2,:] = connected.reshape(-1)
+
+        connected = np.zeros(sp.num_inputs).reshape(sp.input_dims)
+        connected[3][3][1][4] = 1
+        connected[0][0][0][0] = 1
+        # span:   4  4  2  5, avg = 15/4
+        sp.connected_synapses[3,:] = connected.reshape(-1)
+
+        connected = np.zeros(sp.num_inputs).reshape(sp.input_dims)
+        # span:   0  0  0  0, avg = 0
+        sp.connected_synapses[4,:] = connected.reshape(-1)
+
+        true_average_connected_span = [11.0/4, 6.0/4, 14.0/4, 15.0/4, 0]
+
+        for i in range(sp.num_minicolumns):
+            connected_span = sp.average_connected_synapses_per_minicolumn(i)
+            self.assertAlmostEqual(true_average_connected_span[i], connected_span)
+
+
+    def test_bump_up_weak_minicolumns(self):
+        sp = SpatialPooler(
+            input_dims=[8], 
+            minicolumn_dims=[5]
+        )
+
+        sp.synapse_perm_below_stimulus_inc = 0.01
+        sp.synapse_perm_trim_threshold = 0.05
+        sp.overlap_duty_cycles = np.array([0, 0.009, 0.1, 0.001, 0.002])
+        sp.min_overlap_duty_cycles = np.array(5*[0.01])
+
+        sp.potential_pools = np.array(
+            [[1, 1, 1, 1, 0, 0, 0, 0],
+            [1, 0, 0, 0, 1, 1, 0, 1],
+            [0, 0, 1, 0, 1, 1, 1, 0],
+            [1, 1, 1, 0, 0, 0, 1, 0],
+            [1, 1, 1, 1, 1, 1, 1, 1]]
+        )
+
+        sp.permanences = np.array(
+            [[0.200, 0.120, 0.090, 0.040, 0.000, 0.000, 0.000, 0.000],
+            [0.150, 0.000, 0.000, 0.000, 0.180, 0.120, 0.000, 0.450],
+            [0.000, 0.000, 0.014, 0.000, 0.032, 0.044, 0.110, 0.000],
+            [0.041, 0.000, 0.000, 0.000, 0.000, 0.000, 0.178, 0.000],
+            [0.100, 0.738, 0.045, 0.002, 0.050, 0.008, 0.208, 0.034]]
+        )
+
+        true_permanences = [
+            [0.210, 0.130, 0.100, 0.000, 0.000, 0.000, 0.000, 0.000],
+        #    Inc    Inc    Inc    Trim     -      -      -      -
+            [0.160, 0.000, 0.000, 0.000, 0.190, 0.130, 0.000, 0.460],
+        #    Inc      -      -       -     Inc   Inc    -      Inc
+            [0.000, 0.000, 0.014, 0.000, 0.032, 0.044, 0.110, 0.000],
+        #    -        -      -      -      -      -      -     -
+            [0.051, 0.000, 0.000, 0.000, 0.000, 0.000, 0.188, 0.000],
+        #    Inc   Trim    Trim     -      -      -    Inc      -
+            [0.110, 0.748, 0.055, 0.000, 0.060, 0.000, 0.218, 0.000]
+        ]
+
+        sp.bump_up_weak_minicolumns()
+        for i in range(sp.num_minicolumns):
+            perm = list(sp.permanences[i,:])
+            for j in range(sp.num_inputs):
+                self.assertAlmostEqual(true_permanences[i][j], perm[j])
+
+
+    def test_update_min_duty_cycle_local(self):
+        sp = SpatialPooler(
+            input_dims=(5,),
+            minicolumn_dims=(8,),
+            global_inhibition=False,
+        )
+
+        sp.set_inhibition_radius(1)
+        sp.set_overlap_duty_cycles(np.array([0.7, 0.1, 0.5, 0.01, 0.78, 0.55, 0.1, 0.001]))
+        sp.set_active_duty_cycles(np.array([0.9, 0.3, 0.5, 0.7, 0.1, 0.01, 0.08, 0.12]))
+        sp.set_min_percent_overlap_duty_cycles(0.2)
+        sp.update_min_duty_cycles_local()
+
+        result_min_overlap_duty_cycles = sp.get_min_overlap_duty_cycles()
+        for actual, expected in zip(result_min_overlap_duty_cycles, [0.14, 0.14, 0.1, 0.156, 0.156, 0.156, 0.11, 0.02]):
+            self.assertAlmostEqual(actual, expected)
+
+
+    def test_update_min_duty_cycle_global(self):
+        params = self.base_params.copy()
+
+        sp = SpatialPooler(**params)
+
+        sp.num_minicolumns = 5
+        sp.min_percent_overlap_duty_cycles = 0.01
+        sp.overlap_duty_cycles = np.array([0.06, 1, 3, 6, 0.5])
+        sp.active_duty_cycles = np.array([0.6, 0.07, 0.5, 0.4, 0.3])
+        sp.update_min_duty_cycles_global()
+        true_min_overlap_duty_cycles = sp.num_minicolumns*[0.01*6]
+        for i in range(sp.num_minicolumns):
+            self.assertAlmostEqual(true_min_overlap_duty_cycles[i], sp.min_overlap_duty_cycles[i])
+
+        sp.min_percent_overlap_duty_cycles = 0.015
+        sp.num_minicolumns = 5
+        sp.overlap_duty_cycles = np.array([0.86, 2.4, 0.03, 1.6, 1.5])
+        sp.active_duty_cycles = np.array([0.16, 0.007, 0.15, 0.54, 0.13])
+        sp.update_min_duty_cycles_global()
+        true_min_overlap_duty_cycles = sp.num_minicolumns*[0.015*2.4]
+        for i in range(sp.num_minicolumns):
+            self.assertAlmostEqual(true_min_overlap_duty_cycles[i], sp.min_overlap_duty_cycles[i])
+
+        sp.min_percent_overlap_duty_cycles = 0.015
+        sp.num_minicolumns = 5
+        sp.overlap_duty_cycles = np.zeros(5)
+        sp.active_duty_cycles = np.zeros(5)
+        sp.update_min_duty_cycles_global()
+        true_min_overlap_duty_cycles = sp.num_minicolumns * [0]
+        for i in range(sp.num_minicolumns):
+            self.assertAlmostEqual(true_min_overlap_duty_cycles[i], sp.min_overlap_duty_cycles[i])
+
+    
+    def test_adapt_synapses(self):
+        sp = SpatialPooler(
+            input_dims=[8],
+            minicolumn_dims=[4],
+            synapse_perm_dec=0.01,
+            synapse_perm_inc=0.1
+        )
+
+        sp.synapse_perm_trim_threshold = 0.05
+
+        sp.potential_pools = np.array(
+            [[1, 1, 1, 1, 0, 0, 0, 0],
+            [1, 0, 0, 0, 1, 1, 0, 1],
+            [0, 0, 1, 0, 0, 0, 1, 0],
+            [1, 0, 0, 0, 0, 0, 1, 0]]
+        )
+
+        input_vector = np.array([1, 0, 0, 1, 1, 0, 1, 0])
+        active_minicolumns = np.array([0, 1, 2])
+
+        sp.permanences = np.array(
+            [[0.200, 0.120, 0.090, 0.040, 0.000, 0.000, 0.000, 0.000],
+            [0.150, 0.000, 0.000, 0.000, 0.180, 0.120, 0.000, 0.450],
+            [0.000, 0.000, 0.014, 0.000, 0.000, 0.000, 0.110, 0.000],
+            [0.040, 0.000, 0.000, 0.000, 0.000, 0.000, 0.178, 0.000]]
+        )
+
+        true_permanences = [
+            [0.300, 0.110, 0.080, 0.140, 0.000, 0.000, 0.000, 0.000],
+        #   Inc     Dec   Dec    Inc      -      -      -     -
+            [0.250, 0.000, 0.000, 0.000, 0.280, 0.110, 0.000, 0.440],
+        #   Inc      -      -     -      Inc    Dec    -     Dec
+            [0.000, 0.000, 0.000, 0.000, 0.000, 0.000, 0.210, 0.000],
+        #   -      -     Trim     -     -     -       Inc   -
+            [0.040, 0.000, 0.000, 0.000, 0.000, 0.000, 0.178, 0.000]]
+        #    -      -      -      -      -      -      -       -
+
+        sp.adapt_synapses(input_vector, active_minicolumns)
+        for i in range(sp.num_minicolumns):
+            perm = list(sp.permanences[i,:])
+            for j in range(sp.num_inputs):
+                self.assertAlmostEqual(true_permanences[i][j], perm[j])
+
+        sp.potential_pools = np.array(
+            [[1, 1, 1, 0, 0, 0, 0, 0],
+            [0, 1, 1, 1, 0, 0, 0, 0],
+            [0, 0, 1, 1, 1, 0, 0, 0],
+            [1, 0, 0, 0, 0, 0, 1, 0]]
+        )
+
+        input_vector = np.array([1, 0, 0, 1, 1, 0, 1, 0])
+        active_minicolumns = np.array([0, 1, 2])
+
+        sp.permanences = np.array(
+            [[0.200, 0.120, 0.090, 0.000, 0.000, 0.000, 0.000, 0.000],
+            [0.000, 0.017, 0.232, 0.400, 0.000, 0.000, 0.000, 0.000],
+            [0.000, 0.000, 0.014, 0.051, 0.730, 0.000, 0.000, 0.000],
+            [0.170, 0.000, 0.000, 0.000, 0.000, 0.000, 0.380, 0.000]]
+        )
+
+        true_permanences = [
+            [0.30, 0.110, 0.080, 0.000, 0.000, 0.000, 0.000, 0.000],
+            #  Inc    Dec     Dec     -       -    -    -    -
+            [0.000, 0.000, 0.222, 0.500, 0.000, 0.000, 0.000, 0.000],
+            #  -     Trim    Dec    Inc    -       -      -      -
+            [0.000, 0.000, 0.000, 0.151, 0.830, 0.000, 0.000, 0.000],
+            #   -      -    Trim   Inc    Inc     -     -     -
+            [0.170, 0.000, 0.000, 0.000, 0.000, 0.000, 0.380, 0.000]]
+            #  -    -      -      -      -       -       -     -
+
+        sp.adapt_synapses(input_vector, active_minicolumns)
+        for i in range(sp.num_minicolumns):
+            perm = list(sp.permanences[i,:])
+            for j in range(sp.num_inputs):
+                self.assertAlmostEqual(true_permanences[i][j], perm[j])
+
+    
+    def test_raise_permanence_threshold(self):
+        params = self.base_params.copy()
+
+        sp = SpatialPooler(**params)
+
+        sp.input_dims=np.array([5])
+        sp.minicolumn_dims=np.array([5])
+        sp.synapse_perm_connected=0.1
+        sp.stimulus_threshold=3
+        sp.synapse_perm_below_stimulus_inc = 0.01
+
+        sp.permanences = np.array(
+            [[0.0, 0.11, 0.095, 0.092, 0.01],
+            [0.12, 0.15, 0.02, 0.12, 0.09],
+            [0.51, 0.081, 0.025, 0.089, 0.31],
+            [0.18, 0.0601, 0.11, 0.011, 0.03],
+            [0.011, 0.011, 0.011, 0.011, 0.011]]
+        )
+
+        sp.connected_synapses = np.array(
+            [[0, 1, 0, 0, 0],
+            [1, 1, 0, 1, 0],
+            [1, 0, 0, 0, 1],
+            [1, 0, 1, 0, 0],
+            [0, 0, 0, 0, 0]]
+        )
+
+        sp.connected_synapses_counts = np.array([1, 3, 2, 2, 0])
+
+        true_permanences = [
+            [0.01, 0.12, 0.105, 0.102, 0.02],  # incremented once
+            [0.12, 0.15, 0.02, 0.12, 0.09],  # no change
+            [0.53, 0.101, 0.045, 0.109, 0.33],  # increment twice
+            [0.22, 0.1001, 0.15, 0.051, 0.07],  # increment four times
+            [0.101, 0.101, 0.101, 0.101, 0.101] # increment 9 times
+        ]  
+
+        mask_potential_pools = np.array(range(5))
+        for i in range(sp.num_minicolumns):
+            perm = sp.permanences[i,:]
+            sp.raise_permanence_to_threshold(perm, mask_potential_pools)
+            for j in range(sp.num_inputs):
+                self.assertAlmostEqual(true_permanences[i][j], perm[j])
+
+
+    def test_update_permanences_for_minicolumn(self):
+        sp = SpatialPooler(
+            input_dims=[5],
+            minicolumn_dims=[5],
+            synapse_perm_connected=0.1,
+            seed=42,
+        )
+
+        sp.synapse_perm_trim_threshold = 0.05
+
+        permanences = np.array([
+            [-0.10, 0.500, 0.400, 0.010, 0.020],
+            [0.300, 0.010, 0.020, 0.120, 0.090],
+            [0.070, 0.050, 1.030, 0.190, 0.060],
+            [0.180, 0.090, 0.110, 0.010, 0.030],
+            [0.200, 0.101, 0.050, -0.09, 1.100]],
+        )
+
+        true_connected_synapses = [
+            [0, 1, 1, 0, 0],
+            [1, 0, 0, 1, 0],
+            [0, 0, 1, 1, 0],
+            [1, 0, 1, 0, 0],
+            [1, 1, 0, 0, 1]
+        ]
+
+        true_connected_synapses_counts = [2, 2, 2, 2, 3]
+
+        for minicolumn_index in range(sp.num_minicolumns):
+            sp.update_permanences_for_minicolumn(permanences[minicolumn_index], minicolumn_index)
+            self.assertListEqual(true_connected_synapses[minicolumn_index], list(sp.connected_synapses[minicolumn_index]))
+
+        self.assertListEqual(true_connected_synapses_counts, list(sp.connected_synapses_counts))
+
+
+    def test_calculate_overlap(self):
+        '''
+        test that minicolumn computes overlap and percent overlap correctly.
+        '''
+
+        def calculate_overlap_percent(overlaps, connected_synapses_counts):
+            return overlaps.astype(real_type) / connected_synapses_counts
+
+        sp = SpatialPooler(
+            input_dims=[10],
+            minicolumn_dims=[5]
+        )
+
+        sp.connected_synapses = np.array(
+            [[1, 1, 1, 1, 1, 1, 1, 1, 1, 1],
+            [0, 0, 1, 1, 1, 1, 1, 1, 1, 1],
+            [0, 0, 0, 0, 1, 1, 1, 1, 1, 1],
+            [0, 0, 0, 0, 0, 0, 1, 1, 1, 1],
+            [0, 0, 0, 0, 0, 0, 0, 0, 1, 1]]
+        )
+        sp.connected_synapses_counts = np.array([10.0, 8.0, 6.0, 4.0, 2.0])
+        input_vector = np.zeros(sp.num_inputs, dtype=real_type)
+        overlaps = sp.calculate_overlap(input_vector)
+        overlaps_percent = calculate_overlap_percent(overlaps, sp.connected_synapses_counts)
+        true_overlaps = list(np.array([0, 0, 0, 0, 0], dtype=real_type))
+        true_overlaps_percent = list(np.array([0, 0, 0, 0, 0]))
+        self.assertListEqual(list(overlaps), true_overlaps)
+        self.assertListEqual(list(overlaps_percent), true_overlaps_percent)
+
+
+        sp.connected_synapses = np.array(
+            [[1, 1, 1, 1, 1, 1, 1, 1, 1, 1],
+            [0, 0, 1, 1, 1, 1, 1, 1, 1, 1],
+            [0, 0, 0, 0, 1, 1, 1, 1, 1, 1],
+            [0, 0, 0, 0, 0, 0, 1, 1, 1, 1],
+            [0, 0, 0, 0, 0, 0, 0, 0, 1, 1]]
+        )
+        sp.connected_synapses_counts = np.array([10.0, 8.0, 6.0, 4.0, 2.0])
+        input_vector = np.ones(sp.num_inputs, dtype=real_type)
+        overlaps = sp.calculate_overlap(input_vector)
+        overlaps_percent = calculate_overlap_percent(overlaps, sp.connected_synapses_counts)
+        true_overlaps = list(np.array([10, 8, 6, 4, 2], dtype=real_type))
+        true_overlaps_percent = list(np.array([1, 1, 1, 1, 1]))
+        self.assertListEqual(list(overlaps), true_overlaps)
+        self.assertListEqual(list(overlaps_percent), true_overlaps_percent)
+
+
+        sp.connected_synapses = np.array(
+            [[1, 1, 1, 1, 1, 1, 1, 1, 1, 1],
+            [0, 0, 1, 1, 1, 1, 1, 1, 1, 1],
+            [0, 0, 0, 0, 1, 1, 1, 1, 1, 1],
+            [0, 0, 0, 0, 0, 0, 1, 1, 1, 1],
+            [0, 0, 0, 0, 0, 0, 0, 0, 1, 1]]
+        )
+        sp.connected_synapses_counts = np.array([10.0, 8.0, 6.0, 4.0, 2.0])
+        input_vector = np.zeros(sp.num_inputs, dtype=real_type)
+        input_vector[9] = 1
+        overlaps = sp.calculate_overlap(input_vector)
+        overlaps_percent = calculate_overlap_percent(overlaps, sp.connected_synapses_counts)
+        true_overlaps = list(np.array([1, 1, 1, 1, 1], dtype=real_type))
+        true_overlaps_percent = list(np.array([0.1, 0.125, 1.0/6, 0.25, 0.5]))
+        self.assertListEqual(list(overlaps), true_overlaps)
+        self.assertListEqual(list(overlaps_percent), true_overlaps_percent)
+
+
+        # zig-zag
+        sp.connected_synapses = np.array(
+            [[1, 0, 0, 0, 0, 1, 0, 0, 0, 0],
+            [0, 1, 0, 0, 0, 0, 1, 0, 0, 0],
+            [0, 0, 1, 0, 0, 0, 0, 1, 0, 0],
+            [0, 0, 0, 1, 0, 0, 0, 0, 1, 0],
+            [0, 0, 0, 0, 1, 0, 0, 0, 0, 1]]
+        )
+        sp.connected_synapses_counts = np.array([2.0, 2.0, 2.0, 2.0, 2.0])
+        input_vector = np.zeros(sp.num_inputs, dtype=real_type)
+        input_vector[range(0, 10, 2)] = 1
+        overlaps = sp.calculate_overlap(input_vector)
+        overlaps_percent = calculate_overlap_percent(overlaps, sp.connected_synapses_counts)
+        true_overlaps = list(np.array([1, 1, 1, 1, 1], dtype=real_type))
+        true_overlaps_percent = list(np.array([0.5, 0.5, 0.5, 0.5, 0.5]))
+        self.assertListEqual(list(overlaps), true_overlaps)
+        self.assertListEqual(list(overlaps_percent), true_overlaps_percent)
+
+
+    def test_init_permanence1(self):
+        '''
+        test initial permanence generation. ensure that a correct amount of synapses are initialized in
+        a connected state, with permanence values drawn from the correct ranges.
+        '''
+
+        params = self.base_params.copy()
+
+        sp = SpatialPooler(**params)
+
+        sp.input_dims = np.array([10])
+        sp.num_inputs = 10
+        sp.raise_permanence_to_threshold = Mock()
+
+
+        sp.potential_radius = 2
+        sp.init_connected_percent = 1
+        mask = np.array([1, 1, 1, 0, 0, 0, 0, 0, 1, 1])
+        perm = sp.init_permanence(mask)
+        connected = (perm >= sp.synapse_perm_connected).astype(int)
+        num_connected = (connected.nonzero()[0]).size
+        self.assertEqual(num_connected, 5)
+
+
+        sp.init_connected_percent = 0
+        perm = sp.init_permanence(mask)
+        connected = (perm >= sp.synapse_perm_connected).astype(int)
+        num_connected = (connected.nonzero()[0]).size
+        self.assertEqual(num_connected, 0)
+
+
+        sp.init_connected_percent = 0.5
+        sp.potential_radius = 100
+        sp.num_inputs = 100
+        mask = np.ones(100)
+        perm = sp.init_permanence(mask)
+        connected = (perm >= sp.synapse_perm_connected).astype(int)
+        num_connected = (connected.nonzero()[0]).size
+        self.assertGreater(num_connected, 0)
+        self.assertLess(num_connected, sp.num_inputs)
+
+        min_threshold = sp.synapse_perm_min
+        max_threshold = sp.synapse_perm_max
+        self.assertEqual(np.logical_and((perm >= min_threshold),
+                                        (perm <= max_threshold)).all(), True)
+
+
+    def test_init_permanence2(self):
+        '''
+        test initial permanence generation. ensure that permanence values are only assigned to bits within a minicolumn's potential pool.
+        '''
+
+        params = self.base_params.copy()
+
+        sp = SpatialPooler(**params)
+
+        sp.raise_permanence_to_threshold = Mock()
+
+        sp.num_inputs = 10
+        sp.init_connected_percent = 1
+        mask = np.array([1, 1, 0, 0, 0, 0, 0, 0, 0, 0])
+        perm = sp.init_permanence(mask)
+        connected = list((perm > 0).astype(int))
+        true_connected = [1, 1, 0, 0, 0, 0, 0, 0, 0, 0]
+        self.assertListEqual(connected, true_connected)
+
+
+        sp.num_inputs = 10
+        sp.init_connected_percent = 1
+        mask = np.array([0, 0, 0, 0, 1, 1, 1, 0, 0, 0])
+        perm = sp.init_permanence(mask)
+        connected = list((perm > 0).astype(int))
+        true_connected = [0, 0, 0, 0, 1, 1, 1, 0, 0, 0]
+        self.assertListEqual(connected, true_connected)
+
+
+        sp.num_inputs = 10
+        sp.init_connected_percent = 1
+        mask = np.array([0, 0, 0, 0, 0, 0, 0, 0, 1, 1])
+        perm = sp.init_permanence(mask)
+        connected = list((perm > 0).astype(int))
+        true_connected = [0, 0, 0, 0, 0, 0, 0, 0, 1, 1]
+        self.assertListEqual(connected, true_connected)
+
+
+        sp.num_inputs = 10
+        sp.init_connected_percent = 1
+        mask = np.array([1, 1, 1, 1, 1, 1, 1, 0, 1, 1])
+        perm = sp.init_permanence(mask)
+        connected = list((perm > 0).astype(int))
+        true_connected = [1, 1, 1, 1, 1, 1, 1, 0, 1, 1]
+        self.assertListEqual(connected, true_connected)
+
+
+    def test_inhibit_minicolumns_global(self):
+        '''
+        tests that global inhibition correctly picks the correct top number of overlap scores as winning columns.
+        '''
+        
+        params = self.base_params.copy()
+
+        sp = SpatialPooler(**params)
+
+        density = 0.3
+        sp.num_minicolumns = 10
+        overlaps = np.array([1, 2, 1, 4, 8, 3, 12, 5, 4, 1], dtype=real_type)
+        active = list(sp.inhibit_minicolumns_global(overlaps, density))
+        true_active = np.zeros(sp.num_minicolumns)
+        true_active = [4, 6, 7]
+        self.assertListEqual(list(true_active), sorted(active)) # ignore order of columns
+
+
+        density = 0.5
+        sp.num_minicolumns = 10
+        overlaps = np.array(range(10), dtype=real_type)
+        active = list(sp.inhibit_minicolumns_global(overlaps, density))
+        true_active = np.zeros(sp.num_minicolumns)
+        true_active = range(5, 10)
+        self.assertListEqual(list(true_active), sorted(active))
+
+    
+    def test_inhibit_minicolumns_local(self):
+        params = self.base_params.copy()
+
+        sp = SpatialPooler(**params)
+
+        density = 0.5
+        sp.num_minicolumns = 10
+        sp.minicolumn_dims = np.array([sp.num_minicolumns])
+        sp.inhibition_radius = 2
+        overlaps = np.array([1, 2, 7, 0, 3, 4, 16, 1, 1.5, 1.7], dtype=real_type)
+                         #   L  W  W  L  L  W  W   L   L    W
+        true_active = [1, 2, 5, 6, 9]
+        active = list(sp.inhibit_minicolumns_local(overlaps, density))
+        self.assertListEqual(true_active, sorted(active))
+
+
+        density = 0.5
+        sp.num_minicolumns = 10
+        sp.minicolumn_dims = np.array([sp.num_minicolumns])
+        sp.inhibition_radius = 3
+        overlaps = np.array([1, 2, 7, 0, 3, 4, 16, 1, 1.5, 1.7], dtype=real_type)
+                         #   L  W  W  L  W  W  W   L   L    L
+        true_active = [1, 2, 4, 5, 6, 9]
+        active = list(sp.inhibit_minicolumns_local(overlaps, density))
+        self.assertListEqual(true_active, active)
+
+
+        density = 0.3333
+        sp.num_minicolumns = 10
+        sp.minicolumn_dims = np.array([sp.num_minicolumns])
+        sp.inhibition_radius = 3
+        overlaps = np.array([1, 1, 1, 1, 1, 1, 1, 1, 1, 1], dtype=real_type)
+                         #   W  W  L  L  W  W  L  L  W  L
+        true_active = [0, 1, 4, 5, 8]
+        active = list(sp.inhibit_minicolumns_local(overlaps, density))
+        self.assertListEqual(true_active, sorted(active))
+
+    
+    def test_RandomSpatialPoolerDoesNotLearn(self):
+        sp = SpatialPooler(
+            input_dims=[5],
+            minicolumn_dims=[10]
+        )
+
+        input_vector = (np.random.rand(5) > 0.5).astype(uint_type)
+        active_array = np.zeros(sp.num_minicolumns).astype(real_type)
+
+        # should start off at 0
+        self.assertEqual(sp.iteration_num, 0)
+        self.assertEqual(sp.iteration_learn_num, 0)
+
+        # store the initialized state
+        initial_permanences = copy(sp.permanences)
+
+        sp.compute(input_vector, False, active_array)
+        # should have incremented general counter but not learning counter
+        self.assertEqual(sp.iteration_num, 1)
+        self.assertEqual(sp.iteration_learn_num, 0)
+
+        # check the initial perm state was not modified either
+        self.assertEqual((sp.permanences == initial_permanences).all(), True)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,6 +11,7 @@
 -e packages/greedy_infomax
 -e packages/self_supervised_learning
 -e packages/continual_learning
+-e packages/spatial_pooler
 
 # Install projects extra dependency
 # See `setup.cfg` for available extras.


### PR DESCRIPTION
Pure Python 3 version of Spatial Pooler, no C++ dependencies. Cleans up a lot of the old spatial pooler code (removes unused methods, consolidates helper methods, fixes unclear logic, adds comments where ambiguous logic is used, etc.) and makes it more readable. 

Passes all tests. 
- Skipped test cases where `wrapAround=True` is used.
- Skipped `testUpdateBoostFactors` because `wrapAround=True` is the default setting for SP
- Skipped `testIsUpdateRound` and `updateDutyCycleHelper` because the contents of the test are already covered in other tests. Additionally, the helper methods that these tests cover are no longer standalone methods.