### PR TITLE
Removes dependencies from continual learning in dendrites requirements

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -91,7 +91,7 @@ jobs:
       - run:
           name: Collect package dependencies
           command: |
-            cat requirements.txt | grep 'packages' | cut -f2 -d ' ' | xargs -I {} cat {}/setup.cfg > packages.dependencies
+            cat requirements.txt | grep -Eo 'packages/\w+' | xargs -I {} cat {}/setup.cfg > packages.dependencies
 
       - restore_cache:
           key: pip-cache-v1-{{ arch }}-{{ checksum "nupic.torch.sha" }}-{{ checksum "setup.cfg" }}-{{ checksum "packages.dependencies"}}
@@ -126,7 +126,7 @@ jobs:
 
   test:
     working_directory: ~/nta/nupic.research
-    parallelism: 4 
+    parallelism: 4
     docker:
       - image: circleci/python:3.8
     steps:
@@ -142,10 +142,11 @@ jobs:
             set -e
             cp -f .circleci/pytest.ini pytest.ini
             mkdir -p test_results/pytest
-            TEST_FILES=$(grep 'packages' requirements.txt | cut -d ' ' -f2 | xargs -I {} echo  '"{}/tests/**/*.py"' | xargs circleci tests glob "tests/**/*.py" | circleci tests split --split-by=timings --show-counts)
+            TEST_FILES=$(grep -Eo 'packages/\w+' requirements.txt | xargs -I {} echo  '"{}/tests/**/*.py"' | xargs circleci tests glob "tests/**/*.py" | circleci tests split --split-by=timings --show-counts)
             pytest -ra $TEST_FILES
       - store_test_results:
           path: test_results
+
 
   build:
     working_directory: ~/nta/nupic.research

--- a/packages/dendrites/setup.cfg
+++ b/packages/dendrites/setup.cfg
@@ -30,13 +30,15 @@ package_dir =
     =src
 install_requires =
     nupic.research
-    nupic.research.continual_learning
-    ptitprince==0.2.5
     scipy
-    seaborn==0.11.1
     sklearn
     wandb
 
 [options.packages.find]
 where = src
 
+[options.extras_require]
+cl =
+    nupic.research.continual_learning
+    ptitprince==0.2.5
+    seaborn==0.11.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@
 
 # Install nupic.research frameworks
 -e packages/ray
--e packages/dendrites
+-e packages/dendrites[cl]
 -e packages/sigopt
 -e packages/wandb
 -e packages/dynamic_sparse


### PR DESCRIPTION
This PR should streamline usage of dendrites in other projects, such as multitask and others. 

Dendrites is a requirement of continual learning, but continual learning should not be a requirement of dendrites. If needed be the code can be reorganized to reflect this. 