### PR TITLE
Fix CI failures: mark test as slow

### DIFF
--- a/tests/unit/frameworks/htm/sequence_memory_test_base.py
+++ b/tests/unit/frameworks/htm/sequence_memory_test_base.py
@@ -180,6 +180,7 @@ class SequenceMemoryTestBase(object, metaclass=ABCMeta):
                     set(self.get_predicted_cells()), set(self.get_active_cells())
                 )
 
+    @pytest.mark.slow
     def testB3(self):
         """N=300, M=1, P=1. (See how high we can go with N)"""
 


### PR DESCRIPTION
pytorch sequence memory tests are running for over 10 minutes on the CI.

On my M1 Mac, this change reduces this file's test runtime (with py.test -m "not slow") from 30 seconds (before) to 10 seconds (after). If the CI is running on a VM, you could imagine sometimes it is much slower than an M1 mac.