### PR TITLE
Fix Linux conda environment

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -8,9 +8,9 @@ channels:
   - nvidia
   - conda-forge
 
-variables:
-  # Force x86 on Apple M1 laptops for now
-  CONDA_SUBDIR: osx-64
+# Uncomment these lines to force x86 on Apple M1 laptops
+# variables:
+#   CONDA_SUBDIR: osx-64
 
 dependencies:
   - python=3.8


### PR DESCRIPTION
This PR makes `osx-64` platform optional. Apple M1 laptops should uncomment the `variables`